### PR TITLE
CORE-878: Define CRYPTO_NETWORK_TYPE_XLM

### DIFF
--- a/WalletKitCore/include/BRCryptoBase.h
+++ b/WalletKitCore/include/BRCryptoBase.h
@@ -99,10 +99,10 @@ extern uint64_t BLOCK_HEIGHT_UNBOUND_VALUE;
         CRYPTO_NETWORK_TYPE_ETH,
         CRYPTO_NETWORK_TYPE_XRP,
         CRYPTO_NETWORK_TYPE_HBAR,
-        // CRYPTO_NETWORK_TYPE_XLM,
+        CRYPTO_NETWORK_TYPE_XLM,
     } BRCryptoNetworkCanonicalType;
 
-#    define NUMBER_OF_NETWORK_TYPES    (1 + CRYPTO_NETWORK_TYPE_HBAR)
+#    define NUMBER_OF_NETWORK_TYPES    (1 + CRYPTO_NETWORK_TYPE_XLM)
 
     //
     // Crypto Network Base Currency
@@ -115,6 +115,7 @@ extern uint64_t BLOCK_HEIGHT_UNBOUND_VALUE;
 #    define CRYPTO_NETWORK_CURRENCY_ETH     "eth"
 #    define CRYPTO_NETWORK_CURRENCY_XRP     "xrp"
 #    define CRYPTO_NETWORK_CURRENCY_HBAR    "hbar"
+#    define CRYPTO_NETWORK_CURRENCY_XLM     "xlm"
 
     extern const char *
     cryptoNetworkCanonicalTypeGetCurrencyCode (BRCryptoNetworkCanonicalType type);

--- a/WalletKitCore/src/crypto/BRCryptoConfig.h
+++ b/WalletKitCore/src/crypto/BRCryptoConfig.h
@@ -142,6 +142,24 @@ DEFINE_MODES            ("hedera-testnet", CRYPTO_SYNC_MODE_API_ONLY)
 
 // MARK: XLM Mainnet
 
