### PR TITLE
CORE-929: For 'ETH in Blockset', Query w/ Multiple Address String Cases.

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <math.h>  // round()
 #include <stdbool.h>
+#include <ctype.h>
 
 #include "BRCryptoBase.h"
 #include "BRCryptoStatusP.h"
@@ -1490,6 +1491,15 @@ cwmSubmitTransactionAsETH (BREthereumClientContext context,
     cryptoWalletManagerGive (cwm);
 }
 
+static char *
+strcase (const char *s, bool upper) {
+    if (NULL == s) return NULL;
+    char *result = malloc (1 + strlen (s)), *r = result;
+    while (*s) *r++ = (upper ? toupper (*s++) : tolower (*s++));
+    *r = '\0';
+    return result;
+}
+
 static void
 cwmGetTransactionsAsETH (BREthereumClientContext context,
                          BREthereumEWM ewm,
@@ -1505,13 +1515,30 @@ cwmGetTransactionsAsETH (BREthereumClientContext context,
     callbackState->type = CWM_CALLBACK_TYPE_ETH_GET_TRANSACTIONS;
     callbackState->rid = rid;
 
+    // ETH addresses are formally case-insensitive.  Other blockchains, such at BTC, are formally
+    // case-sensitive.  Therefore the defined `funcGetTransfers` interface cannot force a specific
+    // case for all blockchains.  Rather, `funcGetTransfers` is required to accept addresses in
+    // the blockchain's canonical format(s).
+    //
+    // In this ETH context, the address can by any case (a 'Hex' String [0-9a-fA-f]).  However,
+    // we'll force the addresses to be lowercase, in light of: a) ETH check-summed addresses being
+    // an Ethereum after-throught and b) our current implementation of `funcGetTransfers` IS case
+    // sensitive.
+    //
+    // All the same applies to `funcGetTranactions.  That function is not used for ETH.
+#define NUMBER_OF_ADDRESSES         (1)
+    char *addresses[NUMBER_OF_ADDRESSES];
+    addresses[0] = strcase (address, false);
+
     cwm->client.funcGetTransfers (cwm->client.context,
                                   cryptoWalletManagerTake (cwm),
                                   callbackState,
-                                  &address, 1,
+                                  (const char **) addresses, NUMBER_OF_ADDRESSES,
                                   "__native__",
                                   begBlockNumber, endBlockNumber);
 
+    free (addresses[0]);
+#undef NUMBER_OF_ADDRESSES
     cryptoWalletManagerGive (cwm);
 }
 

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1375,7 +1375,7 @@ extension System {
             addresses[index] = asUTF8String (cAddresses.pointee!)
             cAddresses = cAddresses.advanced(by: 1)
         }
-        return addresses.map { $0.lowercased() }
+        return addresses
     }
 
     internal var cryptoClient: BRCryptoClient {


### PR DESCRIPTION
(No Java change; did not have 'address.lowecased()' work-around)