### PR TITLE
CORE-915: Ripple - Support new sequence number start

### DIFF
--- a/WalletKitCore/src/ripple/BRRippleAccount.c
+++ b/WalletKitCore/src/ripple/BRRippleAccount.c
@@ -219,3 +219,9 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
 
     return tx_size;
 }
+
+extern BRRippleSequence rippleAccountGetSequence (BRRippleAccount account)
+{
+    assert(account);
+    return account->sequence;
+}

--- a/WalletKitCore/src/ripple/BRRippleAccount.c
+++ b/WalletKitCore/src/ripple/BRRippleAccount.c
@@ -32,6 +32,8 @@
 
 #define WORD_LIST_LENGTH 2048
 
+#define RIPPLE_SEQUENCE_PROTOCOL_CHANGE_BLOCK 55313921
+
 struct BRRippleAccountRecord {
     BRRippleAddress address; // The 20 byte account id
 
@@ -39,6 +41,9 @@ struct BRRippleAccountRecord {
     BRKey publicKey;  // BIP44: 'Master Public Key 'M' (264 bits) - 8
 
     uint32_t index;     // The BIP-44 Index used for this key.
+
+    // This is the Ripple Ledger index where the account was created (unsigned 32-bits)
+    uint32_t blockNumberAtCreation;
     
     BRRippleSequence sequence;   // The NEXT valid sequence number, must be exactly 1 greater
                                  // than the last transaction sent
@@ -207,9 +212,17 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
     // Create the private key from the paperKey
     BRKey key = deriveRippleKeyFromSeed (seed, 0, false);
 
+    // Figure out the sequence number - first of all increment by 1
+    uint32_t sequence = account->sequence + 1;
+    // Due to a change in the Ripple protocol, the starting sequence value changed
+    // from 1 to the block where the account was created.
+    // NOTE that we need to subtract 1 from the blockNumberAtCreation since that value
+    // is the explicitly set value that we need to use for the first send - and since
+    // we added 1 in the above statement we would be off by 1.
+    sequence += account->blockNumberAtCreation >= RIPPLE_SEQUENCE_PROTOCOL_CHANGE_BLOCK ? account->blockNumberAtCreation - 1 : 0;
     size_t tx_size =
         rippleTransactionSerializeAndSign(transaction, &key, &account->publicKey,
-                                          account->sequence + 1,  // next sequence number
+                                          sequence,  // next sequence number
                                           account->lastLedgerSequence);
 
     // Increment the sequence number if we were able to sign the bytes
@@ -224,4 +237,12 @@ extern BRRippleSequence rippleAccountGetSequence (BRRippleAccount account)
 {
     assert(account);
     return account->sequence;
+}
+
+extern void rippleAccountSetBlockNumberAtCreation (BRRippleAccount account, uint64_t blockHeight)
+{
+    assert(account);
+    // Block heights from Blockset are unsigned 64-bits, but the Ripple block (ledger index) is
+    // only an unsigned 32-bit value
+    account->blockNumberAtCreation = (uint32_t)blockHeight;
 }

--- a/WalletKitCore/src/ripple/BRRippleAccount.h
+++ b/WalletKitCore/src/ripple/BRRippleAccount.h
@@ -127,4 +127,7 @@ extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account);
 
 extern BRKey rippleAccountGetPublicKey(BRRippleAccount account);
 
+// Internal
+extern BRRippleSequence rippleAccountGetSequence (BRRippleAccount account);
+
 #endif

--- a/WalletKitCore/src/ripple/BRRippleAccount.h
+++ b/WalletKitCore/src/ripple/BRRippleAccount.h
@@ -130,4 +130,7 @@ extern BRKey rippleAccountGetPublicKey(BRRippleAccount account);
 // Internal
 extern BRRippleSequence rippleAccountGetSequence (BRRippleAccount account);
 
+// Internal
+extern void rippleAccountSetBlockNumberAtCreation (BRRippleAccount account, uint64_t blockHeight);
+
 #endif

--- a/WalletKitCore/src/ripple/BRRippleTransfer.c
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.c
@@ -151,3 +151,8 @@ extern int
 rippleTransferHasError(BRRippleTransfer transfer) {
     return transfer->error;
 }
+
+extern uint64_t rippleTransferGetBlockHeight (BRRippleTransfer transfer) {
+    assert(transfer);
+    return transfer->blockHeight;
+}

--- a/WalletKitCore/src/ripple/BRRippleTransfer.h
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.h
@@ -52,4 +52,6 @@ extern BRRippleTransaction rippleTransferGetTransaction(BRRippleTransfer transfe
 // Internal
 extern int rippleTransferHasSource (BRRippleTransfer transfer,
                                     BRRippleAddress source);
+
+extern uint64_t rippleTransferGetBlockHeight (BRRippleTransfer transfer);
 #endif

--- a/WalletKitCore/src/ripple/BRRippleWallet.c
+++ b/WalletKitCore/src/ripple/BRRippleWallet.c
@@ -19,8 +19,6 @@
 
 #define RIPPLE_WALLET_MINIMUM_IN_XRP            (20)
 
-#define RIPPLE_SEQUENCE_PROTOCOL_CHANGE 55313921
-
 //
 // Wallet
 //
@@ -195,14 +193,7 @@ static void rippleWalletUpdateSequence (BRRippleWallet wallet,
             sequence += 1;
     }
 
-    // So now the hack part - at block 55,313,921 Ripple started using the block height
-    // as the start sequence, prior to that it was 1.
-    // If minBlockHeight is INT64_MAX then there are no transactions so ignore
-    // If the account was created prior to 55313921 then ignore
-    if (minBlockHeight != INT64_MAX && minBlockHeight >= RIPPLE_SEQUENCE_PROTOCOL_CHANGE) {
-        // Subtract 1 from the minBlockHieght since we add 1 to the sequence before signing
-        sequence += (minBlockHeight - 1);
-    }
+    rippleAccountSetBlockNumberAtCreation(wallet->account, minBlockHeight);
     rippleAccountSetSequence (wallet->account, sequence);
 }
 


### PR DESCRIPTION
Ripple account created after block 55313921 use a different sequence number start point.