+#define NETWORK_NAME    "Stellar"
+DEFINE_NETWORK (xlmMainnet,  "stellar-mainnet", NETWORK_NAME, "mainnet", true, 52473542, 1)
+DEFINE_NETWORK_FEE_ESTIMATE ("stellar-mainnet", "500000", "1m", 1 * 60 * 1000)
+DEFINE_CURRENCY ("stellar-mainnet",     "stellar-mainnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XLM,  "native",   NULL,   true)
+    DEFINE_UNIT ("stellar-testnet:__native__",  "miniStellar", "mxlm",  0,  "mXLM")  // 0.0001 Tx Fee
+    DEFINE_UNIT ("stellar-testnet:__native__",  NETWORK_NAME,  "xlm",   8,  "XLM")   // 10^8
+DEFINE_ADDRESS_SCHEMES  ("stellar-mainnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_MODES            ("stellar-mainnet", CRYPTO_SYNC_MODE_API_ONLY)
+
+DEFINE_NETWORK (xlmTestnet,  "stellar-testnet", NETWORK_NAME, "testnet", false, 50000, 1)
+DEFINE_NETWORK_FEE_ESTIMATE ("stellar-testnet", "500000", "1m", 1 * 60 * 1000)
+DEFINE_CURRENCY ("stellar-testnet",     "stellar-testnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XLM,  "native",   NULL,   true)
+    DEFINE_UNIT ("stellar-testnet:__native__",  "miniStellar", "mxlm",  0,  "mXLM")  // 0.0001 Tx Fee
+    DEFINE_UNIT ("stellar-testnet:__native__",  NETWORK_NAME,  "xlm",   8,  "XLM")   // 10^8
+DEFINE_ADDRESS_SCHEMES  ("stellar-testnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_MODES            ("stellar-testnet", CRYPTO_SYNC_MODE_API_ONLY)
+#undef NETWORK_NAME
+
 #undef DEFINE_NETWORK
 #undef DEFINE_NETWORK_FEE_ESTIMATE
 #undef DEFINE_CURRENCY

--- a/WalletKitCore/src/crypto/BRCryptoNetwork.c
+++ b/WalletKitCore/src/crypto/BRCryptoNetwork.c
@@ -35,7 +35,7 @@ cryptoNetworkCanonicalTypeGetCurrencyCode (BRCryptoNetworkCanonicalType type) {
         CRYPTO_NETWORK_CURRENCY_ETH,
         CRYPTO_NETWORK_CURRENCY_XRP,
         CRYPTO_NETWORK_CURRENCY_HBAR,
-        // "Stellar"
+        CRYPTO_NETWORK_CURRENCY_XLM,
     };
     assert (type < NUMBER_OF_NETWORK_TYPES);
     return currencies[type];
@@ -656,22 +656,36 @@ cryptoNetworkCreateBuiltin (const char *symbol,
         network = cryptoNetworkCreateAsBCH (uids, name, BRBCashParams);
     else if (0 == strcmp ("bchTestnet", symbol))
         network = cryptoNetworkCreateAsBCH (uids, name, BRBCashTestNetParams);
+
+    // ETH
+
     else if (0 == strcmp ("ethMainnet", symbol))
         network = cryptoNetworkCreateAsETH (uids, name, ethNetworkMainnet);
     else if (0 == strcmp ("ethRopsten", symbol))
         network = cryptoNetworkCreateAsETH (uids, name, ethNetworkTestnet);
     else if (0 == strcmp ("ethRinkeby", symbol))
         network = cryptoNetworkCreateAsETH (uids, name, ethNetworkRinkeby);
+
+    // XRP
+
     else if (0 == strcmp ("xrpMainnet", symbol))
         network = cryptoNetworkCreateAsGEN (uids, name, 1, CRYPTO_NETWORK_TYPE_XRP);
     else if (0 == strcmp ("xrpTestnet", symbol))
         network = cryptoNetworkCreateAsGEN (uids, name, 0, CRYPTO_NETWORK_TYPE_XRP);
+
+    // HBAR
+
     else if (0 == strcmp ("hbarMainnet", symbol))
         network = cryptoNetworkCreateAsGEN (uids, name, 1, CRYPTO_NETWORK_TYPE_HBAR);
     else if (0 == strcmp ("hbarTestnet", symbol))
         network = cryptoNetworkCreateAsGEN (uids, name, 0, CRYPTO_NETWORK_TYPE_HBAR);
-//    else if (0 == strcmp ("xlmMainnet", symbol))
-//        network = cryptoNetworkCreateAsGEN (uids, name, GEN_NETWORK_TYPE_Xlm, 1, CRYPTO_NETWORK_TYPE_XLM);
+
+    // XLM
+    
+    else if (0 == strcmp ("xlmMainnet", symbol))
+        network = cryptoNetworkCreateAsGEN (uids, name, 1, CRYPTO_NETWORK_TYPE_XLM);
+    else if (0 == strcmp ("xlmTestnet", symbol))
+        network = cryptoNetworkCreateAsGEN (uids, name, 0, CRYPTO_NETWORK_TYPE_XLM);
     // ...
 
     assert (NULL != network);

--- a/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
@@ -309,7 +309,7 @@ public enum NetworkType: CustomStringConvertible {
     case eth
     case xrp
     case hbar
-//    case xlm
+    case xlm
 
     internal init (core: BRCryptoNetworkCanonicalType) {
         switch core {
@@ -318,7 +318,7 @@ public enum NetworkType: CustomStringConvertible {
         case CRYPTO_NETWORK_TYPE_ETH:  self = .eth
         case CRYPTO_NETWORK_TYPE_XRP:  self = .xrp
         case CRYPTO_NETWORK_TYPE_HBAR: self = .hbar
-//        case CRYPTO_NETWORK_TYPE_XLM:  self = .xlm
+        case CRYPTO_NETWORK_TYPE_XLM:  self = .xlm
         default: preconditionFailure()
         }
     }
@@ -330,7 +330,7 @@ public enum NetworkType: CustomStringConvertible {
         case .eth: return CRYPTO_NETWORK_TYPE_ETH
         case .xrp: return CRYPTO_NETWORK_TYPE_XRP
         case .hbar: return CRYPTO_NETWORK_TYPE_HBAR
-//        case .xml: return CRYPTO_NETWORK_TYPE_XLM
+        case .xlm: return CRYPTO_NETWORK_TYPE_XLM
         }
     }
 

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -374,7 +374,7 @@ extension Network {
         case .eth: return "ethereum"
         case .xrp: return "ripple"
         case .hbar: return "hedera"
-//        case .xlm:  return "stellar"
+        case .xlm: return "stellar"
         }
     }
 }


### PR DESCRIPTION
This puts the top-level linkages in place for Stellar.  Allows for generic/BRGenericStellar.{ch} implementation of the GEN interface (see CORE-775)