### PR TITLE
CORE-940: Add BREthereumExchange

### DIFF
--- a/WalletKitCore/CMakeLists.txt
+++ b/WalletKitCore/CMakeLists.txt
@@ -213,6 +213,8 @@ target_sources (corecrypto
                 ${PROJECT_SOURCE_DIR}/src/ethereum/contract/BREthereumContract.h
                 ${PROJECT_SOURCE_DIR}/src/ethereum/contract/BREthereumToken.c
                 ${PROJECT_SOURCE_DIR}/src/ethereum/contract/BREthereumToken.h
+                ${PROJECT_SOURCE_DIR}/src/ethereum/contract/BREthereumExchange.c
+                ${PROJECT_SOURCE_DIR}/src/ethereum/contract/BREthereumExchange.h
                 # MPT
                 ${PROJECT_SOURCE_DIR}/src/ethereum/mpt/BREthereumMPT.c
                 ${PROJECT_SOURCE_DIR}/src/ethereum/mpt/BREthereumMPT.h

--- a/WalletKitCore/WalletKitCoreTests/test/ethereum/testEwm.c
+++ b/WalletKitCore/WalletKitCoreTests/test/ethereum/testEwm.c
@@ -231,13 +231,13 @@ clientGetTransactions (BREthereumClientContext context,
                                21000,
                                uint256CreateParse ("21000000000", 10, &ignore),
                                "",
-                               118,
-                               21000,
-                               1627184,
                                "0x0ef0110d68ee3af220e0d7c10d644fea98252180dbfc8a94cab9f0ea8b1036af",
+                               1627184,
                                "339050",
                                "3",
                                "1516477482",
+                               21000,
+                               118,
                                "0");
 
         ewmAnnounceTransaction(ewm, rid,
@@ -249,13 +249,13 @@ clientGetTransactions (BREthereumClientContext context,
                                21000,
                                uint256CreateParse ("21000000000", 10, &ignore),
                                "",
-                               118,
-                               21000,
-                               1627184,
                                "0x0ef0110d68ee3af220e0d7c10d644fea98252180dbfc8a94cab9f0ea8b1036af",
+                               1627184,
                                "339050",
                                "3",
                                "1516477482",
+                               21000,
+                               118,
                                "0");
     }
     ewmAnnounceTransactionComplete(ewm, rid, ETHEREUM_BOOLEAN_TRUE);
@@ -286,13 +286,13 @@ clientGetLogs (BREthereumClientContext context,
                         getTokenBRDAddress(ewm->network),
                         3,
                         topics,
-                        "0x0000000000000000000000000000000000000000000000000000000000002328",
-                        uint256CreateParse ("0xba43b7400", 16, &ignore),
-                        0xc64e,
-                        0x0,
+                        uint256CreateParse ("0x2328", 16, &ignore),
+                        "0xbc07f9de46ff70e74d024dc1b8a3730ca54829741418eb50e0511845a02ead9d",
                         0x1e487e,
                         0x0,
-                        0x59fa1ac9);
+                        0x59fa1ac9,
+                        0xc64e,
+                        0x0);
     ewmAnnounceLogComplete(ewm, rid, ETHEREUM_BOOLEAN_TRUE);
 
     free (address);

--- a/WalletKitCore/WalletKitCoreTests/test/ethereum/testEwm.c
+++ b/WalletKitCore/WalletKitCoreTests/test/ethereum/testEwm.c
@@ -186,13 +186,14 @@ clientEstimateGas (BREthereumClientContext context,
                    BREthereumWallet wid,
                    BREthereumTransfer tid,
                    BREthereumCookie cookie,
-                   const char *from,
-                   const char *to,
-                   const char *amount,
-                   const char *price,
-                   const char *data,
                    int rid) {
-    ewmAnnounceGasEstimateSuccess(ewm, wid, cookie, "0x77", price, rid);
+    BREthereumGasPrice gasPrice =  ewmTransferGetGasPrice (ewm, tid, WEI);
+
+    char *gasPriceStr = ethEtherGetValueString (gasPrice.etherPerGas, WEI);
+    char *gasLimitStr = "0x77";
+
+    ewmAnnounceGasEstimateSuccess(ewm, wid, cookie, gasLimitStr, gasPriceStr, rid);
+    free (gasPriceStr);
 }
 
 static void

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -2210,13 +2210,13 @@ cwmAnnounceGetTransferItem (BRCryptoWalletManager cwm,
                                  gasPrice,
                                  input,
                                  nonce,
-                                 gasUsed,
-                                 logIndex,
-                                 blockNumber,
                                  blockHash,
+                                 blockNumber,
                                  blockConfirmations,
                                  blockTransactionIndex,
                                  blockTimestamp,
+                                 gasUsed,
+                                 logIndex,
                                  error);
             break;
         }

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -2191,6 +2191,7 @@ cwmAnnounceGetTransferItem (BRCryptoWalletManager cwm,
             uint64_t gasUsed  = cwmParseUInt64 (cwmLookupAttributeValueForKey ("gasUsed",  attributesCount, attributeKeys, attributeVals), &error); // strtoull(strGasUsed, NULL, 0);
             UInt256  gasPrice = cwmParseUInt256(cwmLookupAttributeValueForKey ("gasPrice", attributesCount, attributeKeys, attributeVals), &error);
             uint64_t nonce    = cwmParseUInt64 (cwmLookupAttributeValueForKey ("nonce",    attributesCount, attributeKeys, attributeVals), &error);
+            const char *input = cwmLookupAttributeValueForKey ("input",    attributesCount, attributeKeys, attributeVals);
             size_t   logIndex = 0;
 
             error |= (CRYPTO_TRANSFER_STATE_ERRORED == status);
@@ -2204,9 +2205,10 @@ cwmAnnounceGetTransferItem (BRCryptoWalletManager cwm,
                                  to,
                                  contract,
                                  amount,
+                                 fee,
                                  gasLimit,
                                  gasPrice,
-                                 "",
+                                 input,
                                  nonce,
                                  gasUsed,
                                  logIndex,

--- a/WalletKitCore/src/ethereum/bcs/BREthereumBCS.h
+++ b/WalletKitCore/src/ethereum/bcs/BREthereumBCS.h
@@ -97,6 +97,15 @@ typedef void
                              OwnershipGiven BREthereumLog log);
 
 /**
+ *
+ **/
+typedef enum {
+    BCS_CALLBACK_EXCHANGE_ADDED,
+    BCS_CALLBACK_EXCHANGE_UPDATED,
+    BCS_CALLBACK_EXCHANGE_DELETED,
+} BREthereumBCSCallbackExchangeType;
+
+/**
  * Save Blocks
  */
 typedef void

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumLog.c
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumLog.c
@@ -277,8 +277,8 @@ logCompare (BREthereumLog l1,
 
     else
         return ETHEREUM_COMPARISON_EQ;
-
 }
+
 extern BREthereumTransactionStatus
 logGetStatus (BREthereumLog log) {
     return log->status;

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
@@ -98,6 +98,33 @@ transactionStatusEqual (BREthereumTransactionStatus ts1,
                                  0 == strcmp (ts1.u.errored.detail, ts2.u.errored.detail))));
 }
 
