### PR TITLE
CORE-928: Fix Ripple sequence error

### DIFF
--- a/WalletKitCore/WalletKitCoreTests/test/ripple/testRipple.c
+++ b/WalletKitCore/WalletKitCoreTests/test/ripple/testRipple.c
@@ -988,7 +988,8 @@ static void submitWithoutDestinationTag() {
     rippleAccountFree(sourceAccount);
 }
 
-static void testStartingSequenceFromBlock(uint64_t start_block, uint32_t expected_sequence)
+static void testStartingSequenceFromBlock(uint64_t start_block, uint32_t expected_sequence,
+                                          int addFailedFirstTransfer)
 {
     const char * paper_key = "patient doctor olympic frog force glimpse endless antenna online dragon bargain someone";
     BRRippleAccount account = rippleAccountCreate(paper_key);
@@ -1000,9 +1001,16 @@ static void testStartingSequenceFromBlock(uint64_t start_block, uint32_t expecte
     BRRippleAccount targetAccount = rippleAccountCreate(target_paper_key);
     BRRippleAddress targetAddress = rippleAccountGetPrimaryAddress(targetAccount);
 
+    BRRippleTransactionHash hash;
+    hex2bin("A3CD5808EB172BE1A532CF372363C505D499F277D4B56241CF3F0FC19ACECA2B", hash.bytes);
+    if (addFailedFirstTransfer) {
+        // Add a failed transfer at an earlier block - we should ignore this when determing
+        // the block where the account is created
+        BRRippleTransfer transfer = rippleTransferCreate(targetAddress, address, 0, 12, hash, 0, start_block - 1000, 1);
+    }
+
     // Create the initial transfer the creates the account (from target to us)
     // NOTE: this transfer MUST use the start_block unaltered as the height
-    BRRippleTransactionHash hash;
     hex2bin("B3CD5808EB172BE1A532CF372363C505D499F277D4B56241CF3F0FC19ACECA2B", hash.bytes);
     BRRippleTransfer transfer = rippleTransferCreate(targetAddress, address, 20000000, 12, hash, 0, start_block, 0);
     rippleWalletAddTransfer(wallet, transfer);
@@ -1041,9 +1049,12 @@ static void testStartingSequenceFromBlock(uint64_t start_block, uint32_t expecte
 
 static void testStartingSequence()
 {
-    testStartingSequenceFromBlock(40000000, 1); // Just an old account created at 40000000
-    testStartingSequenceFromBlock(55313920, 1); // The last block before the new behavior
-    testStartingSequenceFromBlock(55313921, 55313921); // The first block after the new behavior
+    testStartingSequenceFromBlock(40000000, 1, 0); // Just an old account created at 40000000
+    testStartingSequenceFromBlock(40000000, 1, 1); // This time with a failed first transfer
+    testStartingSequenceFromBlock(55313920, 1, 0); // The last block before the new behavior
+    testStartingSequenceFromBlock(55313920, 1, 1); // This time with a failed first transfer
+    testStartingSequenceFromBlock(55313921, 55313921, 0); // The first block after the new behavior
+    testStartingSequenceFromBlock(55313921, 55313921, 1); // This time with a failed first transfer
 }
 
 #pragma clang diagnostic pop

--- a/WalletKitCore/src/generic/BRGenericManager.c
+++ b/WalletKitCore/src/generic/BRGenericManager.c
@@ -181,7 +181,9 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
                                                             strFee,
                                                             timestamp,
                                                             blockHeight,
-                                                            GENERIC_TRANSFER_STATE_ERRORED == state.type);
+                                                            GENERIC_TRANSFER_STATE_ERRORED == state.type ||
+                                                            (GENERIC_TRANSFER_STATE_INCLUDED == state.type
+                                                             && CRYPTO_FALSE == state.u.included.success));
 
     // Set the transfer's `state` and `attributes` from the read values.  For`state`, this will
     // overwrite what `genManagerRecoverTransfer()` assigned but will be correct with the saved

--- a/WalletKitCore/src/ripple/BRRippleAccount.c
+++ b/WalletKitCore/src/ripple/BRRippleAccount.c
@@ -242,6 +242,11 @@ extern BRRippleSequence rippleAccountGetSequence (BRRippleAccount account)
 extern void rippleAccountSetBlockNumberAtCreation (BRRippleAccount account, uint64_t blockHeight)
 {
     assert(account);
+    if (blockHeight == UINT64_MAX) {
+        // Probably doesn't make much difference but UINT64_MAX probably means
+        // we don't have any transfers.
+        blockHeight = 0;
+    }
     // Block heights from Blockset are unsigned 64-bits, but the Ripple block (ledger index) is
     // only an unsigned 32-bit value
     account->blockNumberAtCreation = (uint32_t)blockHeight;

--- a/WalletKitCore/src/ripple/BRRippleWallet.c
+++ b/WalletKitCore/src/ripple/BRRippleWallet.c
@@ -185,10 +185,20 @@ static void rippleWalletUpdateSequence (BRRippleWallet wallet,
     BRRippleSequence sequence = 0;
     // We need to keep track of the first block where this account shows up due to a
     // change in how ripple assigns the sequence number to new accounts
-    uint64_t minBlockHeight = INT64_MAX;
+    uint64_t minBlockHeight = UINT64_MAX;
     for (size_t index = 0; index < array_count(wallet->transfers); index++) {
-        uint64_t blockHeight = rippleTransferGetBlockHeight(wallet->transfers[index]);
-        minBlockHeight = blockHeight < minBlockHeight ? blockHeight : minBlockHeight;
+        BRRippleTransfer transfer = wallet->transfers[index];
+        BRRippleAddress targetAddress = rippleTransferGetTarget(transfer);
+        if (rippleTransferHasError(transfer) == 0
+            && rippleAddressEqual(accountAddress, targetAddress)) {
+            // We trying to find the lowest block number where we were sent
+            // currency successful - basically this is the block where our account
+            // was created *** ignore failed transfers TO us since we end up seeing
+            // items before our account is actually created.
+            uint64_t blockHeight = rippleTransferGetBlockHeight(transfer);
+            minBlockHeight = blockHeight < minBlockHeight ? blockHeight : minBlockHeight;
+        }
+        rippleAddressFree(targetAddress);
         if (rippleTransferHasSource (wallet->transfers[index], accountAddress))
             sequence += 1;
     }


### PR DESCRIPTION
Our wallet can end up with transfers that pre-date our account:
i.e. someone sends us less than 20 XRP and transaction fails
When determining the block number where our account is created
ignore failed transfers directed at us.

Add unit test to cover the above case.