### PR TITLE
CORE-867: Hedera account creation via api.blockset.com/_experimental

### DIFF
--- a/WalletKitCore/include/BRCryptoAccount.h
+++ b/WalletKitCore/include/BRCryptoAccount.h
@@ -55,6 +55,17 @@ extern "C" {
     extern BRCryptoBoolean
     cryptoAccountValidateWordsList (size_t wordsCount);
 
+    /**
+     * Create an Account from a paperKey.  There is absolutely no check on the paperKey as a valid
+     * BIP-39 paperKey for a specified word-list.  Therefore Users should call
+     * `cryptoAccountValidatePaperKey()` prior to any attempt to create an account.
+     *
+     * @param paperKey the paper key
+     * @param timestamp the paper key's creation timestamp
+     * @param uids a uids
+     *
+     * @return The Account, or NULL.  In practice NULL is never returned.
+     */
     extern BRCryptoAccount
     cryptoAccountCreate (const char *paperKey, uint64_t timestamp, const char *uids);
 

--- a/WalletKitJava/CoreNative/src/commonTest/java/com/breadwallet/corenative/CryptoLibraryIT.java
+++ b/WalletKitJava/CoreNative/src/commonTest/java/com/breadwallet/corenative/CryptoLibraryIT.java
@@ -156,7 +156,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;
@@ -196,7 +196,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;
@@ -235,7 +235,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class BRCryptoAccount extends PointerType {
 
-    public static BRCryptoAccount createFromPhrase(byte[] phraseUtf8, UnsignedLong timestamp, String uids) {
+    public static Optional<BRCryptoAccount> createFromPhrase(byte[] phraseUtf8, UnsignedLong timestamp, String uids) {
         long timestampAsLong = timestamp.longValue();
 
         // ensure string is null terminated
@@ -40,13 +40,13 @@ public class BRCryptoAccount extends PointerType {
                 phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
                 ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
-                return new BRCryptoAccount(
+                return Optional.fromNullable(
                         CryptoLibraryDirect.cryptoAccountCreate(
                                 phraseBuffer,
                                 timestampAsLong,
                                 uids
                         )
-                );
+                ).transform(BRCryptoAccount::new);
             } finally {
                 phraseMemory.clear();
             }

--- a/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AccountAIT.java
+++ b/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AccountAIT.java
@@ -24,7 +24,7 @@ public class AccountAIT {
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
 
-        Account account = Account.createFromPhrase(phrase, timestamp, uids);
+        Account account = Account.createFromPhrase(phrase, timestamp, uids).get();
         assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
 
         // check the uids matches the one provided on creation
@@ -36,7 +36,7 @@ public class AccountAIT {
         byte[] phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic".getBytes(StandardCharsets.UTF_8);
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
-        Account accountFromPhrase = Account.createFromPhrase(phrase, timestamp, uids);
+        Account accountFromPhrase = Account.createFromPhrase(phrase, timestamp, uids).get();
 
         // check that serialization is repeatable and valid
         byte[] serializationFromPhrase = accountFromPhrase.serialize();

--- a/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
+++ b/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
@@ -183,11 +183,7 @@ class HelpersAIT {
     /* package */
     static final OkHttpClient DEFAULT_HTTP_CLIENT = new OkHttpClient();
 
-    private static String DEFAULT_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9." +
-            "eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1N" +
-            "zI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2" +
-            "xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0." +
-            "460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg";
+    private static String DEFAULT_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1YjQ1M2VhOC1iOGMxLTQwNTEtODk1MC1jMzE5YmQzMjNiMzQiLCJpYXQiOjE1ODUzNDczMzAsImV4cCI6MTkwMDkzMjAzMCwiYnJkOmN0IjoidXNyIiwiYnJkOmNsaSI6IjY1MTNkOGVjLWM2NDUtNGNkNi1iNDZlLTM3MzM4NGYxMTczMCJ9.PEDGBTSOYaqylQ6Kf6wIdwrNvswneziLO61XTS1AXagjFNkGA_OANGYqw0E-ztOFQAyey4DsOhmUlTQLX5Y3yg";
 
     /* package */
     static BlockchainDb createDefaultBlockchainDbWithToken() {

--- a/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
+++ b/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
@@ -175,7 +175,7 @@ class HelpersAIT {
 
     /* package */
     static Account createDefaultAccount() {
-        return Account.createFromPhrase(DEFAULT_ACCOUNT_KEY, DEFAULT_ACCOUNT_TIMESTAMP, DEFAULT_ACCOUNT_UIDS);
+        return Account.createFromPhrase(DEFAULT_ACCOUNT_KEY, DEFAULT_ACCOUNT_TIMESTAMP, DEFAULT_ACCOUNT_UIDS).get();
     }
 
     // BlockchainDB

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Account.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Account.java
@@ -52,9 +52,9 @@ final class Account implements com.breadwallet.crypto.Account {
      * @param timestamp The timestamp of when this account was first created
      * @param uids The unique identifier of this account
      */
-    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
-        BRCryptoAccount core = BRCryptoAccount.createFromPhrase(phraseUtf8, Utilities.dateAsUnixTimestamp(timestamp), uids);
-        return Account.create(core);
+    static Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+        Optional<BRCryptoAccount> core = BRCryptoAccount.createFromPhrase(phraseUtf8, Utilities.dateAsUnixTimestamp(timestamp), uids);
+        return core.transform(Account::create);
     }
 
     /**

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
@@ -31,8 +31,8 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
 
     private static final CryptoApi.AccountProvider accountProvider = new CryptoApi.AccountProvider() {
         @Override
-        public com.breadwallet.crypto.Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
-            return Account.createFromPhrase(phraseUtf8, timestamp, uids);
+        public Optional<com.breadwallet.crypto.Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+            return Account.createFromPhrase(phraseUtf8, timestamp, uids).transform(a -> a);
         }
 
         @Override

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -31,12 +31,19 @@ import com.breadwallet.crypto.WalletManagerSyncStoppedReason;
 import com.breadwallet.crypto.WalletState;
 import com.breadwallet.crypto.blockchaindb.BlockchainDb;
 import com.breadwallet.crypto.blockchaindb.errors.QueryError;
+import com.breadwallet.crypto.blockchaindb.errors.QueryNoDataError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Blockchain;
 import com.breadwallet.crypto.blockchaindb.models.bdb.BlockchainFee;
+import com.breadwallet.crypto.blockchaindb.models.bdb.HederaAccount;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthLog;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthToken;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthTransaction;
+import com.breadwallet.crypto.errors.AccountInitializationAlreadyInitializedError;
+import com.breadwallet.crypto.errors.AccountInitializationCantCreateError;
+import com.breadwallet.crypto.errors.AccountInitializationError;
+import com.breadwallet.crypto.errors.AccountInitializationMultipleHederaAccountsError;
+import com.breadwallet.crypto.errors.AccountInitializationQueryError;
 import com.breadwallet.crypto.errors.FeeEstimationError;
 import com.breadwallet.crypto.errors.MigrateBlockError;
 import com.breadwallet.crypto.errors.MigrateCreateError;
@@ -2388,5 +2395,121 @@ final class System implements com.breadwallet.crypto.System {
         }
 
         return transfersMerged;
+    }
+
+    @Override
+    public boolean accountIsInitialized(com.breadwallet.crypto.Account account, com.breadwallet.crypto.Network network) {
+        return account.isInitialized(network);
+    }
+
+    @Override
+    public void accountInitialize(com.breadwallet.crypto.Account account,
+                                  com.breadwallet.crypto.Network network,
+                                  CompletionHandler<byte[], AccountInitializationError> handler) {
+        if (accountIsInitialized (account, network)) {
+            accountInitializeReportError (new AccountInitializationAlreadyInitializedError(), handler);
+            return;
+        }
+
+        switch (network.getType()) {
+            case HBAR:
+                Optional<String> publicKey = Optional.fromNullable(account.getInitializationData(network))
+                        .transform((data) -> Coder.createForAlgorithm(com.breadwallet.crypto.Coder.Algorithm.HEX).encode(data))
+                        .get();
+
+                if (!publicKey.isPresent()) {
+                    accountInitializeReportError (new AccountInitializationQueryError(new QueryNoDataError()), handler);
+                    return;
+                }
+
+                Log.log(Level.INFO, "HBAR accountInitialize: publicKey: %s", publicKey.get());
+
+                // We'll recursively reference this 'hederaHandler' - put it in a 'final box' so
+                // that the compiler permits references w/o 'perhaps not initialized' errors.
+                final HederaAccountCompletionHandler[] hederaHandlerBox = new HederaAccountCompletionHandler[1];
+                hederaHandlerBox[0] = new HederaAccountCompletionHandler() {
+                    @Override
+                    public void handleData(List<HederaAccount> accounts) {
+                        switch (accounts.size()) {
+                            case 0:
+                                if (!hederaHandlerBox[0].create) {
+                                    accountInitializeReportError(new AccountInitializationCantCreateError(), handler);
+                                } else {
+                                    // Create the account; but only try once.
+                                    hederaHandlerBox[0].create = false;
+                                    query.createHederaAccount(network.getUids(), publicKey.get(), hederaHandlerBox[0]);
+                                }
+                                break;
+
+                            case 1:
+                                Log.log(Level.INFO, String.format("HBAR accountInitialize: Hedera AccountId: %s, Balance: %s",
+                                        accounts.get(0).getAccountId(),
+                                        accounts.get(0).getBalance()));
+
+                                Optional<byte[]> serialization = accountInitializeUsingHedera(account, network, accounts.get(0));
+                                if (serialization.isPresent()) {
+                                    accountInitializeReportSuccess(serialization.get(), handler);
+                                } else {
+                                    accountInitializeReportError(new AccountInitializationQueryError(new QueryNoDataError()), handler);
+                                }
+                                break;
+
+                            default:
+                                accountInitializeReportError(new AccountInitializationMultipleHederaAccountsError(accounts), handler);
+                                break;
+                        }
+
+                    }
+
+                    @Override
+                    public void handleError(QueryError error) {
+                        accountInitializeReportError(new AccountInitializationQueryError(error), handler);
+                    }
+                };
+
+                query.getHederaAccount(network.getUids(), publicKey.get(), hederaHandlerBox[0]);
+
+            default:
+                checkState(false);
+        }
+    }
+
+    @Override
+    public Optional<byte[]> accountInitializeUsingData(com.breadwallet.crypto.Account account, com.breadwallet.crypto.Network network, byte[] data) {
+        return Optional.of (account.initialize (network, data));
+    }
+
+    @Override
+    public Optional<byte[]> accountInitializeUsingHedera(com.breadwallet.crypto.Account account, com.breadwallet.crypto.Network network, HederaAccount hedera) {
+        return Optional.of (account.initialize (network, hedera.getAccountId().getBytes()));
+    }
+
+    private final CompletionHandler<List<HederaAccount>, QueryError> accountInitializeHandleHederaResult =
+        new CompletionHandler<List<HederaAccount>, QueryError>() {
+            @Override
+            public void handleData(List<HederaAccount> data) {
+                accountInitializeHandleHederaResult.handleData(null);
+            }
+
+            @Override
+            public void handleError(QueryError error) {
+
+            }
+        };
+
+    private void accountInitializeReportError(AccountInitializationError error,
+                                              CompletionHandler<byte[], AccountInitializationError> handler) {
+        // Some thread
+        handler.handleError(error);
+    }
+
+    private void accountInitializeReportSuccess(byte[] data,
+                                                CompletionHandler<byte[], AccountInitializationError> handler) {
+        // Some thread
+        handler.handleData(data);
+    }
+
+    private abstract class HederaAccountCompletionHandler implements CompletionHandler<List<HederaAccount>, QueryError> {
+        boolean create = true;
     }
 }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Account.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Account.java
@@ -28,7 +28,7 @@ public interface Account {
      * @param timestamp The timestamp of when this account was first created
      * @param uids The unique identifier of this account
      */
-    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+    static Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
         return CryptoApi.getProvider().accountProvider().createFromPhrase(phraseUtf8, timestamp, uids);
     }
 

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 public final class CryptoApi {
 
     public interface AccountProvider {
-        Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
+        Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
         Optional<Account> createFromSerialization(byte[] serialization, String uids);
         byte[] generatePhrase(List<String> words);
         boolean validatePhrase(byte[] phraseUtf8, List<String> words);

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -12,6 +12,8 @@ package com.breadwallet.crypto;
 import android.support.annotation.Nullable;
 
 import com.breadwallet.crypto.blockchaindb.BlockchainDb;
+import com.breadwallet.crypto.blockchaindb.models.bdb.HederaAccount;
+import com.breadwallet.crypto.errors.AccountInitializationError;
 import com.breadwallet.crypto.errors.MigrateError;
 import com.breadwallet.crypto.errors.NetworkFeeUpdateError;
 import com.breadwallet.crypto.events.system.SystemListener;
@@ -226,4 +228,13 @@ public interface System {
      */
     void migrateStorage (Network network, List<TransactionBlob> transactionBlobs, List<BlockBlob> blockBlobs,
                          List<PeerBlob> peerBlobs) throws MigrateError;
+
+
+    boolean accountIsInitialized (Account account, Network nework);
+
+    void accountInitialize (Account account, Network network, CompletionHandler<byte[], AccountInitializationError> handler);
+
+    Optional<byte[]> accountInitializeUsingData (Account account, Network network, byte[] data);
+
+    Optional<byte[]> accountInitializeUsingHedera (Account account, Network network, HederaAccount hedera);
 }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -13,6 +13,7 @@ import com.breadwallet.crypto.blockchaindb.apis.bdb.BlockApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.BlockchainApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.CurrencyApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.BdbApiClient;
+import com.breadwallet.crypto.blockchaindb.apis.bdb.ExperimentalApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.SubscriptionApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.TransactionApi;
 import com.breadwallet.crypto.blockchaindb.apis.bdb.TransferApi;
@@ -26,6 +27,7 @@ import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Block;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Blockchain;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
+import com.breadwallet.crypto.blockchaindb.models.bdb.HederaAccount;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Subscription;
 import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionCurrency;
 import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionEndpoint;
@@ -41,6 +43,7 @@ import com.google.common.primitives.UnsignedLong;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import okhttp3.OkHttpClient;
@@ -60,6 +63,7 @@ public class BlockchainDb {
     private final SubscriptionApi subscriptionApi;
     private final TransferApi transferApi;
     private final TransactionApi transactionApi;
+    private final ExperimentalApi experimentalApi;
 
     private final EthBalanceApi ethBalanceApi;
     private final EthBlockApi ethBlockApi;
@@ -91,6 +95,7 @@ public class BlockchainDb {
         BrdApiClient brdClient = new BrdApiClient(client, apiBaseURL, apiDataTask, coder);
 
         ExecutorService executorService = Executors.newCachedThreadPool();
+        ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
         this.ridGenerator = new AtomicInteger(0);
 
@@ -100,6 +105,7 @@ public class BlockchainDb {
         this.subscriptionApi = new SubscriptionApi(bdbClient);
         this.transferApi = new TransferApi(bdbClient, executorService);
         this.transactionApi = new TransactionApi(bdbClient, executorService);
+        this.experimentalApi = new ExperimentalApi(bdbClient, scheduledExecutorService);
 
         this.ethBalanceApi = new EthBalanceApi(brdClient);
         this.ethBlockApi = new EthBlockApi(brdClient);
@@ -415,6 +421,30 @@ public class BlockchainDb {
                 false,
                 false,
                 false,
+                handler
+        );
+    }
+
+    // Addresses
+
+    // Experimental - Hedera Account Creation
+
+    public void getHederaAccount(String id,
+                                 String publicKey,
+                                 CompletionHandler<List<HederaAccount>, QueryError> handler) {
+        experimentalApi.getHederaAccount(
+                id,
+                publicKey,
+                handler
+        );
+    }
+
+    public void createHederaAccount(String id,
+                                    String publicKey,
+                                    CompletionHandler<List<HederaAccount>, QueryError> handler) {
+        experimentalApi.createHederaAccount(
+                id,
+                publicKey,
                 handler
         );
     }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/BdbApiClient.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/BdbApiClient.java
@@ -25,6 +25,7 @@ import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.collect.Multimap;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -89,6 +90,20 @@ public class BdbApiClient {
                 handler);
     }
 
+    <T> void sendPost(List<String> resourcePath,
+                      Multimap<String, String> params,
+                      Object body,
+                      Class<T> clazz,
+                      CompletionHandler<T, QueryError> handler) {
+        makeAndSendRequest(
+                resourcePath,
+                params,
+                body,
+                "POST",
+                new RootObjectResponseParser<>(coder, clazz),
+                handler);
+    }
+
     // Read (cRud)
 
     /* package */
@@ -116,6 +131,21 @@ public class BdbApiClient {
                 null,
                 "GET",
                 new EmbeddedArrayResponseParser<>(resource, coder, clazz),
+                handler);
+    }
+
+    /* package */
+    <T> void sendGetForArray(List<String> resourcePath,
+                             String embeddedPath,
+                             Multimap<String, String> params,
+                             Class<T> clazz,
+                             CompletionHandler<List<T>, QueryError> handler) {
+        makeAndSendRequest(
+                resourcePath,
+                params,
+                null,
+                "GET",
+                new EmbeddedArrayResponseParser<>(embeddedPath, coder, clazz),
                 handler);
     }
 
@@ -153,6 +183,24 @@ public class BdbApiClient {
                            CompletionHandler<T, QueryError> handler) {
         makeAndSendRequest(
                 Arrays.asList(resource, id),
+                params,
+                null,
+                "GET",
+                new RootObjectResponseParser<>(coder, clazz),
+                handler);
+    }
+
+    /* package */
+    <T> void sendGetWithId(List<String> resourcePath,
+                           String id,
+                           Multimap<String, String> params,
+                           Class<T> clazz,
+                           CompletionHandler<T, QueryError> handler) {
+        List<String> fullResourcePath = new ArrayList<>(resourcePath);
+        fullResourcePath.add(id);
+
+        makeAndSendRequest(
+                fullResourcePath,
                 params,
                 null,
                 "GET",

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/ExperimentalApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/ExperimentalApi.java
@@ -1,0 +1,181 @@
+package com.breadwallet.crypto.blockchaindb.apis.bdb;
+
+import com.breadwallet.crypto.blockchaindb.errors.QueryError;
+import com.breadwallet.crypto.blockchaindb.errors.QueryNoDataError;
+import com.breadwallet.crypto.blockchaindb.errors.QueryResponseError;
+import com.breadwallet.crypto.blockchaindb.models.bdb.HederaAccount;
+import com.breadwallet.crypto.utility.CompletionHandler;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ExperimentalApi {
+
+    private final BdbApiClient jsonClient;
+    private final ScheduledExecutorService executorService;
+
+    public ExperimentalApi(BdbApiClient jsonClient,
+                           ScheduledExecutorService executorService) {
+        this.jsonClient = jsonClient;
+        this.executorService = executorService;
+    }
+
+     private void getHederaAccountForTransaction(String id,
+                                                String publicKey,
+                                                HederaTransaction transaction,
+                                                CompletionHandler<List<HederaAccount>, QueryError> handler) {
+        final long retryPeriodInSeconds = 5;
+        final long retryDurationInSeconds = 4 * 60;
+        final long[] retriesRemaining = { (retryDurationInSeconds / retryPeriodInSeconds) - 1 };
+
+        final List<CompletionHandler<HederaTransaction, QueryError>> retryHandler = new ArrayList<>();
+        retryHandler.add (new CompletionHandler<HederaTransaction, QueryError>() {
+            @Override
+            public void handleData(HederaTransaction data) {
+                switch (transaction.getTransactionId()) {
+                    case "success":
+                        getHederaAccount(id, publicKey, handler);
+
+                    case "pending":
+                        if (retriesRemaining[0] == 0)
+                            handler.handleError(new QueryNoDataError());
+                        else {
+                            retriesRemaining[0] -= 1;
+                            executorService.schedule(
+                                    new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            jsonClient.sendGetWithId(
+                                                    "_experimental/hedera/account_transactions",
+                                                    transaction.getTransactionId(),
+                                                    ImmutableMultimap.of(),
+                                                    HederaTransaction.class,
+                                                    retryHandler.get(0));  // recursive-ish
+                                        }
+                                    },
+                                    retryDurationInSeconds,
+                                    TimeUnit.SECONDS);
+                        }
+
+                    default:
+                        handler.handleError(new QueryNoDataError());
+                }
+            }
+
+            @Override
+            public void handleError(QueryError error) {
+                handler.handleError(new QueryNoDataError());
+            }
+        });
+
+        jsonClient.sendGetWithId(
+                "_experimental/hedera/account_transactions",
+                transaction.getTransactionId(),
+                ImmutableMultimap.of(),
+                HederaTransaction.class,
+                retryHandler.get(0));
+    }
+
+    public void getHederaAccount(String id,
+                                 String publicKey,
+                                 CompletionHandler<List<HederaAccount>, QueryError> handler) {
+        jsonClient.sendGetForArray("_experimental/hedera/accounts",
+                ImmutableListMultimap.of(
+                        "blockchain_id", id,
+                        "pub_key", publicKey),
+                HederaAccount.class,
+                handler);
+    }
+
+    public void createHederaAccount(String id,
+                                    String publicKey,
+                                    CompletionHandler<List<HederaAccount>, QueryError> handler) {
+        jsonClient.sendPost("_experimental/hedera/accounts",
+                ImmutableMultimap.of(),
+                NewHederaAccount.create(id, publicKey),
+                HederaTransaction.class,
+                new CompletionHandler<HederaTransaction, QueryError>() {
+                    @Override
+                    public void handleData(HederaTransaction transaction) {
+                        getHederaAccountForTransaction(id, publicKey, transaction, handler);
+                    }
+
+                    @Override
+                    public void handleError(QueryError error) {
+                        if (error instanceof QueryResponseError && 422 == ((QueryResponseError) error).getStatusCode())
+                            getHederaAccount(id, publicKey, handler);
+                        else
+                            handler.handleError(error);
+                    }
+                });
+    }
+
+    private static class NewHederaAccount {
+        @JsonCreator
+        public static NewHederaAccount create(@JsonProperty("blockchain_id") String blockchainId,
+                                              @JsonProperty("pub_key") String publicKey) {
+            return new NewHederaAccount(
+                    checkNotNull(blockchainId),
+                    checkNotNull(publicKey)
+            );
+        }
+
+        private final String blockchainId;
+        private final String publicKey;
+
+        private NewHederaAccount(String blockchainId,
+                                 String publicKey) {
+            this.blockchainId = blockchainId;
+            this.publicKey = publicKey;
+        }
+
+        @JsonProperty("blockchain_id")
+        public String getBlockchainId() {
+            return blockchainId;
+        }
+
+        @JsonProperty("pub_key")
+        public String getPublicKey() {
+            return publicKey;
+        }
+    }
+
+    private static class HederaTransaction {
+        @JsonCreator
+        public static HederaTransaction create(@JsonProperty("account_id") String accountId,
+                    @JsonProperty("transaction_id") String transactionId) {
+            return new HederaTransaction(
+                    accountId,
+                    checkNotNull(transactionId)
+            );
+        }
+
+        private final String accountId;
+        private final String transactionId;
+
+        public HederaTransaction(String accountId,
+                                 String transactionId) {
+            this.accountId = accountId;
+            this.transactionId = transactionId;
+        }
+
+        @JsonProperty("account_id")
+        public String getAccountId() {
+            return accountId;
+        }
+
+        @JsonProperty("transaction_id")
+        public String getTransactionId() {
+            return transactionId;
+        }
+    }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/HederaAccount.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/HederaAccount.java
@@ -1,0 +1,59 @@
+package com.breadwallet.crypto.blockchaindb.models.bdb;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class HederaAccount {
+    @JsonCreator
+    public static HederaAccount create(@JsonProperty("account_id") String accountId,
+                                       @JsonProperty("hbar_balance") Long balance,
+                                       @JsonProperty("account_status") String status,
+                                       @JsonProperty("updated") Date timestamp) {
+        return new HederaAccount(
+                checkNotNull(accountId),
+                checkNotNull(balance),
+                checkNotNull(status),
+                checkNotNull(timestamp)
+        );
+    }
+
+    private final String accountId;
+    private final Long balance;
+    private final String status;
+    private final Date timestamp;
+
+    private HederaAccount (String accountId, Long balance, String status, Date timestamp) {
+        this.accountId = accountId;
+        this.balance = balance;
+        this.status = status;
+        this.timestamp = timestamp;
+    }
+
+    @JsonProperty("account_id")
+    public String getAccountId () {
+        return accountId;
+    }
+
+    @JsonProperty("hbar_balance")
+    public Long getBalance () {
+        return balance;
+    }
+
+    @JsonProperty("account_status")
+    public String getStatus() {
+        return status;
+    }
+
+    @JsonProperty("updated")
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public boolean isDeleted() {
+        return !"active".equalsIgnoreCase(status);
+    }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/HederaAccount.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/HederaAccount.java
@@ -3,6 +3,7 @@ package com.breadwallet.crypto.blockchaindb.models.bdb;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Comparator;
 import java.util.Date;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -56,4 +57,7 @@ public class HederaAccount {
     public boolean isDeleted() {
         return !"active".equalsIgnoreCase(status);
     }
+
+    public static final Comparator<HederaAccount> BALANCE_COMPARATOR =
+            (HederaAccount a1, HederaAccount a2) -> Long.compare(a1.getBalance(), a2.getBalance());
 }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationAlreadyInitializedError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationAlreadyInitializedError.java
@@ -1,0 +1,4 @@
+package com.breadwallet.crypto.errors;
+
+public final class AccountInitializationAlreadyInitializedError extends AccountInitializationError {
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationCantCreateError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationCantCreateError.java
@@ -1,0 +1,4 @@
+package com.breadwallet.crypto.errors;
+
+public final class AccountInitializationCantCreateError extends AccountInitializationError {
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationError.java
@@ -1,0 +1,7 @@
+package com.breadwallet.crypto.errors;
+
+public abstract class AccountInitializationError extends Exception {
+
+    /* package */
+    AccountInitializationError () { super (); }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationMultipleHederaAccountsError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationMultipleHederaAccountsError.java
@@ -1,0 +1,17 @@
+package com.breadwallet.crypto.errors;
+
+import com.breadwallet.crypto.blockchaindb.models.bdb.HederaAccount;
+
+import java.util.List;
+
+public final class AccountInitializationMultipleHederaAccountsError extends AccountInitializationError {
+    List<HederaAccount> accounts;
+
+    public AccountInitializationMultipleHederaAccountsError (List<HederaAccount> accounts) {
+        this.accounts = accounts;
+    }
+
+    public List<HederaAccount> getAccounts() {
+        return accounts;
+    }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationQueryError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/AccountInitializationQueryError.java
@@ -1,0 +1,15 @@
+package com.breadwallet.crypto.errors;
+
+import com.breadwallet.crypto.blockchaindb.errors.QueryError;
+
+public final class AccountInitializationQueryError extends AccountInitializationError {
+    QueryError queryError;
+
+    public AccountInitializationQueryError(QueryError queryError) {
+        this.queryError = queryError;
+    }
+
+    public QueryError getQueryError() {
+        return queryError;
+    }
+}

--- a/WalletKitJava/crypto/src/test/java/com/breadwallet/crypto/BlockchainDbIT.java
+++ b/WalletKitJava/crypto/src/test/java/com/breadwallet/crypto/BlockchainDbIT.java
@@ -48,11 +48,7 @@ public class BlockchainDbIT {
 
     private static final String API_BASE_URL = "https://api.breadwallet.com";
     private static final String BDB_BASE_URL = "https://api.blockset.com";
-    private static final String BRD_AUTH_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9." +
-            "eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1N" +
-            "zI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2" +
-            "xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0." +
-            "460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg";
+    private static final String BRD_AUTH_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1YjQ1M2VhOC1iOGMxLTQwNTEtODk1MC1jMzE5YmQzMjNiMzQiLCJpYXQiOjE1ODUzNDczMzAsImV4cCI6MTkwMDkzMjAzMCwiYnJkOmN0IjoidXNyIiwiYnJkOmNsaSI6IjY1MTNkOGVjLWM2NDUtNGNkNi1iNDZlLTM3MzM4NGYxMTczMCJ9.PEDGBTSOYaqylQ6Kf6wIdwrNvswneziLO61XTS1AXagjFNkGA_OANGYqw0E-ztOFQAyey4DsOhmUlTQLX5Y3yg";
 
     private BlockchainDb blockchainDb;
 

--- a/WalletKitJava/cryptodemo-android/build.gradle
+++ b/WalletKitJava/cryptodemo-android/build.gradle
@@ -26,13 +26,13 @@ android {
             debuggable true
             jniDebuggable true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1NzI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0.460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg"'
+            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1YjQ1M2VhOC1iOGMxLTQwNTEtODk1MC1jMzE5YmQzMjNiMzQiLCJpYXQiOjE1ODUzNDczMzAsImV4cCI6MTkwMDkzMjAzMCwiYnJkOmN0IjoidXNyIiwiYnJkOmNsaSI6IjY1MTNkOGVjLWM2NDUtNGNkNi1iNDZlLTM3MzM4NGYxMTczMCJ9.PEDGBTSOYaqylQ6Kf6wIdwrNvswneziLO61XTS1AXagjFNkGA_OANGYqw0E-ztOFQAyey4DsOhmUlTQLX5Y3yg"'
 
         }
         debug {
             debuggable true
             jniDebuggable true
-            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1NzI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0.460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg"'
+            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1YjQ1M2VhOC1iOGMxLTQwNTEtODk1MC1jMzE5YmQzMjNiMzQiLCJpYXQiOjE1ODUzNDczMzAsImV4cCI6MTkwMDkzMjAzMCwiYnJkOmN0IjoidXNyIiwiYnJkOmNsaSI6IjY1MTNkOGVjLWM2NDUtNGNkNi1iNDZlLTM3MzM4NGYxMTczMCJ9.PEDGBTSOYaqylQ6Kf6wIdwrNvswneziLO61XTS1AXagjFNkGA_OANGYqw0E-ztOFQAyey4DsOhmUlTQLX5Y3yg"'
         }
     }
 

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -149,7 +149,7 @@ public class CoreCryptoApplication extends Application {
             systemListener.addSystemListener(new CoreSystemListener(mode, isMainnet, currencyCodesNeeded));
 
             String uids = UUID.randomUUID().toString();
-            account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids);
+            account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids).get();
 
             blockchainDb = BlockchainDb.createForTest (new OkHttpClient(), BDB_AUTH_TOKEN);
             system = System.create(systemExecutor, systemListener, account,

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -9,12 +9,10 @@ package com.breadwallet.cryptodemo;
 
 import android.support.annotation.Nullable;
 
-import com.breadwallet.crypto.Coder;
 import com.breadwallet.crypto.Account;
 import com.breadwallet.crypto.AddressScheme;
 import com.breadwallet.crypto.Currency;
 import com.breadwallet.crypto.Network;
-import com.breadwallet.crypto.NetworkType;
 import com.breadwallet.crypto.System;
 import com.breadwallet.crypto.Transfer;
 import com.breadwallet.crypto.Wallet;
@@ -35,6 +33,7 @@ import com.breadwallet.crypto.events.walletmanager.WalletManagerEvent;
 import com.google.common.base.Optional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -150,23 +149,49 @@ public class CoreSystemListener implements SystemListener {
 
                 system.wipe(network);
                 if (!account.isInitialized(network)) {
-                    Coder hexCoder = Coder.createForAlgorithm(com.breadwallet.crypto.Coder.Algorithm.HEX);
-
-                    byte[] dataForInitialization = account.getInitializationData (network);
-                    Log.log(Level.FINE, String.format("Account: DataForInitialization: %s",
-                            hexCoder.encode(dataForInitialization).get()));
-
-                    if (NetworkType.HBAR == network.getType()) {
-                        byte[] initializationData = "0.0.114008".getBytes();
-                        Log.log(Level.FINE, String.format("Account: InitializationData: %s", "0.0.114008"));
-
-                        byte[] serializationData = account.initialize(network, initializationData);
-                        Log.log(Level.FINE, String.format("Account: Serialization: %s",
-                                hexCoder.encode(serializationData).get()));
-                    }
-                    Log.log(Level.FINE, String.format("Account: Initialized: %s", account.isInitialized(network)));
+//                    switch (network.getType()) {
+//                        case HBAR:
+//                            Coder hexCoder = Coder.createForAlgorithm(com.breadwallet.crypto.Coder.Algorithm.HEX);
+//
+//                            byte[] dataForInitialization = account.getInitializationData(network);
+//                            Log.log(Level.FINE, String.format("Account: DataForInitialization: %s",
+//                                    hexCoder.encode(dataForInitialization).get()));
+//
+//                            system.getQuery().accountExistsForHedera(network.getUids(), dataForInitialization,
+//                                    new CompletionHandler<byte[], QueryError>() {
+//                                        @Override
+//                                        public void handleData(byte[] data) {
+//                                            Log.log(Level.FINE, String.format("Account: Exists: InitializationData: %s",
+//                                                    new String (data))); // Hedera AccountID: 0.0.<n>
+//
+//                                            account.initialize(network, data);
+//                                            checkState(system.createWalletManager(network, mode, addressScheme, Collections.emptySet()));
+//                                        }
+//
+//                                        @Override
+//                                        public void handleError(QueryError error) {
+//                                            system.getQuery().accountCreateForHedera(network.getUids(), dataForInitialization,
+//                                                    new CompletionHandler<byte[], QueryError>() {
+//                                                        @Override
+//                                                        public void handleData(byte[] data) {
+//                                                            Log.log(Level.FINE, String.format("Account: Create: InitializationData: %s",
+//                                                                    new String (data))); // Hedera AccountID: 0.0.<n>
+//
+//                                                            account.initialize(network, data);
+//                                                            checkState(system.createWalletManager(network, mode, addressScheme, Collections.emptySet()));
+//                                                        }
+//
+//                                                        @Override
+//                                                        public void handleError(QueryError error) {
+//                                                            checkState(false);
+//                                                        }
+//                                                    });
+//                                        }
+//                                    });
+//                        default:
+//                            checkState(false);
+//                    }
                 }
-                checkState(system.createWalletManager(network, mode, addressScheme, Collections.emptySet()));
             }
         }
     }

--- a/WalletKitSwift/WalletKit/BRCryptoAccount.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoAccount.swift
@@ -135,7 +135,7 @@ public final class Account {
     ///
     /// - Returns: `true` if initialized; `false` otherwise
     ///
-    public func isInitialized (onNetwork network: Network) -> Bool {
+    internal func isInitialized (onNetwork network: Network) -> Bool {
         return CRYPTO_TRUE == cryptoAccountIsInitialized (core, network.core)
     }
 
@@ -151,7 +151,7 @@ public final class Account {
     ///            serialization must be saved otherwise the initialization will be lost upon the
     ///            next System start.
     ///
-    public func initialize (onNetwork network: Network, using data: Data) -> Data? {
+    internal func initialize (onNetwork network: Network, using data: Data) -> Data? {
         guard !isInitialized (onNetwork: network)
             else { return nil }
 
@@ -178,7 +178,7 @@ public final class Account {
     ///
     /// - Returns: Opaque data to be provided to the 'initialization provider'
     ///
-    public func getInitializationdData (onNetwork network: Network) -> Data? {
+    internal func getInitializationdData (onNetwork network: Network) -> Data? {
         var bytesCount: BRCryptoCount = 0
         return cryptoAccountGetInitializationData (core,
                                                    network.core,

--- a/WalletKitSwift/WalletKit/BRCryptoAccount.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoAccount.swift
@@ -113,7 +113,7 @@ public final class Account {
     ///
     /// - Parameters:
     ///   - phrase: the candidate paper key
-    ///   - words: A local-specific BIP-39-defined array of BIP39_WORDLIST_COUNT words.
+    ///   - words: A locale-specific BIP-39-defined array of BIP39_WORDLIST_COUNT words.
     ///
     /// - Returns: true is a valid paper key; false otherwise
     ///

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -219,11 +219,13 @@ public final class System {
         case .hbar:
             // For Hedera, the account initialization data is the public key.
             guard let publicKey = account.getInitializationdData(onNetwork: network)
-                .flatMap ({ String (data: $0, encoding: .utf8) })
+                .flatMap ({ CoreCoder.hex.encode(data: $0) })
             else {
                 accountInitializeReportResult (Result.failure(.queryFailure("No initialization data")), completion)
                 return
             }
+
+            print ("SYS: Account: Hedera: publicKey: \(publicKey)")
 
             // Find a pre-existing account or create one if necessary.
             query.getHederaAccount (blockchainId: network.uids, publicKey: publicKey) {
@@ -285,6 +287,8 @@ public final class System {
                     }
 
                 case 1:
+                    print ("SYS: Account: Hedera: AccountID: \(accounts[0].id), Balance: \(accounts[0].balance)")
+
                     let serialization = accountInitializeHedera (account,
                                                                  onNetwork: network,
                                                                  hedera: accounts[0])
@@ -1632,7 +1636,7 @@ extension System {
                         else { System.cleanup  ("SYS: SubmitTransaction: Missed {network}", cwm: cwm); return }
 
                     manager.query.submitTransactionAsETH (network: network,
-                                                          transaction: data.asHexEncodedString (prefix: "0x")) {
+                                                          transaction: "0x" + CoreCoder.hex.encode (data: data)!) {
                                                             (res: Result<String, BlockChainDB.QueryError>) in
                                                             defer { cryptoWalletManagerGive (cwm!) }
                                                             res.resolve (

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -378,23 +378,3 @@ extension Network {
         }
     }
 }
-
-// https://stackoverflow.com/a/40089462/1286639
-extension Data {
-    struct HexEncodingOptions: OptionSet {
-        let rawValue: Int
-        static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
-    }
-
-    func asHexEncodedString (prefix: String = "",
-                             options: HexEncodingOptions = []) -> String {
-        let hexDigits = Array((options.contains(.upperCase) ? "0123456789ABCDEF" : "0123456789abcdef").utf16)
-        var chars: [unichar] = []
-        chars.reserveCapacity(2 * count)
-        for byte in self {
-            chars.append(hexDigits[Int(byte / 16)])
-            chars.append(hexDigits[Int(byte % 16)])
-        }
-        return prefix + String(utf16CodeUnits: chars, count: chars.count)
-    }
-}

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
@@ -140,9 +140,9 @@ class CoreDemoListener: SystemListener {
 
                                     // Chose the Hedera account with the largest balance - DEMO-SPECFIC
                                     let hederaAccount = accounts.sorted { $0.balance > $1.balance }[0]
-                                    serializationData = system.accountInitializeHedera (system.account,
-                                                                                         onNetwork: network,
-                                                                                         hedera: hederaAccount)
+                                    serializationData = system.accountInitialize (system.account,
+                                                                                  onNetwork: network,
+                                                                                  hedera: hederaAccount)
 
                                 case .queryFailure(let message):
                                     print ("APP: Account: Initalization Query Error: \(message)")

--- a/WalletKitSwift/WalletKitDemo/WalletKitDemo.xcodeproj/xcshareddata/xcschemes/WalletKitDemo.xcscheme
+++ b/WalletKitSwift/WalletKitDemo/WalletKitDemo.xcodeproj/xcshareddata/xcschemes/WalletKitDemo.xcscheme
@@ -50,6 +50,32 @@
             ReferencedContainer = "container:WalletKitDemo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "loan(C)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "era(C)"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "green"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "super(C)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "wine(C)"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "infant"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Draft until tests.  Please have a look in pieces: 

- BlockChainDB: defines {create, get}HederaAccount and return Model.HederaAccount.  This interface is meant to be analogous to other BlockChainDB interfaces.  Make the GET/POST requests, returns a Result as an array of Model.HederaAccount or QueryError.  Parsing must be consistent with defined GET/POST API.  This code repeatedly queries `GET .../account_transaction/:id` every 5 seconds for a period of 4 minutes.

- System: Do all the work to coordinate Account initialization - which really only applies to Hedera.  Make the calls to BlockChainDB and Account.  Convert QueryError and other errors to AccountInitializationError.  At one time, it was thought that 'account initialization' would need some User provided, blockchain specific data - that probably is still the case.  However, that need is not represented here.  We can initialize a Hedera account w/o additional input.  Generally, I'm unhappy about this interface.

- Core Demo Listener: Uses System to initialize a Hedera account.  On error, falls back to `AccountSpecification` to find an Hedera account, if one exists.