+extern BREthereumComparison
+transactionStatusCompare (const BREthereumTransactionStatus *ts1,
+                          const BREthereumTransactionStatus *ts2) {
+    int t1Blocked = ts1->type == TRANSACTION_STATUS_INCLUDED;
+    int t2Blocked = ts2->type == TRANSACTION_STATUS_INCLUDED;
+
+    if (t1Blocked && t2Blocked)
+        return (ts1->u.included.blockNumber < ts2->u.included.blockNumber
+                ? ETHEREUM_COMPARISON_LT
+                : (ts1->u.included.blockNumber > ts2->u.included.blockNumber
+                   ? ETHEREUM_COMPARISON_GT
+                   : (ts1->u.included.transactionIndex < ts2->u.included.transactionIndex
+                      ? ETHEREUM_COMPARISON_LT
+                      : (ts1->u.included.transactionIndex > ts2->u.included.transactionIndex
+                         ? ETHEREUM_COMPARISON_GT
+                         : ETHEREUM_COMPARISON_EQ))));
+
+    else if (!t1Blocked && t2Blocked)
+        return ETHEREUM_COMPARISON_GT;
+
+    else if (t1Blocked && !t2Blocked)
+        return ETHEREUM_COMPARISON_LT;
+
+    else
+        return ETHEREUM_COMPARISON_EQ;
+}
+
 extern BREthereumTransactionErrorType
 lookupTransactionErrorType (const char *reasons[],
                             const char *reason) {

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.h
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.h
@@ -132,6 +132,10 @@ extern BREthereumBoolean
 transactionStatusEqual (BREthereumTransactionStatus ts1,
                         BREthereumTransactionStatus ts2);
 
+extern BREthereumComparison
+transactionStatusCompare (const BREthereumTransactionStatus *ts1,
+                          const BREthereumTransactionStatus *ts2);
+
 extern BREthereumTransactionStatus
 transactionStatusRLPDecode (BRRlpItem item,
                             const char *reasons[],

--- a/WalletKitCore/src/ethereum/contract/BREthereumExchange.c
+++ b/WalletKitCore/src/ethereum/contract/BREthereumExchange.c
@@ -1,0 +1,279 @@
+//
+//  BREthereumExchange.c
+//  BRCore
+//
+//  Created by Ed Gamble on 6/9/20.
+//  Copyright © 2018-2019 Breadwinner AG.  All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#include "BREthereumExchange.h"
+
+struct BREthereumExchangeRecord {
+    // THIS MUST BE FIRST to support BRSet operations.
+
+     /**
+      * The hash - computed from the identifier pair {Transaction-Hash, Receipt-Index}
+      */
+     BREthereumHash hash;
+
+    BREthereumAddress source;
+    BREthereumAddress target;
+
+    BREthereumAddress contract;  //  EMPTY_ADDRESS_INIT if 'Eth'
+    size_t contractAssetIndex;
+
+    UInt256 assetValue;
+
+    /*
+     * A unique identifer - derived from the transactionHash and the transactionReceiptIndex
+     */
+    struct {
+        /**
+         * The hash of the transaction producing this log.  This value *does not* depend on
+         * which block records the Log.
+         */
+        BREthereumHash transactionHash;
+
+        /**
+         * The receipt index from the transaction's contract execution for this log.  It can't
+         * possibly be the case that this number varies, can it - contract execution, regarding
+         * event generating, must be deterministic?
+         */
+        size_t exchangeIndex;
+    } identifier;
+
+    /**
+     * status
+     */
+    BREthereumTransactionStatus status;
+};
+
+extern BREthereumExchange
+ethExchangeCreate (BREthereumAddress source,
+                   BREthereumAddress target,
+                   BREthereumAddress contract,  // NULL if 'Ether'
+                   size_t contractAssetIndex,
+                   UInt256 value) {
+    BREthereumExchange exchange = calloc (1, sizeof (struct BREthereumExchangeRecord));
+
+    exchange->hash = ethHashCreateEmpty();
+
+    exchange->source = source;
+    exchange->target = target;
+
+    exchange->contract = contract;
+    exchange->contractAssetIndex = contractAssetIndex;
+
+    exchange->assetValue = value;
+
+    exchange->identifier.exchangeIndex = EXCHANGE_INDEX_UNKNOWN;
+
+    return exchange;
+}
+
+
+extern void
+ethExchangeInitializeIdentifier (BREthereumExchange exchange,
+                                 BREthereumHash transactionHash,
+                                 size_t exchangeIndex) {
+    exchange->identifier.transactionHash = transactionHash;
+    exchange->identifier.exchangeIndex   = exchangeIndex;
+
+    BRRlpData data = { sizeof (exchange->identifier), (uint8_t*) &exchange->identifier };
+    exchange->hash = ethHashCreateFromData(data);
+}
+
+extern BREthereumBoolean
+ethExchangeExtractIdentifier (BREthereumExchange exchange,
+                              BREthereumHash *transactionHash,
+                              size_t *exchangeIndex) {
+    if (EXCHANGE_INDEX_UNKNOWN == exchange->identifier.exchangeIndex)
+        return ETHEREUM_BOOLEAN_FALSE;
+
+    if (NULL != transactionHash) *transactionHash = exchange->identifier.transactionHash;
+    if (NULL != exchangeIndex)   *exchangeIndex   = exchange->identifier.exchangeIndex;
+
+    return ETHEREUM_BOOLEAN_TRUE;
+}
+
+extern BREthereumHash
+ethExchangeGetHash (BREthereumExchange exchange) {
+    assert (EXCHANGE_INDEX_UNKNOWN != exchange->identifier.exchangeIndex);
+    return exchange->hash;
+}
+
+extern BREthereumAddress
+ethExchangeGetSourceAddress (BREthereumExchange exchange) {
+    return exchange->source;
+}
+
+extern BREthereumAddress
+ethExchangeGetTargetAddress (BREthereumExchange exchange) {
+    return exchange->target;
+}
+
+extern BREthereumAddress
+ethExchangeGetContract (BREthereumExchange exchange) {
+    return exchange->contract;
+}
+
+extern size_t
+ethExchangeGetContractAssetIndex (BREthereumExchange exchange) {
+    return exchange->contractAssetIndex;
+}
+
+extern UInt256
+ethExchangeGetAssetValue (BREthereumExchange exchange) {
+    return exchange->assetValue;
+}
+
+static inline int
+ethExchangeHasStatus (BREthereumExchange exchange,
+                      BREthereumTransactionStatusType type) {
+    return type == exchange->status.type;
+}
+
+extern BREthereumComparison
+ethExchangeCompare (BREthereumExchange l1,
+                    BREthereumExchange l2) {
+
+    if (  l1 == l2) return ETHEREUM_COMPARISON_EQ;
+    if (NULL == l2) return ETHEREUM_COMPARISON_LT;
+    if (NULL == l1) return ETHEREUM_COMPARISON_GT;
+
+    int t1Blocked = ethExchangeHasStatus(l1, TRANSACTION_STATUS_INCLUDED);
+    int t2Blocked = ethExchangeHasStatus(l2, TRANSACTION_STATUS_INCLUDED);
+
+    if (t1Blocked && t2Blocked)
+        return (l1->status.u.included.blockNumber < l2->status.u.included.blockNumber
+                ? ETHEREUM_COMPARISON_LT
+                : (l1->status.u.included.blockNumber > l2->status.u.included.blockNumber
+                   ? ETHEREUM_COMPARISON_GT
+                   : (l1->status.u.included.transactionIndex < l2->status.u.included.transactionIndex
+                      ? ETHEREUM_COMPARISON_LT
+                      : (l1->status.u.included.transactionIndex > l2->status.u.included.transactionIndex
+                         ? ETHEREUM_COMPARISON_GT
+                         : (l1->identifier.exchangeIndex < l2->identifier.exchangeIndex
+                            ? ETHEREUM_COMPARISON_LT
+                            : (l1->identifier.exchangeIndex > l2->identifier.exchangeIndex
+                               ? ETHEREUM_COMPARISON_GT
+                               : ETHEREUM_COMPARISON_EQ))))));
+
+    else if (!t1Blocked && t2Blocked)
+        return ETHEREUM_COMPARISON_GT;
+
+    else if (t1Blocked && !t2Blocked)
+        return ETHEREUM_COMPARISON_LT;
+
+    else
+        return ETHEREUM_COMPARISON_EQ;
+}
+
+extern BREthereumTransactionStatus
+ethExchangeGetStatus (BREthereumExchange exchange) {
+    return exchange->status;
+}
+
+extern void
+ethExchangeSetStatus (BREthereumExchange exchange,
+                      BREthereumTransactionStatus status) {
+    exchange->status = status;
+}
+
+extern BREthereumBoolean
+ethExchangeIsConfirmed (BREthereumExchange exchange) {
+    return AS_ETHEREUM_BOOLEAN(TRANSACTION_STATUS_INCLUDED == exchange->status.type);
+}
+
+extern BREthereumBoolean
+ethExchangeIsErrored (BREthereumExchange exchange) {
+    return AS_ETHEREUM_BOOLEAN(TRANSACTION_STATUS_ERRORED == exchange->status.type);
+}
+
+// Support BRSet
+extern size_t
+ethExchangeHashValue (const void *e) {
+    assert (EXCHANGE_INDEX_UNKNOWN != ((BREthereumExchange) e)->identifier.exchangeIndex);
+    return (size_t) ethHashSetValue(&((BREthereumExchange) e)->hash);
+}
+
+// Support BRSet
+extern int
+ethExchangeHashEqual (const void *l1, const void *l2) {
+    if (l1 == l2) return 1;
+
+    assert (EXCHANGE_INDEX_UNKNOWN != ((BREthereumExchange) l1)->identifier.exchangeIndex);
+    assert (EXCHANGE_INDEX_UNKNOWN != ((BREthereumExchange) l2)->identifier.exchangeIndex);
+    return ethHashSetEqual (&((BREthereumExchange) l1)->hash,
+                            &((BREthereumExchange) l2)->hash);
+
+}
+
+extern BREthereumExchange
+ethExchangeRlpDecode (BRRlpItem item,
+                      BREthereumRlpType type,
+                      BRRlpCoder coder) {
+    BREthereumExchange exchange = calloc (1, sizeof (struct BREthereumExchangeRecord));
+
+    size_t itemsCount = 0;
+    const BRRlpItem *items = rlpDecodeList(coder, item, &itemsCount);
+    assert ((5 == itemsCount && RLP_TYPE_NETWORK == type) ||
+            (8 == itemsCount && RLP_TYPE_ARCHIVE == type));
+
+    exchange->source   = ethAddressRlpDecode (items[0], coder);
+    exchange->target   = ethAddressRlpDecode (items[1], coder);
+    exchange->contract = ethAddressRlpDecode (items[2], coder);
+
+    exchange->contractAssetIndex = rlpDecodeUInt64  (coder, items[3], 0);
+    exchange->assetValue         = rlpDecodeUInt256 (coder, items[4], 0);
+
+    if (RLP_TYPE_ARCHIVE == type) {
+        BREthereumHash hash = ethHashRlpDecode(items[5], coder);
+        size_t exchangeIndex = rlpDecodeUInt64 (coder, items[6], 0);
+        ethExchangeInitializeIdentifier (exchange, hash, (size_t) exchangeIndex);
+
+        exchange->status = transactionStatusRLPDecode (items[7], NULL, coder);
+    }
+
+    return exchange;
+}
+/**
+ * [QUASI-INTERNAL - used by BREthereumBlock]
+ */
+extern BRRlpItem
+ethExchangeRlpEncode(BREthereumExchange exchange,
+                     BREthereumRlpType type,
+                     BRRlpCoder coder) {
+    BRRlpItem items[8]; // more than enough
+
+    items[0] = ethAddressRlpEncode (exchange->source,   coder);
+    items[1] = ethAddressRlpEncode (exchange->target,   coder);
+    items[2] = ethAddressRlpEncode (exchange->contract, coder);
+    items[3] = rlpEncodeUInt64  (coder, exchange->contractAssetIndex, 0);
+    items[4] = rlpEncodeUInt256 (coder, exchange->assetValue, 0);
+
+    if (RLP_TYPE_ARCHIVE == type) {
+        items[5] = ethHashRlpEncode(exchange->identifier.transactionHash, coder);
+        items[6] = rlpEncodeUInt64(coder, exchange->identifier.exchangeIndex, 0);
+        items[7] = transactionStatusRLPEncode(exchange->status, coder);
+    }
+
+    return rlpEncodeListItems(coder, items, (RLP_TYPE_ARCHIVE == type ? 8 : 5));
+}
+
+extern void
+ethExchangeRelease (BREthereumExchange exchange) {
+    if (NULL == exchange) return;
+    free (exchange);
+}
+
+extern BREthereumExchange
+ethExchangeCopy (BREthereumExchange exchange) {
+    BREthereumExchange copy = calloc (1, sizeof (struct BREthereumExchangeRecord));
+
+    memcpy (copy, exchange, sizeof(struct BREthereumExchangeRecord));
+    return copy;
+}
+

--- a/WalletKitCore/src/ethereum/contract/BREthereumExchange.h
+++ b/WalletKitCore/src/ethereum/contract/BREthereumExchange.h
@@ -1,0 +1,138 @@
+//
+//  BREthereumExchange.h
+//  BRCore
+//
+//  Created by Ed Gamble on 6/9/20.
+//  Copyright © 2018-2019 Breadwinner AG.  All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#ifndef BR_Ethereum_Exchange_h
+#define BR_Ethereum_Exchange_h
+
+#include "ethereum/base/BREthereumBase.h"
+#include "ethereum/blockchain/BREthereumTransactionStatus.h"
+#include "BREthereumContract.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * An Ethereum Exchange ...
+ *
+ */
+typedef struct BREthereumExchangeRecord *BREthereumExchange;
+
+extern BREthereumExchange
+ethExchangeCreate (BREthereumAddress source,
+                   BREthereumAddress target,
+                   BREthereumAddress contract,  // NULL if 'Ether'
+                   size_t contractdAssetIndex,
+                   UInt256 value);
+
+
+extern void
+ethExchangeInitializeIdentifier (BREthereumExchange exchange,
+                                 BREthereumHash transactionHash,
+                                 size_t exchangeIndex);
+
+/**
+ * An identifier for an unknown exchange index index.
+ */
+#define EXCHANGE_INDEX_UNKNOWN       (SIZE_MAX)
+
+/**
+ * Extract the log's identifier components.  A Log is identified by the transaction hash that
+ * originated the log and the index of the log in the block's transaction receipts array.
+ *
+ * If the log has not been recorded in a block, then FALSE is returned.  Otherwise TRUE is returned
+ * and `transactionHash` and `transacetionReceiptIndex` will be filled.
+ *
+ * @param log the log
+ * @param transactionHash a hash pointer; if non-NULL will be filled with the transaction's hash
+ * @param exchangeIndex an index pointer, if non-NULL will be filled with the logs
+ *    index in the block's transaction receipts array.
+ *
+ * @return TRUE if recorded in a block, FALSE otherwise.
+ */
+extern BREthereumBoolean
+ethExchangeExtractIdentifier (BREthereumExchange log,
+                              BREthereumHash *transactionHash,
+                              size_t *exchangeIndex);
+
+extern BREthereumHash
+ethExchangeGetHash (BREthereumExchange exchange);
+
+extern BREthereumAddress
+ethExchangeGetSourceAddress (BREthereumExchange exchange);
+
+extern BREthereumAddress
+ethExchangeGetTargetAddress (BREthereumExchange exchange);
+
+extern BREthereumAddress
+ethExchangeGetContract (BREthereumExchange exchange);
+
+extern size_t
+ethExchangeGetContractAssetIndex (BREthereumExchange exchange);
+
+extern UInt256
+ethExchangeGetAssetValue (BREthereumExchange exchange);
+
+extern BREthereumComparison
+ethExchangeCompare (BREthereumExchange e1,
+                    BREthereumExchange e2) ;
+
+extern BREthereumTransactionStatus
+ethExchangeGetStatus (BREthereumExchange exchange);
+
+extern void
+ethExchangeSetStatus (BREthereumExchange exchange,
+                      BREthereumTransactionStatus status);
+
+extern BREthereumBoolean
+ethExchangeIsConfirmed (BREthereumExchange exchange);
+
+extern BREthereumBoolean
+ethExchangeIsErrored (BREthereumExchange exchange);
+
+// Support BRSet
+extern size_t
+ethExchangeHashValue (const void *h);
+
+// Support BRSet
+extern int
+ethExchangeHashEqual (const void *h1, const void *h2);
+
+extern BREthereumExchange
+ethExchangeRlpDecode (BRRlpItem item,
+                      BREthereumRlpType type,
+                      BRRlpCoder coder);
+/**
+ * [QUASI-INTERNAL - used by BREthereumBlock]
+ */
+extern BRRlpItem
+ethExchangeRlpEncode(BREthereumExchange exchange,
+                     BREthereumRlpType type,
+                     BRRlpCoder coder);
+
+extern void
+ethExchangeRelease (BREthereumExchange exchange);
+
+extern BREthereumExchange
+ethExchangeCopy (BREthereumExchange exchange);
+
+#if 0
+extern void
+logsRelease (BRArrayOf(BREthereumLog) logs);
+
+extern void
+logReleaseForSet (void *ignore, void *item);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BR_Ethereum_Exchange_h */

--- a/WalletKitCore/src/ethereum/ewm/BREthereumClient.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumClient.h
@@ -209,6 +209,24 @@ extern "C" {
                             int id,
                             BREthereumBoolean success);
 
+    /// MARK: - Get Exchanges
+
+    extern BREthereumStatus
+    ewmAnnounceExchange (BREthereumEWM ewm,
+                         int id,
+                         const char *hash,
+                         const char *from,
+                         const char *to,
+                         const char *contract,
+                         UInt256  amount,
+                         UInt256  gasPrice,
+                         uint64_t gasUsed,
+                         uint64_t logIndex,
+                         uint64_t blockNumber,
+                         uint64_t blockTransactionIndex,
+                         uint64_t blockTimestamp);
+
+
     /// MARK: - Get Transfers
 
     extern BREthereumStatus
@@ -219,6 +237,7 @@ extern "C" {
                         const char *to,
                         const char *contract,
                         const char *amount, // value
+                        const char *fee,
                         uint64_t gasLimit,
                         UInt256 gasPrice,
                         const char *data,

--- a/WalletKitCore/src/ethereum/ewm/BREthereumClient.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumClient.h
@@ -150,27 +150,24 @@ extern "C" {
                                                int rid);
 
     extern BREthereumStatus
-    ewmAnnounceTransaction(BREthereumEWM ewm,
-                           int id,
-                           const char *hashString,
-                           const char *from,
-                           const char *to,
-                           const char *contract,
-                           UInt256 amount, // value
-                           uint64_t gasLimit,
-                           UInt256 gasPrice,
-                           const char *data,
-                           uint64_t nonce,
-                           uint64_t  gasUsed,
-                           uint64_t  blockNumber,
-                           const char *strBlockHash,
-                           uint64_t blockConfirmations,
-                           uint64_t blockTransactionIndex,
-                           uint64_t blockTimestamp,
-                           // cumulative gas used,
-                           // confirmations
-                           // txreceipt_status
-                           bool isError);
+    ewmAnnounceTransaction (BREthereumEWM ewm,
+                            int id,
+                            const char *hash,
+                            const char *from,
+                            const char *to,
+                            const char *contract,
+                            UInt256  amount, // value
+                            uint64_t gasLimit,
+                            UInt256  gasPrice,
+                            const char *data,
+                            const char *blockHash,
+                            uint64_t  blockNumber,
+                            uint64_t blockConfirmations,
+                            uint64_t blockTransactionIndex,
+                            uint64_t blockTimestamp,
+                            uint64_t  gasUsed,
+                            uint64_t nonce,
+                            bool isError);
 
     extern void
     ewmAnnounceTransactionComplete (BREthereumEWM ewm,
@@ -189,20 +186,20 @@ extern "C" {
                                        uint64_t endBlockNumber,
                                        int rid);
 
-    extern BREthereumStatus
-    ewmAnnounceLog (BREthereumEWM ewm,
-                    int id,
-                    const char *hash,
-                    const char *contract,
-                    size_t topicCount,
-                    const char **arrayTopics,
-                    const char *strData,
-                    UInt256  gasPrice,
-                    uint64_t gasUsed,
-                    uint64_t logIndex,
-                    uint64_t blockNumber,
-                    uint64_t blockTransactionIndex,
-                    uint64_t blockTimestamp);
+extern BREthereumStatus
+ewmAnnounceLog (BREthereumEWM ewm,
+                int id,
+                const char *hash,
+                const char *contract,
+                size_t topicsCount,
+                const char **arrayTopics,
+                UInt256 amount,
+                const char *blockHash,
+                uint64_t blockNumber,
+                uint64_t blockTransactionIndex,
+                uint64_t blockTimestamp,
+                uint64_t gasUsed,
+                uint64_t logIndex);
 
     extern void
     ewmAnnounceLogComplete (BREthereumEWM ewm,
@@ -219,37 +216,37 @@ extern "C" {
                          const char *to,
                          const char *contract,
                          UInt256  amount,
-                         UInt256  gasPrice,
-                         uint64_t gasUsed,
-                         uint64_t logIndex,
+                         const char *blockHash,
                          uint64_t blockNumber,
                          uint64_t blockTransactionIndex,
-                         uint64_t blockTimestamp);
+                         uint64_t blockTimestamp,
+                         uint64_t gasUsed,
+                         uint64_t exchangeIndex);
 
 
     /// MARK: - Get Transfers
 
     extern BREthereumStatus
-    ewmAnnounceTransfer(BREthereumEWM ewm,
-                        int id,
-                        const char *strHash,
-                        const char *from,
-                        const char *to,
-                        const char *contract,
-                        const char *amount, // value
-                        const char *fee,
-                        uint64_t gasLimit,
-                        UInt256 gasPrice,
-                        const char *data,
-                        uint64_t  nonce,
-                        uint64_t  gasUsed,
-                        uint64_t logIndex,
-                        uint64_t  blockNumber,
-                        const char *strBlockHash,
-                        uint64_t blockConfirmations,
-                        uint64_t blockTransactionIndex,
-                        uint64_t blockTimestamp,
-                        bool isError);
+    ewmAnnounceTransfer (BREthereumEWM ewm,
+                         int id,
+                         const char *hash,
+                         const char *from,
+                         const char *to,
+                         const char *contract,
+                         const char *amount, // value
+                         const char *fee,
+                         uint64_t gasLimit,
+                         UInt256  gasPrice,
+                         const char *data,
+                         uint64_t  nonce,
+                         const char *blockHash,
+                         uint64_t blockNumber,
+                         uint64_t blockConfirmations,
+                         uint64_t blockTransactionIndex,
+                         uint64_t blockTimestamp,
+                         uint64_t gasUsed,
+                         uint64_t logIndex,
+                         bool isError);
 
     /// MARK: - Get Tokens
 

--- a/WalletKitCore/src/ethereum/ewm/BREthereumEWM.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumEWM.h
@@ -295,7 +295,7 @@ ewmWalletCreateTransferToReplace(BREthereumEWM ewm,
                                  BREthereumBoolean updateGasLimit,
                                  BREthereumBoolean updateNonce);
 
-extern unsigned int
+extern uint64_t
 ewmWalletGetTransferNonce (BREthereumEWM ewm,
                            BREthereumWallet wallet);
 
@@ -321,7 +321,6 @@ ewmTransferGetIdentifier (BREthereumEWM ewm,
 extern BREthereumHash
 ewmTransferGetOriginatingTransactionHash (BREthereumEWM ewm,
                                           BREthereumTransfer transfer);
-
 
 extern BREthereumAmount
 ewmTransferGetAmount(BREthereumEWM ewm,

--- a/WalletKitCore/src/ethereum/ewm/BREthereumEWMClient.c
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumEWMClient.c
@@ -346,6 +346,8 @@ ewmHandleAnnounceNonce (BREthereumEWM ewm,
         // Only save the primaryWallet if the nonce has, in fact, changed.
         if (oldNonce != ethAccountGetAddressNonce (ewm->account, address))
             ewmHandleSaveWallet (ewm, ewmGetWallet(ewm), CLIENT_CHANGE_UPD);
+
+        eth_log ("EWM", "Nonce: %" PRIu64, newNonce);
     }
     pthread_mutex_unlock (&ewm->lock);
 }

--- a/WalletKitCore/src/ethereum/ewm/BREthereumEWMEvent.c
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumEWMEvent.c
@@ -270,6 +270,44 @@ ewmSignalLog (BREthereumEWM ewm,
 
 // ==============================================================================================
 //
+// Handle Exchange
+//
+typedef struct {
+    BREvent base;
+    BREthereumEWM ewm;
+    BREthereumBCSCallbackExchangeType type;
+    BREthereumExchange exchange;
+} BREthereumHandleExchangeEvent;
+
+static void
+ewmHandleExchangeEventDispatcher(BREventHandler ignore,
+                            BREthereumHandleExchangeEvent *event) {
+    ewmHandleExchange(event->ewm, event->type, event->exchange);
+}
+
+static void
+ewmHandleExchangeEventDestroyer (BREthereumHandleExchangeEvent *event) {
+    ethExchangeRelease(event->exchange);
+}
+
+BREventType handleExchangeEventType = {
+    "EWM: Handle Exchange Event",
+    sizeof (BREthereumHandleExchangeEvent),
+    (BREventDispatcher) ewmHandleExchangeEventDispatcher,
+    (BREventDestroyer) ewmHandleExchangeEventDestroyer
+};
+
+extern void
+ewmSignalExchange (BREthereumEWM ewm,
+              BREthereumBCSCallbackExchangeType type,
+              OwnershipGiven BREthereumExchange exchange) {
+    BREthereumHandleExchangeEvent event = { { NULL, &handleExchangeEventType }, ewm, type, exchange };
+    eventHandlerSignalEvent(ewm->handler, (BREvent*) &event);
+}
+
+
+// ==============================================================================================
+//
 // Handle SaveBlocks
 //
 typedef struct {
@@ -909,6 +947,43 @@ ewmSignalAnnounceLog (BREthereumEWM ewm,
 }
 
 //
+// Announce Exchange
+//
+typedef struct {
+    struct BREventRecord base;
+    BREthereumEWM ewm;
+    BREthereumEWMClientAnnounceExchangeBundle *bundle;
+    int rid;
+} BREthereumEWMClientAnnounceExchangeEvent;
+
+static void
+ewmSignalAnnounceExchangeDispatcher (BREventHandler ignore,
+                                     BREthereumEWMClientAnnounceExchangeEvent *event) {
+    ewmHandleAnnounceExchange(event->ewm, event->bundle, event->rid);
+}
+
+static void
+ewmSignalAnnounceExchangeDestroyer (BREthereumEWMClientAnnounceExchangeEvent *event) {
+    ewmClientAnnounceExchangeBundleRelease(event->bundle);
+}
+
+static BREventType ewmClientAnnounceExchangeEventType = {
+    "EWM: Client Announce Exchange Event",
+    sizeof (BREthereumEWMClientAnnounceExchangeEvent),
+    (BREventDispatcher) ewmSignalAnnounceExchangeDispatcher,
+    (BREventDestroyer) ewmSignalAnnounceExchangeDestroyer
+};
+
+extern void
+ewmSignalAnnounceExchange (BREthereumEWM ewm,
+                           BREthereumEWMClientAnnounceExchangeBundle *bundle,
+                           int rid) {
+    BREthereumEWMClientAnnounceExchangeEvent message =
+    { { NULL, &ewmClientAnnounceExchangeEventType}, ewm, bundle, rid};
+    eventHandlerSignalEvent (ewm->handler, (BREvent*) &message);
+}
+
+//
 // Announce {Transaction, Log} Complete
 //
 typedef struct {
@@ -1021,6 +1096,7 @@ const BREventType *ewmEventTypes[] = {
     &handleGasEstimateEventType,
     &handleTransactionEventType,
     &handleLogEventType,
+    &handleExchangeEventType,
     &handleSaveBlocksEventType,
     &handleSaveNodesEventType,
     &handleSyncEventType,
@@ -1040,6 +1116,7 @@ const BREventType *ewmEventTypes[] = {
     &ewmClientAnnounceSubmitTransferEventType,
     &ewmClientAnnounceTransactionEventType,
     &ewmClientAnnounceLogEventType,
+    &ewmClientAnnounceExchangeEventType,
     &ewmClientAnnounceCompleteEventType,
     &ewmClientAnnounceTokenEventType,
     &ewmClientAnnounceTokenCompleteEventType,

--- a/WalletKitCore/src/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumEWMPrivate.h
@@ -274,6 +274,22 @@ ewmSignalLog (BREthereumEWM ewm,
               OwnershipGiven BREthereumLog log);
 
 //
+// Signal/Handle Exchange (x-BCS Callback)
+//
+// See the comments for ewm{Handle,Signal}Transaction() above
+//
+extern void
+ewmHandleExchange (BREthereumEWM ewm,
+                   BREthereumBCSCallbackExchangeType type,
+                   OwnershipGiven BREthereumExchange exchange);
+
+extern void
+ewmSignalExchange (BREthereumEWM ewm,
+                   BREthereumBCSCallbackExchangeType type,
+                   OwnershipGiven BREthereumExchange exchange);
+
+
+//
 // Signal/Handle Save Blocks (BCS Callback)
 //
 extern void
@@ -475,13 +491,47 @@ ewmClientAnnounceLogBundleRelease (BREthereumEWMClientAnnounceLogBundle *bundle)
 
 extern void
 ewmSignalAnnounceLog (BREthereumEWM ewm,
-                            BREthereumEWMClientAnnounceLogBundle *bundle,
-                            int id);
+                      BREthereumEWMClientAnnounceLogBundle *bundle,
+                      int id);
 
 extern void
 ewmHandleAnnounceLog (BREthereumEWM ewm,
-                            BREthereumEWMClientAnnounceLogBundle *bundle,
-                            int id);
+                      BREthereumEWMClientAnnounceLogBundle *bundle,
+                      int id);
+
+/// MARK: - Exchanges
+
+typedef struct {
+    BREthereumHash hash;
+    BREthereumAddress from;
+    BREthereumAddress to;
+    BREthereumAddress contract;
+    UInt256  amount;
+    uint64_t gasLimit;
+    UInt256 gasPrice;
+    uint64_t gasUsed;
+    uint64_t blockNumber;
+    BREthereumHash blockHash;
+    uint64_t blockConfirmations;
+    uint64_t blockTransactionIndex;
+    uint64_t blockTimestamp;
+    BREthereumBoolean isError;
+} BREthereumEWMClientAnnounceExchangeBundle;
+
+static inline void
+ewmClientAnnounceExchangeBundleRelease (BREthereumEWMClientAnnounceExchangeBundle *bundle) {
+    free (bundle);
+}
+
+extern void
+ewmSignalAnnounceExchange (BREthereumEWM ewm,
+                           BREthereumEWMClientAnnounceExchangeBundle *bundle,
+                           int id);
+
+extern void
+ewmHandleAnnounceExchange (BREthereumEWM ewm,
+                           BREthereumEWMClientAnnounceExchangeBundle *bundle,
+                           int id);
 
 /// MARK: - Account Complete
 

--- a/WalletKitCore/src/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumEWMPrivate.h
@@ -471,13 +471,15 @@ typedef struct {
     BREthereumAddress contract;
     size_t topicCount;
     char **arrayTopics;
-    char *data;
-    UInt256 gasPrice;
-    uint64_t gasUsed;
-    uint64_t logIndex;
+    UInt256 value;
+
+    BREthereumHash blockHash;
     uint64_t blockNumber;
     uint64_t blockTransactionIndex;
     uint64_t blockTimestamp;
+    uint64_t gasUsed;
+
+    uint64_t logIndex;
 } BREthereumEWMClientAnnounceLogBundle;
 
 static inline void
@@ -485,7 +487,7 @@ ewmClientAnnounceLogBundleRelease (BREthereumEWMClientAnnounceLogBundle *bundle)
     for (int i = 0; i < bundle->topicCount; i++)
         free (bundle->arrayTopics[i]);
     free (bundle->arrayTopics);
-    free (bundle->data);
+//    free (bundle->data);
     free (bundle);
 }
 
@@ -507,15 +509,12 @@ typedef struct {
     BREthereumAddress to;
     BREthereumAddress contract;
     UInt256  amount;
-    uint64_t gasLimit;
-    UInt256 gasPrice;
-    uint64_t gasUsed;
-    uint64_t blockNumber;
     BREthereumHash blockHash;
-    uint64_t blockConfirmations;
+    uint64_t blockNumber;
     uint64_t blockTransactionIndex;
     uint64_t blockTimestamp;
-    BREthereumBoolean isError;
+    uint64_t gasUsed;
+    uint64_t exchangeIndex;
 } BREthereumEWMClientAnnounceExchangeBundle;
 
 static inline void

--- a/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.c
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.c
@@ -459,6 +459,13 @@ transferGetBasisLog (BREthereumTransfer transfer) {
             : NULL);
 }
 
+extern BREthereumExchange
+transferGetBasisExchange (BREthereumTransfer transfer) {
+    return (TRANSFER_BASIS_EXCHANGE == transfer->basis.type
+            ? transfer->basis.u.exchange
+            : NULL);
+}
+
 extern void
 transferSign (BREthereumTransfer transfer,
               BREthereumNetwork network,

--- a/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.c
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.c
@@ -67,6 +67,7 @@ typedef struct {
     union {
         BREthereumTransaction transaction;
         BREthereumLog log;
+        BREthereumExchange exchange;
     } u;
 } BREthereumTransferBasis;
 
@@ -81,6 +82,11 @@ transferBasisRelease (BREthereumTransferBasis *basis) {
         case TRANSFER_BASIS_LOG:
             logRelease (basis->u.log);
             basis->u.log = NULL;
+            break;
+
+        case TRANSFER_BASIS_EXCHANGE:
+            ethExchangeRelease (basis->u.exchange);
+            basis->u.exchange = NULL;
             break;
     }
 }
@@ -99,6 +105,14 @@ transferBasisGetHash (BREthereumTransferBasis *basis) {
 
             BREthereumHash hash = EMPTY_HASH_INIT;
             logExtractIdentifier(basis->u.log, &hash, NULL);
+            return hash;
+        }
+
+        case TRANSFER_BASIS_EXCHANGE: {
+            if (NULL == basis->u.exchange) return EMPTY_HASH_INIT;
+
+            BREthereumHash hash = EMPTY_HASH_INIT;
+            ethExchangeExtractIdentifier (basis->u.exchange, &hash, NULL);
             return hash;
         }
     }
@@ -334,6 +348,39 @@ transferCreateWithLog (OwnershipGiven BREthereumLog log,
     return transfer;
 }
 
+extern BREthereumTransfer
+transferCreateWithExchange (OwnershipGiven BREthereumExchange exchange,
+                            BRSetOf (BREthereumToken) tokens) {
+    BREthereumFeeBasis feeBasis = {
+         FEE_BASIS_NONE
+     };
+
+    BREthereumAddress address = ethExchangeGetContract (exchange);
+    BREthereumToken   token  = BRSetGet (tokens, &address);
+
+    UInt256          value  = ethExchangeGetAssetValue (exchange);
+    BREthereumAmount amount = (NULL == token
+                               ? ethAmountCreateEther (ethEtherCreate (value))
+                               : ethAmountCreateToken (ethTokenQuantityCreate(token, value)));
+
+    // No originating transaction
+    BREthereumTransfer transfer = transferCreateDetailed (ethExchangeGetSourceAddress (exchange),
+                                                          ethExchangeGetTargetAddress (exchange),
+                                                          amount,
+                                                          feeBasis,
+                                                          NULL);
+    // Basis - the transfer now owns the log
+    transfer->basis = (BREthereumTransferBasis) {
+        TRANSFER_BASIS_EXCHANGE,
+        { .exchange = exchange }
+    };
+
+    // Status
+    transfer->status = transferStatusCreate(ethExchangeGetStatus(exchange));
+
+    return transfer;
+}
+
 extern void
 transferRelease (BREthereumTransfer transfer) {
     transactionRelease (transfer->originatingTransaction);
@@ -517,6 +564,8 @@ transferGetIdentifier (BREthereumTransfer transfer) {
             return (NULL == transfer->basis.u.transaction ? EMPTY_HASH_INIT : transactionGetHash(transfer->basis.u.transaction));
         case TRANSFER_BASIS_LOG:
             return (NULL == transfer->basis.u.log ? EMPTY_HASH_INIT : logGetHash(transfer->basis.u.log));
+        case TRANSFER_BASIS_EXCHANGE:
+            return (NULL == transfer->basis.u.exchange ? EMPTY_HASH_INIT : ethExchangeGetHash (transfer->basis.u.exchange));
     }
 }
 
@@ -594,6 +643,23 @@ transferSetBasisForLog (BREthereumTransfer transfer,
     transfer->status = transferStatusCreate (logGetStatus(log));
 }
 
+extern void
+transferSetBasisForExchange (BREthereumTransfer transfer,
+                             OwnershipGiven BREthereumExchange exchange) {
+    assert (TRANSFER_BASIS_EXCHANGE == transfer->basis.type);
+    assert (NULL != exchange);
+
+    if (transfer->basis.u.exchange != exchange)
+        transferBasisRelease (&transfer->basis);
+
+    transfer->basis = (BREthereumTransferBasis) {
+        TRANSFER_BASIS_EXCHANGE,
+        { .exchange = exchange}
+    };
+
+    transfer->status = transferStatusCreate (ethExchangeGetStatus (exchange));
+}
+
 /// MARK: - Status
 
 extern BREthereumTransactionStatus
@@ -609,6 +675,12 @@ transferGetStatusForBasis (BREthereumTransfer transfer) {
             assert (NULL != transfer->basis.u.log || NULL != transfer->originatingTransaction);
             return (NULL != transfer->basis.u.log
                     ? logGetStatus (transfer->basis.u.log)
+                    : transactionGetStatus (transfer->originatingTransaction));
+
+        case TRANSFER_BASIS_EXCHANGE:
+            assert (NULL != transfer->basis.u.exchange || NULL != transfer->originatingTransaction);
+            return (NULL != transfer->basis.u.exchange
+                    ? ethExchangeGetStatus (transfer->basis.u.exchange)
                     : transactionGetStatus (transfer->originatingTransaction));
     }
 }
@@ -751,6 +823,14 @@ transferProvideOriginatingTransaction (BREthereumTransfer transfer) {
 private_extern BREthereumEther
 transferGetEffectiveAmountInEther(BREthereumTransfer transfer) {
     switch (transfer->basis.type) {
+        case TRANSFER_BASIS_EXCHANGE:
+            if (NULL == transfer->basis.u.exchange) return ethEtherCreateZero();
+            else {
+                BREthereumAddress contract = ethExchangeGetContract (transfer->basis.u.exchange);
+                return (ETHEREUM_BOOLEAN_IS_TRUE (ethAddressEqual (EMPTY_ADDRESS_INIT, contract))
+                        ? ethEtherCreate (ethExchangeGetAssetValue (transfer->basis.u.exchange))
+                        : ethEtherCreateZero());
+            }
         case TRANSFER_BASIS_LOG:
             return ethEtherCreateZero();
         case TRANSFER_BASIS_TRANSACTION:
@@ -779,6 +859,8 @@ transferCompare (BREthereumTransfer t1,
             return transactionCompare (t1->basis.u.transaction, t2->basis.u.transaction);
         case TRANSFER_BASIS_LOG:
             return logCompare (t1->basis.u.log, t2->basis.u.log);
+        case TRANSFER_BASIS_EXCHANGE:
+            return ethExchangeCompare (t1->basis.u.exchange, t2->basis.u.exchange);
     }
 }
 

--- a/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.h
@@ -15,6 +15,7 @@
 #include "ethereum/blockchain/BREthereumNetwork.h"
 #include "ethereum/blockchain/BREthereumTransaction.h"
 #include "ethereum/blockchain/BREthereumLog.h"
+#include "ethereum/contract/BREthereumExchange.h"
 #include "BREthereumBase.h"
 #include "BREthereumAmount.h"
 #include "BREthereumAccount.h"
@@ -27,7 +28,8 @@ extern "C" {
 
 typedef enum  {
     TRANSFER_BASIS_TRANSACTION,
-    TRANSFER_BASIS_LOG
+    TRANSFER_BASIS_LOG,
+    TRANSFER_BASIS_EXCHANGE
 } BREthereumTransferBasisType;
 
 /**
@@ -59,6 +61,10 @@ extern BREthereumTransfer
 transferCreateWithLog (OwnershipGiven BREthereumLog log,
                        BREthereumToken token,
                        BRRlpCoder coder);           // For decoding log->data into UInt256
+
+extern BREthereumTransfer
+transferCreateWithExchange (OwnershipGiven BREthereumExchange exchange,
+                            BRSetOf (BREthereumToken) tokens);
 
 extern void
 transferRelease (BREthereumTransfer transfer);
@@ -172,6 +178,10 @@ transferSetBasisForTransaction (BREthereumTransfer transfer,
 extern void
 transferSetBasisForLog (BREthereumTransfer transfer,
                         OwnershipGiven BREthereumLog log);
+
+extern void
+transferSetBasisForExchange (BREthereumTransfer transfer,
+                             OwnershipGiven BREthereumExchange exchange);
 
 //
 //

--- a/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumTransfer.h
@@ -101,6 +101,9 @@ transferGetBasisTransaction (BREthereumTransfer transfer);
 extern BREthereumLog
 transferGetBasisLog (BREthereumTransfer transfer);
 
+extern BREthereumExchange
+transferGetBasisExchange (BREthereumTransfer transfer);
+
 extern void
 transferSign (BREthereumTransfer transfer,
               BREthereumNetwork network,

--- a/WalletKitCore/src/ethereum/ewm/BREthereumWallet.c
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumWallet.c
@@ -583,7 +583,7 @@ walletGetTransferCount (BREthereumWallet wallet) {
     return array_count(wallet->transfers);
 }
 
-extern unsigned int
+extern uint64_t
 walletGetTransferCountAsSource (BREthereumWallet wallet) {
     unsigned int count = 0;
 
@@ -594,9 +594,9 @@ walletGetTransferCountAsSource (BREthereumWallet wallet) {
     return count;
 }
 
-extern unsigned int
+extern uint64_t
 walletGetTransferNonceMaximumAsSource (BREthereumWallet wallet) {
-    unsigned int nonce = 0;
+    uint64_t nonce = TRANSACTION_NONCE_IS_NOT_ASSIGNED;
 
 #define MAX(x,y)    ((x) >= (y) ? (x) : (y))
     for (int i = 0; i < array_count(wallet->transfers); i++)
@@ -604,7 +604,8 @@ walletGetTransferNonceMaximumAsSource (BREthereumWallet wallet) {
             uint64_t newNonce = (unsigned int) transferGetNonce(wallet->transfers[i]);
             // wallet->transfers can have a newly created transfer that does not yet have
             // an assigned nonce - avoid such a transfer.
-            if (TRANSACTION_NONCE_IS_NOT_ASSIGNED != newNonce && newNonce > nonce)
+            if ( TRANSACTION_NONCE_IS_NOT_ASSIGNED != newNonce  &&
+                (TRANSACTION_NONCE_IS_NOT_ASSIGNED == nonce     || newNonce > nonce))
                 nonce = (unsigned int) newNonce;
         }
 #undef MAX

--- a/WalletKitCore/src/ethereum/ewm/BREthereumWallet.h
+++ b/WalletKitCore/src/ethereum/ewm/BREthereumWallet.h
@@ -230,10 +230,10 @@ walletGetTransferByIndex(BREthereumWallet wallet,
 extern unsigned long
 walletGetTransferCount (BREthereumWallet wallet);
 
-extern unsigned int
+extern uint64_t
 walletGetTransferCountAsSource (BREthereumWallet wallet);
 
-extern unsigned int
+extern uint64_t
 walletGetTransferNonceMaximumAsSource (BREthereumWallet wallet);
 
 //

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -1948,7 +1948,8 @@ final class System implements com.breadwallet.crypto.System {
             com.breadwallet.crypto.blockchaindb.models.bdb.Transfer transferMatchingFee = null;
             for (com.breadwallet.crypto.blockchaindb.models.bdb.Transfer transfer: transfersWithoutFee) {
                 if (transferWithFee.getTransactionId().equals(transfer.getTransactionId()) &&
-                    transferWithFee.getFromAddress().equals(transfer.getFromAddress())) {
+                    transferWithFee.getFromAddress().equals(transfer.getFromAddress()) &&
+                    transferWithFee.getAmount().getCurrencyId().equals(transfer.getAmount().getCurrencyId())) {
                     transferMatchingFee = transfer;
                     break;
                 }

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1328,11 +1328,12 @@ extension System {
                 // We may or may not have a non-fee transfer matching `transferWithFee`.  We
                 // may or may not have more than one non-fee transfers matching `transferWithFee`
 
-                // Find the first of the non-fee transfers matching `transferWithFee`
+                // Find the first of the non-fee transfers matching `transferWithFee`.
                 let transferMatchingFee = transfers[partition...]
                     .first {
                         $0.transactionId == transferWithFee.transactionId &&
-                            $0.source == transferWithFee.source
+                            $0.source == transferWithFee.source &&
+                            $0.amount.currency == transferWithFee.amount.currency
                 }
 
                 // We must have a transferMatchingFee; if we don't add one
@@ -1462,10 +1463,10 @@ extension System {
                                                             let blockHash             = transaction.blockHash
                                                             let status    = System.getTransferStatus (transaction.status)
 
-
                                                             System.mergeTransfers (transaction, with: addresses)
                                                                 .forEach { (arg: (transfer: BlockChainDB.Model.Transfer, fee: BlockChainDB.Model.Amount?)) in
                                                                     let (transfer, fee) = arg
+                                                                    precondition (fee.map { $0.currency == transfer.amount.currency } ?? true)
 
                                                                     let metaData = (transaction.metaData ?? [:]).merging (transfer.metaData ?? [:]) { (cur, new) in new }
 


### PR DESCRIPTION
This started as 'get the account nonce correct'... and morphed into 'handle internal transactions'

This involved adding `BREthereumExchange`, an analog to `BREtheremLog`, which represents an arbitrary exchange of an asset that in not a) ETH in a transaction nor b) a known ERC20 token transfer via a LogEvent.

The asset for a `BREthereumExchange' can be either ETH or TOK.  The exchange becomes the basis for a BRCryptoTransfer and thus a wallet could hold transfers with a basis of: Transaction and/or Exchange or Log and/or Exchange.

Rewrite BREthereumTransaction to handle an exchange?  Can't because a transaction has a nonce and an exchange cannot result in a nonce increment.

Rewrite BREtheremLog to handle an exchange?  BREthereumLog is a concept handled in the P2P Light Client - with a structure based on LogTopics (ERC20 'transfer' function, etc).  An exchange has none of that.