### PR TITLE
CORE-874: In `bwmHandleTxAdded()`, don't dereference `refedTransaction`

### DIFF
--- a/WalletKitCore/src/bitcoin/BRWalletManager.c
+++ b/WalletKitCore/src/bitcoin/BRWalletManager.c
@@ -1136,6 +1136,7 @@ BRWalletManagerNew (BRWalletManagerClient client,
     size_t txCount = BRWalletTransactions (bwm->wallet, NULL, 0);
     if (txCount) {
         BRArrayOf(BRTransaction *) txns = calloc (txCount, sizeof(BRTransaction*));
+        // Fills txns with direct references to BRWallet transactions; caution warranted.
         BRWalletTransactions (bwm->wallet, txns, txCount);
 
         for (size_t i = 0; i < txCount; i++) {
@@ -1145,7 +1146,7 @@ BRWalletManagerNew (BRWalletManagerClient client,
             BRTransactionWithState txnWithState = BRWalletManagerAddTransaction (bwm,
                                                                                  BRTransactionCopy (txns[i]),
                                                                                  txns[i]);
-            if (BRWalletTransactionIsResolved (bwm->wallet, txns[i]))
+            if (BRWalletTransactionIsResolved (bwm->wallet, txnWithState->ownedTransaction))
                 BRTransactionWithStateSetResolved (txnWithState);
 
             if (txnWithState->isResolved)
@@ -1722,6 +1723,9 @@ extern void
 bwmHandleTxAdded (BRWalletManager manager,
                   OwnershipGiven BRTransaction *ownedTransaction,
                   OwnershipKept BRTransaction *refedTransaction) {
+    // RefedTransaction and OwnTransaction are guaranteed identical; don't access the
+    // content of refedTransaction; it is OwnershipKept and could be gone by now.
+
     pthread_mutex_lock (&manager->lock);
     int needEvents = 1;
 
@@ -1730,7 +1734,7 @@ bwmHandleTxAdded (BRWalletManager manager,
     if (NULL == txnWithState) {
         // first we've seen it, so it came from the network; add it to our list
         txnWithState = BRWalletManagerAddTransaction (manager, ownedTransaction, refedTransaction);
-        if (BRWalletTransactionIsResolved (manager->wallet, refedTransaction)) {
+        if (BRWalletTransactionIsResolved (manager->wallet, txnWithState->ownedTransaction)) {
             BRTransactionWithStateSetResolved (txnWithState);
         }
     } else {
@@ -1750,7 +1754,10 @@ bwmHandleTxAdded (BRWalletManager manager,
     }
     assert (NULL != txnWithState);
 
-    if (BRWalletTransactionIsResolved (manager->wallet, refedTransaction))
+    // Check 'IsResolved' based on the 'old' ownedTransaction; resolution does not depend on
+    // any fields that might have changed in the ownedTransaction argument to this function.  Thus
+    // is is okay to use `txnWithState->ownedTransaction`
+    if (BRWalletTransactionIsResolved (manager->wallet, txnWithState->ownedTransaction))
         BRTransactionWithStateSetResolved (txnWithState);
 
     // Find other transactions that are now resolved.
@@ -1762,7 +1769,7 @@ bwmHandleTxAdded (BRWalletManager manager,
 
     for (size_t index = 0; index < transactionsCount; index++) {
         BRTransactionWithState txnWithState  = manager->transactions[index];
-        uint8_t nowResolved = BRWalletTransactionIsResolved (manager->wallet, txnWithState->refedTransaction);
+        uint8_t nowResolved = BRWalletTransactionIsResolved (manager->wallet, txnWithState->ownedTransaction);
 
         if (!txnWithState->isResolved && nowResolved) {
             BRTransactionWithStateSetResolved (txnWithState);


### PR DESCRIPTION
This commit was missed in the breadwallet-core -> walletkit repo conversion.