### PR TITLE
CORE-882: Add System.accountIsInitialized(...:completion)

### DIFF
--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -232,6 +232,8 @@ public interface System {
 
     boolean accountIsInitialized (Account account, Network nework);
 
+    void accountIsInitializedConfirm (Account account, Network network, CompletionHandler<Boolean, AccountInitializationError> handler);
+
     void accountInitialize (Account account, Network network, CompletionHandler<byte[], AccountInitializationError> handler);
 
     Optional<byte[]> accountInitializeUsingData (Account account, Network network, byte[] data);

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -232,7 +232,7 @@ public interface System {
 
     boolean accountIsInitialized (Account account, Network nework);
 
-    void accountIsInitializedConfirm (Account account, Network network, CompletionHandler<Boolean, AccountInitializationError> handler);
+    void accountIsInitialized(Account account, Network network, CompletionHandler<Boolean, AccountInitializationError> handler);
 
     void accountInitialize (Account account, Network network, CompletionHandler<byte[], AccountInitializationError> handler);
 

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -10,7 +10,6 @@ package com.breadwallet.cryptodemo;
 import android.support.annotation.Nullable;
 
 import com.breadwallet.crypto.Account;
-import com.breadwallet.crypto.Address;
 import com.breadwallet.crypto.AddressScheme;
 import com.breadwallet.crypto.Coder;
 import com.breadwallet.crypto.Currency;
@@ -159,7 +158,7 @@ public class CoreSystemListener implements SystemListener {
                     checkState (network.getType() == NetworkType.HBAR);
                     List<byte[]> serializationData = new ArrayList<>();
 
-                    system.accountIsInitializedConfirm(system.getAccount(), network, new CompletionHandler<Boolean, AccountInitializationError>() {
+                    system.accountIsInitialized(system.getAccount(), network, new CompletionHandler<Boolean, AccountInitializationError>() {
                                 @Override
                                 public void handleData(Boolean exists) {
                                     Log.log(Level.FINE, String.format("Account: Hedera: Exists: %s", exists));

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -159,6 +159,18 @@ public class CoreSystemListener implements SystemListener {
                     checkState (network.getType() == NetworkType.HBAR);
                     List<byte[]> serializationData = new ArrayList<>();
 
+                    system.accountIsInitializedConfirm(system.getAccount(), network, new CompletionHandler<Boolean, AccountInitializationError>() {
+                                @Override
+                                public void handleData(Boolean exists) {
+                                    Log.log(Level.FINE, String.format("Account: Hedera: Exists: %s", exists));
+                                }
+
+                                @Override
+                                public void handleError(AccountInitializationError error) {
+                                    Log.log(Level.FINE, String.format("Account: Hedera: Exists: Error: %s", error.getLocalizedMessage()));
+                                }
+                            }
+                    );
                     system.accountInitialize(system.getAccount(), network, new CompletionHandler<byte[], AccountInitializationError>() {
                         @Override
                         public void handleData(byte[] data) {
@@ -173,7 +185,7 @@ public class CoreSystemListener implements SystemListener {
 
                                 // Sort accounts....
                                 system.accountInitializeUsingHedera (system.getAccount(), network, accounts.get(0))
-                                        .transform((bytes) -> { serializationData.add(bytes); return null; });
+                                        .transform((bytes) -> { serializationData.add(bytes); return true; });
                             }
                             createWalletManagerIfAppropriate(serializationData, system, network, mode, addressScheme);
                         }

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
@@ -118,6 +118,16 @@ class CoreDemoListener: SystemListener {
                     // Recover if account is not initialized
                     if !system.accountIsInitialized (system.account, onNetwork: network) {
                         guard .hbar == network.type else { preconditionFailure () }
+
+                        system.accountIsInitialized(system.account, onNetwork: network) {
+                            (res: Result<Bool, System.AccountInitializationError>) in
+                            res.resolve(success: { (exists: Bool) in
+                                print ("APP: Account: Exists: \(exists)")
+                            }) { (error: System.AccountInitializationError) in
+                                print ("APP: Account: Exists: Erorr: \(error.localizedDescription)")
+                            }
+                        }
+
                         system.accountInitialize (system.account, onNetwork: network) {
                             (res:Result<Data, System.AccountInitializationError>) in
 


### PR DESCRIPTION
Asynchronously check if an account on a network is initialized.  Unlike accountIsInitialized(...), this functions does not cache the initialized status; it checks each time.  Works for *all* existing networks (BTC, ...).