### PR TITLE
CORE-938: Use 'gasUsed' in ETH feeBasisConfirmed

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -1295,17 +1295,17 @@ cwmTransactionEventAsETH (BREthereumClientContext context,
             if (NULL != transfer ){
                 uint64_t blockNumber, blockTransactionIndex, blockTimestamp;
                 BREthereumGas gasUsed;
+                ewmTransferExtractStatusIncluded(ewm, tid, NULL, &blockNumber, &blockTransactionIndex, &blockTimestamp, &gasUsed);
 
                 BRCryptoTransferState oldState = cryptoTransferGetState (transfer);
 
-                BREthereumFeeBasis ethFeeBasis = ewmTransferGetFeeBasis (ewm, tid);
+                BREthereumFeeBasis ethFeeBasisEstimated = ewmTransferGetFeeBasis (ewm, tid);
 
                 BRCryptoUnit unit = cryptoTransferGetUnitForFee(transfer);
                 BRCryptoFeeBasis feeBasisConfirmed = cryptoFeeBasisCreateAsETH (unit,
-                                                                                ethFeeBasisGetGasLimit(ethFeeBasis),
-                                                                                ethFeeBasisGetGasPrice(ethFeeBasis));
+                                                                                gasUsed,
+                                                                                ethFeeBasisGetGasPrice(ethFeeBasisEstimated));
 
-                ewmTransferExtractStatusIncluded(ewm, tid, NULL, &blockNumber, &blockTransactionIndex, &blockTimestamp, &gasUsed);
                 BRCryptoTransferState newState = cryptoTransferStateIncludedInit (blockNumber,
                                                                                   blockTransactionIndex,
                                                                                   blockTimestamp,


### PR DESCRIPTION
ETH Transfers associated with a TOK Transfer incorrectly have a fee based on the gasEstimate, not on the gasUsed.  