### PR TITLE
CORE-876: Account.create() as consistently `Optional`

### DIFF
--- a/WalletKitCore/include/BRCryptoAccount.h
+++ b/WalletKitCore/include/BRCryptoAccount.h
@@ -55,6 +55,17 @@ extern "C" {
     extern BRCryptoBoolean
     cryptoAccountValidateWordsList (size_t wordsCount);
 
+    /**
+     * Create an Account from a paperKey.  There is absolutely no check on the paperKey as a valid
+     * BIP-39 paperKey for a specified word-list.  Therefore Users should call
+     * `cryptoAccountValidatePaperKey()` prior to any attempt to create an account.
+     *
+     * @param paperKey the paper key
+     * @param timestamp the paper key's creation timestamp
+     * @param uids a uids
+     *
+     * @return The Account, or NULL.  In practice NULL is never returned.
+     */
     extern BRCryptoAccount
     cryptoAccountCreate (const char *paperKey, uint64_t timestamp, const char *uids);
 

--- a/WalletKitJava/CoreNative/src/commonTest/java/com/breadwallet/corenative/CryptoLibraryIT.java
+++ b/WalletKitJava/CoreNative/src/commonTest/java/com/breadwallet/corenative/CryptoLibraryIT.java
@@ -156,7 +156,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;
@@ -196,7 +196,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;
@@ -235,7 +235,7 @@ public class CryptoLibraryIT {
                 paperKey.getBytes(StandardCharsets.UTF_8),
                 UnsignedLong.valueOf(epoch),
                 uids
-        );
+        ).get();
 
         try {
             BRCryptoNetwork network;

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class BRCryptoAccount extends PointerType {
 
-    public static BRCryptoAccount createFromPhrase(byte[] phraseUtf8, UnsignedLong timestamp, String uids) {
+    public static Optional<BRCryptoAccount> createFromPhrase(byte[] phraseUtf8, UnsignedLong timestamp, String uids) {
         long timestampAsLong = timestamp.longValue();
 
         // ensure string is null terminated
@@ -40,13 +40,13 @@ public class BRCryptoAccount extends PointerType {
                 phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
                 ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
-                return new BRCryptoAccount(
+                return Optional.fromNullable(
                         CryptoLibraryDirect.cryptoAccountCreate(
                                 phraseBuffer,
                                 timestampAsLong,
                                 uids
                         )
-                );
+                ).transform(BRCryptoAccount::new);
             } finally {
                 phraseMemory.clear();
             }

--- a/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AccountAIT.java
+++ b/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AccountAIT.java
@@ -24,7 +24,7 @@ public class AccountAIT {
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
 
-        Account account = Account.createFromPhrase(phrase, timestamp, uids);
+        Account account = Account.createFromPhrase(phrase, timestamp, uids).get();
         assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
 
         // check the uids matches the one provided on creation
@@ -36,7 +36,7 @@ public class AccountAIT {
         byte[] phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic".getBytes(StandardCharsets.UTF_8);
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
-        Account accountFromPhrase = Account.createFromPhrase(phrase, timestamp, uids);
+        Account accountFromPhrase = Account.createFromPhrase(phrase, timestamp, uids).get();
 
         // check that serialization is repeatable and valid
         byte[] serializationFromPhrase = accountFromPhrase.serialize();

--- a/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
+++ b/WalletKitJava/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/HelpersAIT.java
@@ -175,7 +175,7 @@ class HelpersAIT {
 
     /* package */
     static Account createDefaultAccount() {
-        return Account.createFromPhrase(DEFAULT_ACCOUNT_KEY, DEFAULT_ACCOUNT_TIMESTAMP, DEFAULT_ACCOUNT_UIDS);
+        return Account.createFromPhrase(DEFAULT_ACCOUNT_KEY, DEFAULT_ACCOUNT_TIMESTAMP, DEFAULT_ACCOUNT_UIDS).get();
     }
 
     // BlockchainDB

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Account.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Account.java
@@ -52,9 +52,9 @@ final class Account implements com.breadwallet.crypto.Account {
      * @param timestamp The timestamp of when this account was first created
      * @param uids The unique identifier of this account
      */
-    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
-        BRCryptoAccount core = BRCryptoAccount.createFromPhrase(phraseUtf8, Utilities.dateAsUnixTimestamp(timestamp), uids);
-        return Account.create(core);
+    static Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+        Optional<BRCryptoAccount> core = BRCryptoAccount.createFromPhrase(phraseUtf8, Utilities.dateAsUnixTimestamp(timestamp), uids);
+        return core.transform(Account::create);
     }
 
     /**

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
@@ -31,8 +31,8 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
 
     private static final CryptoApi.AccountProvider accountProvider = new CryptoApi.AccountProvider() {
         @Override
-        public com.breadwallet.crypto.Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
-            return Account.createFromPhrase(phraseUtf8, timestamp, uids);
+        public Optional<com.breadwallet.crypto.Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+            return Account.createFromPhrase(phraseUtf8, timestamp, uids).transform(a -> a);
         }
 
         @Override

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Account.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Account.java
@@ -28,7 +28,7 @@ public interface Account {
      * @param timestamp The timestamp of when this account was first created
      * @param uids The unique identifier of this account
      */
-    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+    static Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
         return CryptoApi.getProvider().accountProvider().createFromPhrase(phraseUtf8, timestamp, uids);
     }
 

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 public final class CryptoApi {
 
     public interface AccountProvider {
-        Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
+        Optional<Account> createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
         Optional<Account> createFromSerialization(byte[] serialization, String uids);
         byte[] generatePhrase(List<String> words);
         boolean validatePhrase(byte[] phraseUtf8, List<String> words);

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -149,7 +149,7 @@ public class CoreCryptoApplication extends Application {
             systemListener.addSystemListener(new CoreSystemListener(mode, isMainnet, currencyCodesNeeded));
 
             String uids = UUID.randomUUID().toString();
-            account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids);
+            account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids).get();
 
             blockchainDb = BlockchainDb.createForTest (new OkHttpClient(), BDB_AUTH_TOKEN);
             system = System.create(systemExecutor, systemListener, account,

--- a/WalletKitSwift/WalletKit/BRCryptoAccount.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoAccount.swift
@@ -113,7 +113,7 @@ public final class Account {
     ///
     /// - Parameters:
     ///   - phrase: the candidate paper key
-    ///   - words: A local-specific BIP-39-defined array of BIP39_WORDLIST_COUNT words.
+    ///   - words: A locale-specific BIP-39-defined array of BIP39_WORDLIST_COUNT words.
     ///
     /// - Returns: true is a valid paper key; false otherwise
     ///


### PR DESCRIPTION
Functionally, there is no change.  Make Swift/Java consistent; but both assume a paperKey produces an Account, always.