### PR TITLE
CORE-911: In Core Crypto, Handled Blockset `SUBMITTED` but not `INCLUDED`

### DIFF
--- a/WalletKitCore/src/generic/BRGenericManager.c
+++ b/WalletKitCore/src/generic/BRGenericManager.c
@@ -503,6 +503,24 @@ genManagerSubmitTransfer (BRGenericManager gwm,
     free (tx);
 }
 
+extern BRGenericTransferState
+genManagerRecoverTransferState (BRGenericManager gwm,
+                                uint64_t timestamp,
+                                uint64_t blockHeight,
+                                BRGenericFeeBasis feeBasis,
+                                BRCryptoBoolean error) {
+    return (blockHeight == BLOCK_HEIGHT_UNBOUND && CRYPTO_TRUE == error
+            ? genTransferStateCreateOther (GENERIC_TRANSFER_STATE_ERRORED)
+            : (blockHeight == BLOCK_HEIGHT_UNBOUND
+               ? genTransferStateCreateOther(GENERIC_TRANSFER_STATE_SUBMITTED)
+               : genTransferStateCreateIncluded (blockHeight,
+                                                 GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
+                                                 timestamp,
+                                                 feeBasis,
+                                                 error,
+                                                 NULL)));
+}
+
 extern BRGenericTransfer
 genManagerRecoverTransfer (BRGenericManager gwm,
                            BRGenericWallet wallet,
@@ -534,13 +552,12 @@ genManagerRecoverTransfer (BRGenericManager gwm,
                               ? GENERIC_TRANSFER_SENT
                               : GENERIC_TRANSFER_RECEIVED));
 
-    genTransferSetState (transfer,
-                         genTransferStateCreateIncluded (blockHeight,
-                                                         GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
-                                                         timestamp,
-                                                         feeBasis,
-                                                         0 == error,
-                                                         NULL));
+    BRGenericTransferState transferState = genManagerRecoverTransferState (gwm,
+                                                                           timestamp,
+                                                                           blockHeight,
+                                                                           feeBasis,
+                                                                           AS_CRYPTO_BOOLEAN (0 == error));
+    genTransferSetState (transfer, transferState);
 
     genAddressRelease (source);
     genAddressRelease (target);
@@ -560,13 +577,13 @@ genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
     array_new (transfers, array_count(refs));
     for (size_t index = 0; index < array_count(refs); index++) {
         BRGenericTransfer transfer = genTransferAllocAndInit (gwm->handlers->type, refs[index]);
-        genTransferSetState (transfer,
-                             genTransferStateCreateIncluded (blockHeight,
-                                                             GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
-                                                             timestamp,
-                                                             genTransferGetFeeBasis (transfer),
-                                                             0 == error,
-                                                             NULL));
+        BRGenericFeeBasis feeBasis = genTransferGetFeeBasis (transfer);
+        BRGenericTransferState transferState = genManagerRecoverTransferState (gwm,
+                                                                               timestamp,
+                                                                               blockHeight,
+                                                                               feeBasis,
+                                                                               AS_CRYPTO_BOOLEAN (0 == error));
+        genTransferSetState (transfer, transferState);
         array_add (transfers, transfer);
     }
     pthread_mutex_unlock (&gwm->lock);

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -1757,7 +1757,7 @@ final class System implements com.breadwallet.crypto.System {
                                                     return;
                                                 }
 
-                                                UnsignedLong blockHeight = transaction.getBlockHeight().or(UnsignedLong.ZERO);
+                                                UnsignedLong blockHeight = transaction.getBlockHeight().or(BRConstants.BLOCK_HEIGHT_UNBOUND);
                                                 UnsignedLong timestamp =
                                                         transaction.getTimestamp().transform(Utilities::dateAsUnixTimestamp).or(UnsignedLong.ZERO);
                                                 BRCryptoTransferStateType status = (transaction.getStatus().equals("confirmed")
@@ -1937,7 +1937,7 @@ final class System implements com.breadwallet.crypto.System {
                                                     List<ObjectPair<com.breadwallet.crypto.blockchaindb.models.bdb.Transfer, String>> merged;
 
                                                     for (Transaction transaction : transactions) {
-                                                        UnsignedLong blockHeight = transaction.getBlockHeight().or(UnsignedLong.ZERO);
+                                                        UnsignedLong blockHeight = transaction.getBlockHeight().or(BRConstants.BLOCK_HEIGHT_UNBOUND);
                                                         UnsignedLong timestamp = transaction.getTimestamp().transform(Utilities::dateAsUnixTimestamp).or(UnsignedLong.ZERO);
 
                                                         BRCryptoTransferStateType status = (transaction.getStatus().equals("confirmed")

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1482,7 +1482,7 @@ extension System {
                                                     success: {
                                                         $0.forEach { (model: BlockChainDB.Model.Transaction) in
                                                             let timestamp = model.timestamp.map { $0.asUnixTimestamp } ?? 0
-                                                            let height    = model.blockHeight ?? 0
+                                                            let height    = model.blockHeight ?? BLOCK_HEIGHT_UNBOUND
                                                             let status    = System.getTransferStatus (model.status)
 
                                                             if var data = model.raw {
@@ -1600,7 +1600,7 @@ extension System {
                                                         success: {
                                                             $0.forEach { (transaction: BlockChainDB.Model.Transaction) in
                                                                 let timestamp = transaction.timestamp.map { $0.asUnixTimestamp } ?? 0
-                                                                let height    = transaction.blockHeight ?? 0
+                                                                let height    = transaction.blockHeight ?? BLOCK_HEIGHT_UNBOUND
                                                                 let status    = System.getTransferStatus (transaction.status)
 
                                                                 System.mergeTransfers (transaction.transfers, with: addresses)


### PR DESCRIPTION
If Blockset does not provide a blockHeight, then the transaction/transfer is not in the blockchain.  Don't resolve the blockheight optional with ZERO but will BLOCK_HEIGHT_UNBOUND.  Then in BTC/BCH code use TX_UNCONFIRMED.  For GEN handle the state carefully.
