### PR TITLE
CORE-933: Add support for Bitcoin SV

### DIFF
--- a/WalletKitCore/CMakeLists.txt
+++ b/WalletKitCore/CMakeLists.txt
@@ -147,7 +147,12 @@ target_sources (corecrypto
                 ${PROJECT_SOURCE_DIR}/src/bcash/BRBCashAddr.h
                 ${PROJECT_SOURCE_DIR}/src/bcash/BRBCashParams.h
                 ${PROJECT_SOURCE_DIR}/src/bcash/BRBCashParams.c)
-
+# BSV
+target_sources (corecrypto
+                PRIVATE
+                ${PROJECT_SOURCE_DIR}/src/bsv/BRBSVParams.h
+                ${PROJECT_SOURCE_DIR}/src/bsv/BRBSVParams.c)
+                
 # Ethereum
 target_sources (corecrypto
                 PRIVATE

--- a/WalletKitCore/WalletKitCoreTests/WalletKitCoreTests.swift
+++ b/WalletKitCore/WalletKitCoreTests/WalletKitCoreTests.swift
@@ -26,7 +26,7 @@ final class WalletKitCoreTests: XCTestCase {
     var paperKey: String! = nil
     var isMainnet = true
     var uids: String = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96"
-    var isBTC: Int32! = 1 // or is BCH
+    var bitcoinChain: BRBitcoinChain = BITCOIN_CHAIN_BTC
 
     var accountSpecifications: [AccountSpecification] = []
      var accountSpecification: AccountSpecification! {
@@ -116,6 +116,22 @@ final class WalletKitCoreTests: XCTestCase {
             storagePathClear();
 
             let network = createBitcoinCashNetwork (isMainnet: isMainnet, blockHeight: blockHeight)
+            defer { cryptoNetworkGive (network) }
+
+            let success = runCryptoTestsWithAccountAndNetwork (account, network, storagePath)
+            XCTAssertEqual(CRYPTO_TRUE, success)
+        }
+    }
+    
+    func testCryptoWithAccountAndNetworkBSV() {
+        let account = cryptoAccountCreate(paperKey, 0, uids)
+        defer { cryptoAccountGive (account) }
+
+        let configurations: [(Bool, UInt64)] = [(true, 500_000), (false, 1_500_000),]
+        configurations.forEach { (isMainnet, blockHeight) in
+            storagePathClear();
+
+            let network = createBitcoinSVNetwork (isMainnet: isMainnet, blockHeight: blockHeight)
             defer { cryptoNetworkGive (network) }
 
             let success = runCryptoTestsWithAccountAndNetwork (account, network, storagePath)
@@ -216,11 +232,11 @@ final class WalletKitCoreTests: XCTestCase {
 
     func testBitcoin () {
         XCTAssert(1 == BRRunTests())
-        XCTAssert(1 == BRRunTestsBWM (paperKey, storagePath, isBTC, (isMainnet ? 1 : 0)));
+        XCTAssert(1 == BRRunTestsBWM (paperKey, storagePath, bitcoinChain, (isMainnet ? 1 : 0)));
     }
 
     func testBitcoinSyncOne() {
-        BRRunTestsSync (paperKey, isBTC, (isMainnet ? 1 : 0));
+        BRRunTestsSync (paperKey, bitcoinChain, (isMainnet ? 1 : 0));
     }
 
     func runBitcoinSyncMany (_ count: Int) {
@@ -230,7 +246,7 @@ final class WalletKitCoreTests: XCTestCase {
                 .async {
                     group.enter()
                     let paperKey = i <= self.accountSpecifications.count ? self.accountSpecifications[i - 1].paperKey : nil
-                    BRRunTestsSync (paperKey, self.isBTC, (self.isMainnet ? 1 : 0));
+                    BRRunTestsSync (paperKey, self.bitcoinChain, (self.isMainnet ? 1 : 0));
                     group.leave()
             }
         }
@@ -243,9 +259,9 @@ final class WalletKitCoreTests: XCTestCase {
     }
 
     func XtestBitcoinSyncAll () {
-        for useBTC in [false, true] {
+        for chain in [BITCOIN_CHAIN_BTC, BITCOIN_CHAIN_BCH, BITCOIN_CHAIN_BSV] {
             for useMainnet in [false, true] {
-                self.isBTC = useBTC ? 1 : 0
+                self.bitcoinChain = chain
                 self.isMainnet = useMainnet
                 runBitcoinSyncMany (10)
             }
@@ -259,15 +275,15 @@ final class WalletKitCoreTests: XCTestCase {
     func testBitcoinWalletManagerSync () {
         print ("BTC: TST: Core Dir: \(storagePath!)")
         storagePathClear()
-        BRRunTestWalletManagerSync (paperKey, storagePath, isBTC, (isMainnet ? 1 : 0));
-        BRRunTestWalletManagerSync (paperKey, storagePath, isBTC, (isMainnet ? 1 : 0));
+        BRRunTestWalletManagerSync (paperKey, storagePath, bitcoinChain, (isMainnet ? 1 : 0));
+        BRRunTestWalletManagerSync (paperKey, storagePath, bitcoinChain, (isMainnet ? 1 : 0));
     }
 
     func XtestBitcoinWalletManagerSyncStressBTC() {
         let configurations: [(Int32, UInt64)] = [(1, 500_000), (0, 1_500_000),]
         configurations.forEach { (isMainnet, blockHeight) in
             storagePathClear();
-            let success = BRRunTestWalletManagerSyncStress(paperKey, storagePath, 0, blockHeight, 1, isMainnet);
+            let success = BRRunTestWalletManagerSyncStress(paperKey, storagePath, 0, blockHeight, BITCOIN_CHAIN_BTC, isMainnet);
             XCTAssertEqual(1, success)
         }
     }
@@ -276,7 +292,16 @@ final class WalletKitCoreTests: XCTestCase {
         let configurations: [(Int32, UInt64)] = [(1, 500_000), (0, 1_500_000),]
         configurations.forEach { (isMainnet, blockHeight) in
             storagePathClear();
-            let success = BRRunTestWalletManagerSyncStress(paperKey, storagePath, 0, blockHeight, 0, isMainnet);
+            let success = BRRunTestWalletManagerSyncStress(paperKey, storagePath, 0, blockHeight, BITCOIN_CHAIN_BCH, isMainnet);
+            XCTAssertEqual(1, success)
+        }
+    }
+    
+    func XtestBitcoinWalletManagerSyncStressBSV() {
+        let configurations: [(Int32, UInt64)] = [(1, 500_000), (0, 1_500_000),]
+        configurations.forEach { (isMainnet, blockHeight) in
+            storagePathClear();
+            let success = BRRunTestWalletManagerSyncStress(paperKey, storagePath, 0, blockHeight, BITCOIN_CHAIN_BSV, isMainnet);
             XCTAssertEqual(1, success)
         }
     }
@@ -333,6 +358,39 @@ final class WalletKitCoreTests: XCTestCase {
         defer { cryptoUnitGive (satUnit) }
 
         let btcUnit = cryptoUnitCreate (currency, "btc", "bitcoin", "B", satUnit, 8)
+        defer { cryptoUnitGive (btcUnit) }
+
+        let factor = cryptoAmountCreateInteger (1_000, satUnit)
+        defer { cryptoAmountGive (factor) }
+
+        let fee = cryptoNetworkFeeCreate (30_000, factor, satUnit)
+        defer { cryptoNetworkFeeGive (fee) }
+
+        cryptoNetworkSetHeight (network, blockHeight)
+
+        cryptoNetworkSetCurrency (network, currency)
+        cryptoNetworkAddCurrency (network, currency, satUnit, btcUnit)
+
+        cryptoNetworkAddCurrencyUnit(network, currency, satUnit)
+        cryptoNetworkAddCurrencyUnit(network, currency, btcUnit)
+
+        cryptoNetworkAddNetworkFee(network, fee)
+
+        return cryptoNetworkTake (network)
+    }
+    
+    private func createBitcoinSVNetwork(isMainnet: Bool, blockHeight: UInt64) -> BRCryptoNetwork {
+        let uids = "bitcoinsv-" + (isMainnet ? "mainnet" : "testnet")
+        let network = cryptoNetworkFindBuiltin(uids);
+        defer { cryptoNetworkGive (network) }
+
+        let currency = cryptoCurrencyCreate ("bitcoin-sv", "bitcoin sv", "bsv", "native", nil)
+        defer { cryptoCurrencyGive (currency) }
+
+        let satUnit = cryptoUnitCreateAsBase (currency, "sat", "satoshis", "SAT")
+        defer { cryptoUnitGive (satUnit) }
+
+        let btcUnit = cryptoUnitCreate (currency, "bsv", "bitcoinsv", "B", satUnit, 8)
         defer { cryptoUnitGive (btcUnit) }
 
         let factor = cryptoAmountCreateInteger (1_000, satUnit)

--- a/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
+++ b/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
@@ -37,6 +37,8 @@
 #include "bcash/BRBCashParams.h"
 #include "bcash/BRBCashAddr.h"
 
+#include "bsv/BRBSVParams.h"
+
 #include "bitcoin/BRBloomFilter.h"
 #include "bitcoin/BRMerkleBlock.h"
 #include "bitcoin/BRWallet.h"
@@ -47,6 +49,8 @@
 #include "bitcoin/BRPaymentProtocol.h"
 #include "bitcoin/BRTransaction.h"
 #include "bitcoin/BRWalletManager.h"
+
+#include "test.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,6 +71,40 @@
 #define _va_first(first, ...) first
 #define _va_rest(first, ...) __VA_ARGS__
 #endif
+
+extern const BRChainParams* getChainParams (BRBitcoinChain chain, int isMainnet) {
+    switch (chain) {
+        case BITCOIN_CHAIN_BTC:
+            return isMainnet ? BRMainNetParams : BRTestNetParams;
+            
+        case BITCOIN_CHAIN_BCH:
+            return isMainnet ? BRBCashParams : BRBCashTestNetParams;
+            
+        case BITCOIN_CHAIN_BSV:
+            return isMainnet ? BRBSVParams : BRBSVTestNetParams;
+            
+        default:
+            assert(0);
+            return NULL;
+    }
+}
+
+extern const char * getChainName (BRBitcoinChain chain) {
+    switch (chain) {
+        case BITCOIN_CHAIN_BTC:
+            return "btc";
+            
+        case BITCOIN_CHAIN_BCH:
+            return "bch";
+            
+        case BITCOIN_CHAIN_BSV:
+            return "bsv";
+            
+        default:
+            assert(0);
+            return NULL;
+    }
+}
 
 int BRIntsTests()
 {
@@ -3305,11 +3343,9 @@ static void testSyncSaveBlocks (void *c, int replace, BRMerkleBlock *blocks[], s
 }
 
 extern int BRRunTestsSync (const char *paperKey,
-                           int isBTC,
+                           BRBitcoinChain bitcoinChain,
                            int isMainnet) {
-    const BRChainParams *params = (isBTC & isMainnet ? BRMainNetParams
-                                   : (isBTC & !isMainnet ? BRTestNetParams
-                                      : (isMainnet ? BRBCashParams : BRBCashTestNetParams)));
+    const BRChainParams *params = getChainParams(bitcoinChain, isMainnet);
 
     uint32_t epoch;
     int needPaperKey = NULL == paperKey;

--- a/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
+++ b/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
@@ -1579,6 +1579,8 @@ runCryptoTestsWithAccountAndNetwork (BRCryptoAccount account,
                              && (cryptoNetworkAsBTC (network) == BRMainNetParams || cryptoNetworkAsBTC (network) == BRTestNetParams));
     BRCryptoBoolean isBch = (AS_CRYPTO_BOOLEAN (BLOCK_CHAIN_TYPE_BTC == chainType)
                              && (cryptoNetworkAsBTC (network) == BRBCashParams || cryptoNetworkAsBTC (network) == BRBCashTestNetParams));
+    BRCryptoBoolean isBsv = (AS_CRYPTO_BOOLEAN (BLOCK_CHAIN_TYPE_BTC == chainType)
+                             && (cryptoNetworkAsBTC (network) == BRBSVParams || cryptoNetworkAsBTC (network) == BRBSVTestNetParams));
 
     BRCryptoAddressScheme scheme = ((isBtc || isBch) ?
                                     CRYPTO_ADDRESS_SCHEME_BTC_LEGACY :
@@ -1598,7 +1600,7 @@ runCryptoTestsWithAccountAndNetwork (BRCryptoAccount account,
         }
     }
 
-    if (isBtc || isBch || isEth) {
+    if (isBtc || isBch || isBsv || isEth) {
         success = AS_CRYPTO_BOOLEAN(runCryptoWalletManagerLifecycleTest (account,
                                                                          network,
                                                                          CRYPTO_SYNC_MODE_P2P_ONLY,

--- a/WalletKitCore/WalletKitCoreTests/test/include/test.h
+++ b/WalletKitCore/WalletKitCoreTests/test/include/test.h
@@ -16,6 +16,7 @@
 #include "BRCryptoSync.h"
 #include "BRCryptoAccount.h"
 #include "BRCryptoNetwork.h"
+#include "bitcoin/BRChainParams.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,29 +70,41 @@ extern void
 runPerfTestsCoder (int repeat, int many);
 
 // Bitcoin
+typedef enum {
+    BITCOIN_CHAIN_BTC,
+    BITCOIN_CHAIN_BCH,
+    BITCOIN_CHAIN_BSV
+} BRBitcoinChain;
+
+extern const BRChainParams*
+getChainParams (BRBitcoinChain chain, int isMainnet);
+
+extern const char *
+getChainName (BRBitcoinChain chain);
+
 extern int BRRunSupTests (void);
 
 extern int BRRunTests();
 
 extern int BRRunTestsSync (const char *paperKey,
-                           int isBTC,
+                           BRBitcoinChain bitcoinChain,
                            int isMainnet);
 
 extern int BRRunTestWalletManagerSync (const char *paperKey,
                                        const char *storagePath,
-                                       int isBTC,
+                                       BRBitcoinChain bitcoinChain,
                                        int isMainnet);
 
 extern int BRRunTestWalletManagerSyncStress(const char *paperKey,
                                             const char *storagePath,
                                             uint32_t earliestKeyTime,
                                             uint64_t blockHeight,
-                                            int isBTC,
+                                            BRBitcoinChain bitcoinChain,
                                             int isMainnet);
 
 extern int BRRunTestsBWM (const char *paperKey,
                           const char *storagePath,
-                          int isBTC,
+                          BRBitcoinChain bitcoinChain,
                           int isMainnet);
 
 extern void BRRandInit (void);

--- a/WalletKitCore/include/BRCryptoBase.h
+++ b/WalletKitCore/include/BRCryptoBase.h
@@ -96,6 +96,7 @@ extern uint64_t BLOCK_HEIGHT_UNBOUND_VALUE;
     typedef enum {
         CRYPTO_NETWORK_TYPE_BTC,
         CRYPTO_NETWORK_TYPE_BCH,
+        CRYPTO_NETWORK_TYPE_BSV,
         CRYPTO_NETWORK_TYPE_ETH,
         CRYPTO_NETWORK_TYPE_XRP,
         CRYPTO_NETWORK_TYPE_HBAR,
@@ -112,6 +113,7 @@ extern uint64_t BLOCK_HEIGHT_UNBOUND_VALUE;
     //
 #    define CRYPTO_NETWORK_CURRENCY_BTC     "btc"
 #    define CRYPTO_NETWORK_CURRENCY_BCH     "bch"
+#    define CRYPTO_NETWORK_CURRENCY_BSV     "bsv"
 #    define CRYPTO_NETWORK_CURRENCY_ETH     "eth"
 #    define CRYPTO_NETWORK_CURRENCY_XRP     "xrp"
 #    define CRYPTO_NETWORK_CURRENCY_HBAR    "hbar"

--- a/WalletKitCore/src/bitcoin/BRSyncManager.c
+++ b/WalletKitCore/src/bitcoin/BRSyncManager.c
@@ -17,6 +17,7 @@
 
 #include "support/BRArray.h"
 #include "support/BRAddress.h"
+#include "bcash/BRBCashParams.h"
 #include "bcash/BRBCashAddr.h"
 
 #include "BRSyncManager.h"
@@ -1234,8 +1235,8 @@ BRClientSyncManagerConvertAddressToString (BRClientSyncManager manager,
 
     BRArrayOf(char *) addressesAsString = NULL;
 
-    // For BTC, simply extract the BRAddress' string
-    if (BRChainParamsIsBitcoin (manager->chainParams)) {
+    // For BTC/BSV, simply extract the BRAddress' string
+    if (0 == BRChainParamsIsBitcash (manager->chainParams)) {
         array_new(addressesAsString, addressesCount);
         array_set_count(addressesAsString, addressesCount);
 

--- a/WalletKitCore/src/bitcoin/BRWalletManager.c
+++ b/WalletKitCore/src/bitcoin/BRWalletManager.c
@@ -22,6 +22,7 @@
 #include "support/BRBase58.h"
 #include "BRChainParams.h"
 #include "bcash/BRBCashParams.h"
+#include "bsv/BRBSVParams.h"
 
 #include "support/BRFileService.h"
 #include "ethereum/event/BREvent.h"
@@ -81,9 +82,15 @@ getCurrencyName (const BRChainParams *params) {
         params->magicNumber == BRTestNetParams->magicNumber)
         return "btc";
 
-    if (params->magicNumber == BRBCashParams->magicNumber ||
-        params->magicNumber == BRBCashTestNetParams->magicNumber)
+    if (params == BRBCashParams ||
+        params == BRBCashTestNetParams) {
         return "bch";
+    }
+    
+    if (params == BRBSVParams ||
+        params == BRBSVTestNetParams) {
+        return "bsv";
+    }
 
     // this should never happen!
     assert (0);
@@ -1216,6 +1223,11 @@ BRWalletManagerGetWallet (BRWalletManager manager) {
 extern int
 BRWalletManagerHandlesBTC (BRWalletManager manager) {
     return BRChainParamsIsBitcoin (manager->chainParams);
+}
+
+extern int
+BRWalletManagerHandlesBCH (BRWalletManager manager) {
+    return BRChainParamsIsBitcash (manager->chainParams);
 }
 
 extern void

--- a/WalletKitCore/src/bitcoin/BRWalletManager.c
+++ b/WalletKitCore/src/bitcoin/BRWalletManager.c
@@ -78,8 +78,8 @@ getNetworkName (const BRChainParams *params) {
 
 static const char *
 getCurrencyName (const BRChainParams *params) {
-    if (params->magicNumber == BRMainNetParams->magicNumber ||
-        params->magicNumber == BRTestNetParams->magicNumber)
+    if (params == BRMainNetParams ||
+        params == BRTestNetParams)
         return "btc";
 
     if (params == BRBCashParams ||

--- a/WalletKitCore/src/bitcoin/BRWalletManager.h
+++ b/WalletKitCore/src/bitcoin/BRWalletManager.h
@@ -324,6 +324,13 @@ extern int
 BRWalletManagerHandlesBTC (BRWalletManager manager);
 
 /**
+ * Return `1` if `manager` handles BCH; otherwise `0` if BTC/BSV.  Note: the `BRChainParams` determine
+ * BTC vs BCH vs BSV.
+ */
+extern int
+BRWalletManagerHandlesBCH (BRWalletManager manager);
+
+/**
  * Creates an unsigned transaction that sends the specified amount from the wallet to the given
  * address.  The address must satisfy BRAddressIsValid() using the provided BRWalletManager
  * address parameters.  In particular, a BCH address (either mainnet or testnet) *does not*

--- a/WalletKitCore/src/bsv/BRBSVParams.c
+++ b/WalletKitCore/src/bsv/BRBSVParams.c
@@ -1,0 +1,181 @@
+//
+//  BRBSVParams.c
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-06-04.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#include "support/BRInt.h"
+#include "support/BRSet.h"
+#include "bitcoin/BRPeer.h"
+#include "BRBSVParams.h"
+
+static const char *BRBSVDNSSeeds[] = {
+    "seed.bitcoinsv.io",
+    "seed.cascharia.com",
+    "seed.satoshisvision.network",
+    NULL
+};
+
+static const char *BRBSVTestNetDNSSeeds[] = {
+    "testnet-seed.bitcoinsv.io",
+    "testnet-seed.cascharia.com",
+    "testnet-seed.bitcoincloud.net",
+    NULL
+};
+
+static const BRCheckPoint BRBSVTestNetCheckpoints[] = {
+    {       0, uint256("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"), 1296688602, 0x1d00ffff },
+    {  100800, uint256("0000000000a33112f86f3f7b0aa590cb4949b84c2d9c673e9e303257b3be9000"), 1376543922, 0x1c00d907 },
+    {  201600, uint256("0000000000376bb71314321c45de3015fe958543afcbada242a3b1b072498e38"), 1393813869, 0x1b602ac0 },
+    {  302400, uint256("0000000000001c93ebe0a7c33426e8edb9755505537ef9303a023f80be29d32d"), 1413766239, 0x1a33605e },
+    {  403200, uint256("0000000000ef8b05da54711e2106907737741ac0278d59f358303c71d500f3c4"), 1431821666, 0x1c02346c },
+    {  504000, uint256("0000000000005d105473c916cd9d16334f017368afea6bcee71629e0fcf2f4f5"), 1436951946, 0x1b00ab86 },
+    {  604800, uint256("00000000000008653c7e5c00c703c5a9d53b318837bb1b3586a3d060ce6fff2e"), 1447484641, 0x1a092a20 },
+    {  705600, uint256("00000000004ee3bc2e2dd06c31f2d7a9c3e471ec0251924f59f222e5e9c37e12"), 1455728685, 0x1c0ffff0 },
+    {  806400, uint256("0000000000000faf114ff29df6dbac969c6b4a3b407cd790d3a12742b50c2398"), 1462006183, 0x1a34e280 },
+    {  907200, uint256("0000000000166938e6f172a21fe69fe335e33565539e74bf74eeb00d2022c226"), 1469705562, 0x1c00ffff },
+    { 1008000, uint256("000000000000390aca616746a9456a0d64c1bd73661fd60a51b5bf1c92bae5a0"), 1476926743, 0x1a52ccc0 },
+    { 1108800, uint256("00000000000288d9a219419d0607fb67cc324d4b6d2945ca81eaa5e739fab81e"), 1490751239, 0x1b09ecf0 },
+    { 1209600, uint256("0000000000083e8da119a0dee60f7d8925488f43a9f3591fef0cf8c3b1a86887"), 1517992679, 0x1c01bbf5 },
+    { 1223263, uint256("000000000005b07ecf85563034d13efd81c1a29e47e22b20f4fc6919d5b09cd6"), 1522608381, 0x1d00ffff }
+};
+
+// blockchain checkpoints - these are also used as starting points for partial chain downloads, so they must be at
+// difficulty transition boundaries in order to verify the block difficulty at the immediately following transition
+static const BRCheckPoint BRBSVCheckpoints[] = {
+    {      0, uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), 1231006505, 0x1d00ffff },
+    {  20160, uint256("000000000f1aef56190aee63d33a373e6487132d522ff4cd98ccfc96566d461e"), 1248481816, 0x1d00ffff },
+    {  40320, uint256("0000000045861e169b5a961b7034f8de9e98022e7a39100dde3ae3ea240d7245"), 1266191579, 0x1c654657 },
+    {  60480, uint256("000000000632e22ce73ed38f46d5b408ff1cff2cc9e10daaf437dfd655153837"), 1276298786, 0x1c0eba64 },
+    {  80640, uint256("0000000000307c80b87edf9f6a0697e2f01db67e518c8a4d6065d1d859a3a659"), 1284861847, 0x1b4766ed },
+    { 100800, uint256("000000000000e383d43cc471c64a9a4a46794026989ef4ff9611d5acb704e47a"), 1294031411, 0x1b0404cb },
+    { 120960, uint256("0000000000002c920cf7e4406b969ae9c807b5c4f271f490ca3de1b0770836fc"), 1304131980, 0x1b0098fa },
+    { 141120, uint256("00000000000002d214e1af085eda0a780a8446698ab5c0128b6392e189886114"), 1313451894, 0x1a094a86 },
+    { 161280, uint256("00000000000005911fe26209de7ff510a8306475b75ceffd434b68dc31943b99"), 1326047176, 0x1a0d69d7 },
+    { 181440, uint256("00000000000000e527fc19df0992d58c12b98ef5a17544696bbba67812ef0e64"), 1337883029, 0x1a0a8b5f },
+    { 201600, uint256("00000000000003a5e28bef30ad31f1f9be706e91ae9dda54179a95c9f9cd9ad0"), 1349226660, 0x1a057e08 },
+    { 221760, uint256("00000000000000fc85dd77ea5ed6020f9e333589392560b40908d3264bd1f401"), 1361148470, 0x1a04985c },
+    { 241920, uint256("00000000000000b79f259ad14635739aaf0cc48875874b6aeecc7308267b50fa"), 1371418654, 0x1a00de15 },
+    { 262080, uint256("000000000000000aa77be1c33deac6b8d3b7b0757d02ce72fffddc768235d0e2"), 1381070552, 0x1916b0ca },
+    { 282240, uint256("0000000000000000ef9ee7529607286669763763e0c46acfdefd8a2306de5ca8"), 1390570126, 0x1901f52c },
+    { 302400, uint256("0000000000000000472132c4daaf358acaf461ff1c3e96577a74e5ebf91bb170"), 1400928750, 0x18692842 },
+    { 322560, uint256("000000000000000002df2dd9d4fe0578392e519610e341dd09025469f101cfa1"), 1411680080, 0x181fb893 },
+    { 342720, uint256("00000000000000000f9cfece8494800d3dcbf9583232825da640c8703bcd27e7"), 1423496415, 0x1818bb87 },
+    { 362880, uint256("000000000000000014898b8e6538392702ffb9450f904c80ebf9d82b519a77d5"), 1435475246, 0x1816418e },
+    { 383040, uint256("00000000000000000a974fa1a3f84055ad5ef0b2f96328bc96310ce83da801c9"), 1447236692, 0x1810b289 },
+    { 403200, uint256("000000000000000000c4272a5c68b4f55e5af734e88ceab09abf73e9ac3b6d01"), 1458292068, 0x1806a4c3 },
+    { 423360, uint256("000000000000000001630546cde8482cc183708f076a5e4d6f51cd24518e8f85"), 1470163842, 0x18057228 },
+    { 443520, uint256("00000000000000000345d0c7890b2c81ab5139c6e83400e5bed00d23a1f8d239"), 1481765313, 0x18038b85 },
+    { 463680, uint256("000000000000000000431a2f4619afe62357cd16589b638bb638f2992058d88e"), 1493259601, 0x18021b3e },
+    { 483840, uint256("00000000000000000098963251fcfc19d0fa2ef05cf22936a182609f8d650346"), 1503802540, 0x1803c5d5 },
+    { 504000, uint256("0000000000000000006cdeece5716c9c700f34ad98cb0ed0ad2c5767bbe0bc8c"), 1510516839, 0x18021abd },
+    { 524160, uint256("0000000000000000003f40db0a3ed4b4d82b105e212166b2db498d5688bac60f"), 1522711454, 0x18033b64 },
+    { 544320, uint256("000000000000000001619f65f7d5ef7a06ee50d2b459cdf727d74b2a7a762268"), 1534794998, 0x18022f7e },
+    // BSV forked from BCH at block height 556766
+    { 620538, uint256("000000000000000001618b0a11306363725fbb8dbecbb0201c2b4064cda00790"), 1580780106, 0x18021566 },
+};
+
+static const BRMerkleBlock *_medianBlock(const BRMerkleBlock *b, const BRSet *blockSet)
+{
+    const BRMerkleBlock *b0 = NULL, *b1 = NULL, *b2 = b;
+
+    b1 = (b2) ? BRSetGet(blockSet, &b2->prevBlock) : NULL;
+    b0 = (b1) ? BRSetGet(blockSet, &b1->prevBlock) : NULL;
+    if (b0 && b2 && b0->timestamp > b2->timestamp) b = b0, b0 = b2, b2 = b;
+    if (b0 && b1 && b0->timestamp > b1->timestamp) b = b0, b0 = b1, b1 = b;
+    if (b1 && b2 && b1->timestamp > b2->timestamp) b = b1, b1 = b2, b2 = b;
+    return (b0 && b1 && b2) ? b1 : NULL;
+}
+
+static int BRBSVVerifyDifficulty(const BRMerkleBlock *block, const BRSet *blockSet)
+{
+    const BRMerkleBlock *b, *first, *last;
+    int i, sz, size = 0x1d;
+    uint64_t t, target, w, work = 0;
+    int64_t timespan;
+
+    assert(block != NULL);
+    assert(blockSet != NULL);
+
+    if (block && block->height >= 504032) { // D601 hard fork height: https://reviews.bitcoinabc.org/D601
+        last = BRSetGet(blockSet, &block->prevBlock);
+        last = _medianBlock(last, blockSet);
+
+        for (i = 0, first = block; first && i <= 144; i++) {
+            first = BRSetGet(blockSet, &first->prevBlock);
+        }
+
+        first = _medianBlock(first, blockSet);
+
+        if (! first) return 1;
+        timespan = (int64_t)last->timestamp - first->timestamp;
+        if (timespan > 288*10*60) timespan = 288*10*60;
+        if (timespan < 72*10*60) timespan = 72*10*60;
+
+        for (b = last; b != first;) {
+            // target is in "compact" format, where the most significant byte is the size of the value in bytes, next
+            // bit is the sign, and the last 23 bits is the value after having been right shifted by (size - 3)*8 bits
+            sz = b->target >> 24, t = b->target & 0x007fffff;
+
+            // work += 2^256/(target + 1)
+            w = (t) ? ~0ULL/t : ~0ULL;
+            while (sz < size) work >>= 8, size--;
+            while (size < sz) w >>= 8, sz--;
+            while (work + w < w) w >>= 8, work >>= 8, size--;
+            work += w;
+
+            b = BRSetGet(blockSet, &b->prevBlock);
+        }
+
+        // work = work*10*60/timespan
+        while (work > ~0ULL/(10*60)) work >>= 8, size--;
+        work = work*10*60/timespan;
+
+        // target = (2^256/work) - 1
+        while (work && ~0ULL/work < 0x8000) work >>= 8, size--;
+        target = (work) ? ~0ULL/work : ~0ULL;
+
+        while (size < 1 || target > 0x007fffff) target >>= 8, size++; // normalize target for "compact" format
+        target |= size << 24;
+
+        if (target > 0x1d00ffff) target = 0x1d00ffff; // max proof-of-work
+        if (target - block->target > 1) return 0;
+    }
+
+    return 1;
+}
+
+static int BRBSVTestNetVerifyDifficulty(const BRMerkleBlock *block, const BRSet *blockSet)
+{
+    return 1; // XXX skip testnet difficulty check for now
+}
+
+static const BRChainParams BRBSVParamsRecord = {
+    BRBSVDNSSeeds,
+    8333,                // standardPort
+    0xe8f3e1e3,          // magicNumber
+    SERVICES_NODE_BCASH, // services
+    BRBSVVerifyDifficulty,
+    BRBSVCheckpoints,
+    sizeof(BRBSVCheckpoints)/sizeof(*BRBSVCheckpoints),
+    { BITCOIN_PUBKEY_PREFIX, BITCOIN_SCRIPT_PREFIX, BITCOIN_PRIVKEY_PREFIX, NULL },
+    BSV_FORKID
+};
+const BRChainParams *BRBSVParams = &BRBSVParamsRecord;
+
+static const BRChainParams BRBSVTestNetParamsRecord = {
+    BRBSVTestNetDNSSeeds,
+    18333,               // standardPort
+    0xf4f3e5f4,          // magicNumber
+    SERVICES_NODE_BCASH, // services
+    BRBSVTestNetVerifyDifficulty,
+    BRBSVTestNetCheckpoints,
+    sizeof(BRBSVTestNetCheckpoints)/sizeof(*BRBSVTestNetCheckpoints),
+    { BITCOIN_PUBKEY_PREFIX_TEST, BITCOIN_SCRIPT_PREFIX_TEST, BITCOIN_PRIVKEY_PREFIX_TEST, NULL },
+    BSV_FORKID
+};
+const BRChainParams *BRBSVTestNetParams = &BRBSVTestNetParamsRecord;

--- a/WalletKitCore/src/bsv/BRBSVParams.h
+++ b/WalletKitCore/src/bsv/BRBSVParams.h
@@ -1,0 +1,37 @@
+//
+//  BRBSVParams.h
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-06-04.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#ifndef BRBSVParams_h
+#define BRBSVParams_h
+
+#include "bitcoin/BRChainParams.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+#define BSV_FORKID 0x40
+
+extern const BRChainParams *BRBSVParams;
+extern const BRChainParams *BRBSVTestNetParams;
+
+static inline const BRChainParams *BRChainParamsGetBSV (int mainnet) {
+    return mainnet ? BRBSVParams : BRBSVTestNetParams;
+}
+
+static inline int BRChainParamsIsBSV (const BRChainParams *params) {
+    return BRBSVParams == params || BRBSVTestNetParams == params;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BRSVParams_h

--- a/WalletKitCore/src/crypto/BRCryptoAddress.c
+++ b/WalletKitCore/src/crypto/BRCryptoAddress.c
@@ -131,9 +131,9 @@ cryptoAddressCreateFromString (BRCryptoNetwork network,
     switch (cryptoNetworkGetType(network)) {
         case BLOCK_CHAIN_TYPE_BTC: {
             const BRChainParams *params = cryptoNetworkAsBTC (network);
-            return (BRChainParamsIsBitcoin (params)
-                    ? cryptoAddressCreateFromStringAsBTC (params->addrParams, string)
-                    : cryptoAddressCreateFromStringAsBCH (params->addrParams, string));
+            return (BRChainParamsIsBitcash (params)
+                    ? cryptoAddressCreateFromStringAsBCH (params->addrParams, string)
+                    : cryptoAddressCreateFromStringAsBTC (params->addrParams, string));
         }
         case BLOCK_CHAIN_TYPE_ETH:
             return cryptoAddressCreateFromStringAsETH (string);

--- a/WalletKitCore/src/crypto/BRCryptoConfig.h
+++ b/WalletKitCore/src/crypto/BRCryptoConfig.h
@@ -72,6 +72,26 @@ DEFINE_ADDRESS_SCHEMES  ("bitcoincash-testnet", CRYPTO_ADDRESS_SCHEME_BTC_LEGACY
 DEFINE_MODES            ("bitcoincash-testnet", CRYPTO_SYNC_MODE_API_ONLY,  CRYPTO_SYNC_MODE_P2P_ONLY)
 #undef NETWORK_NAME
 
+// MARK: - BSV
+
+#define NETWORK_NAME    "Bitcoin SV"
+DEFINE_NETWORK (bsvMainnet,  "bitcoinsv-mainnet", NETWORK_NAME, "mainnet", true, 617640, 6)
+DEFINE_NETWORK_FEE_ESTIMATE ("bitcoinsv-mainnet", "2", "10m", 20 * 60 * 1000)
+DEFINE_CURRENCY ("bitcoinsv-mainnet",     "bitcoinsv-mainnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_BSV,  "native",   NULL,   true)
+    DEFINE_UNIT ("bitcoinsv-mainnet:__native__",      "Satoshi",    "sat",      0,      "SAT")
+    DEFINE_UNIT ("bitcoinsv-mainnet:__native__",      NETWORK_NAME, "bsv",      8,      "BSV")
+DEFINE_ADDRESS_SCHEMES  ("bitcoinsv-mainnet", CRYPTO_ADDRESS_SCHEME_BTC_LEGACY)
+DEFINE_MODES            ("bitcoinsv-mainnet", CRYPTO_SYNC_MODE_API_ONLY, CRYPTO_SYNC_MODE_P2P_ONLY)
+
+DEFINE_NETWORK (bsvTestnet,  "bitcoinsv-testnet", NETWORK_NAME, "testnet", false, 1353306, 6)
+DEFINE_NETWORK_FEE_ESTIMATE ("bitcoinsv-testnet", "2", "10m", 20 * 60 * 1000)
+DEFINE_CURRENCY ("bitcoinsv-testnet",     "bitcoinsv-testnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_BSV,  "native",   NULL,   true)
+    DEFINE_UNIT ("bitcoinsv-testnet:__native__",      "Satoshi",    "sat",      0,      "SAT")
+    DEFINE_UNIT ("bitcoinsv-testnet:__native__",      NETWORK_NAME, "bsv",      8,      "BSV")
+DEFINE_ADDRESS_SCHEMES  ("bitcoinsv-testnet", CRYPTO_ADDRESS_SCHEME_BTC_LEGACY)
+DEFINE_MODES            ("bitcoinsv-testnet", CRYPTO_SYNC_MODE_API_ONLY,  CRYPTO_SYNC_MODE_P2P_ONLY)
+#undef NETWORK_NAME
+
 // MARK: - ETH
 
 #define NETWORK_NAME    "Ethereum"

--- a/WalletKitCore/src/crypto/BRCryptoNetwork.c
+++ b/WalletKitCore/src/crypto/BRCryptoNetwork.c
@@ -16,6 +16,7 @@
 
 #include "bitcoin/BRChainParams.h"
 #include "bcash/BRBCashParams.h"
+#include "bsv/BRBSVParams.h"
 #include "ethereum/BREthereum.h"
 
 #include <stdbool.h>
@@ -33,6 +34,7 @@ cryptoNetworkCanonicalTypeGetCurrencyCode (BRCryptoNetworkCanonicalType type) {
     static const char *currencies[NUMBER_OF_NETWORK_TYPES] = {
         CRYPTO_NETWORK_CURRENCY_BTC,
         CRYPTO_NETWORK_CURRENCY_BCH,
+        CRYPTO_NETWORK_CURRENCY_BSV,
         CRYPTO_NETWORK_CURRENCY_ETH,
         CRYPTO_NETWORK_CURRENCY_XRP,
         CRYPTO_NETWORK_CURRENCY_HBAR,
@@ -176,6 +178,17 @@ cryptoNetworkCreateAsBCH (const char *uids,
 }
 
 static BRCryptoNetwork
+cryptoNetworkCreateAsBSV (const char *uids,
+                          const char *name,
+                          const BRChainParams *params) {
+    BRCryptoNetwork network = cryptoNetworkCreate (uids, name, CRYPTO_NETWORK_TYPE_BSV);
+    network->type = BLOCK_CHAIN_TYPE_BTC;
+    network->u.btc = params;
+
+    return network;
+}
+
+static BRCryptoNetwork
 cryptoNetworkCreateAsETH (const char *uids,
                           const char *name,
                           BREthereumNetwork net) {
@@ -262,7 +275,8 @@ cryptoNetworkIsMainnet (BRCryptoNetwork network) {
     switch (network->type) {
         case BLOCK_CHAIN_TYPE_BTC:
             return AS_CRYPTO_BOOLEAN (network->u.btc == BRMainNetParams ||
-                                      network->u.btc == BRBCashParams);
+                                      network->u.btc == BRBCashParams ||
+                                      network->u.btc == BRBSVParams);
         case BLOCK_CHAIN_TYPE_ETH:
             return AS_CRYPTO_BOOLEAN (network->u.eth == ethNetworkMainnet);
         case BLOCK_CHAIN_TYPE_GEN:
@@ -657,6 +671,10 @@ cryptoNetworkCreateBuiltin (const char *symbol,
         network = cryptoNetworkCreateAsBCH (uids, name, BRBCashParams);
     else if (0 == strcmp ("bchTestnet", symbol))
         network = cryptoNetworkCreateAsBCH (uids, name, BRBCashTestNetParams);
+    else if (0 == strcmp ("bsvMainnet", symbol))
+        network = cryptoNetworkCreateAsBSV (uids, name, BRBSVParams);
+    else if (0 == strcmp ("bsvTestnet", symbol))
+        network = cryptoNetworkCreateAsBSV (uids, name, BRBSVTestNetParams);
     else if (0 == strcmp ("ethMainnet", symbol))
         network = cryptoNetworkCreateAsETH (uids, name, ethNetworkMainnet);
     else if (0 == strcmp ("ethRopsten", symbol))

--- a/WalletKitCore/src/crypto/BRCryptoNetworkP.h
+++ b/WalletKitCore/src/crypto/BRCryptoNetworkP.h
@@ -18,6 +18,7 @@
 
 #include "bitcoin/BRChainParams.h"
 #include "bcash/BRBCashParams.h"
+#include "bsv/BRBSVParams.h"
 #include "ethereum/BREthereum.h"
 #include "generic/BRGeneric.h"
 

--- a/WalletKitCore/src/crypto/BRCryptoPayment.c
+++ b/WalletKitCore/src/crypto/BRCryptoPayment.c
@@ -143,7 +143,7 @@ cryptoPaymentProtocolRequestBitPayBuilderAddOutput(BRCryptoPaymentProtocolReques
                                                    uint64_t satoshis) {
     if (satoshis) {
         const BRChainParams * chainParams = cryptoNetworkAsBTC (builder->cryptoNetwork);
-        int isBTC = BRChainParamsIsBitcoin (chainParams);
+        int isBTC = (0 == BRChainParamsIsBitcash (chainParams));
 
         if (isBTC) {
             if (BRAddressIsValid (chainParams->addrParams, address)) {
@@ -443,7 +443,7 @@ cryptoPaymentProtocolRequestGetPrimaryTargetAddress (BRCryptoPaymentProtocolRequ
             BRPaymentProtocolRequest *request = protoReq->u.btc.request;
             if (0 != request->details->outCount) {
                 const BRChainParams * chainParams = cryptoNetworkAsBTC (protoReq->cryptoNetwork);
-                int isBTC = BRChainParamsIsBitcoin (chainParams);
+                int isBTC = (0 == BRChainParamsIsBitcash (chainParams));
 
                 BRTxOutput *output = &request->details->outputs[0];
                 size_t addressSize = BRTxOutputAddress (output, NULL, 0, chainParams->addrParams);

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -327,7 +327,7 @@ cryptoWalletGetAddress (BRCryptoWallet wallet,
             BRAddress btcAddress = (CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT == addressScheme
                                     ? BRWalletReceiveAddress(wid)
                                     : BRWalletLegacyAddress (wid));
-            return cryptoAddressCreateAsBTC (btcAddress, AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(wallet->u.btc.bwm)));
+            return cryptoAddressCreateAsBTC (btcAddress, AS_CRYPTO_BOOLEAN (0 == BRWalletManagerHandlesBCH(wallet->u.btc.bwm)));
             }
 
         case BLOCK_CHAIN_TYPE_ETH: {
@@ -628,7 +628,7 @@ cryptoWalletCreateTransferMultiple (BRCryptoWallet wallet,
                                                                              outputsCount,
                                                                              cryptoFeeBasisAsBTC(estimatedFeeBasis));
             transfer = NULL == tid ? NULL : cryptoTransferCreateAsBTC (unit, unitForFee, wid, tid,
-                                                                       AS_CRYPTO_BOOLEAN(BRWalletManagerHandlesBTC(bwm)));
+                                                                       AS_CRYPTO_BOOLEAN(0 == BRWalletManagerHandlesBCH(bwm)));
             break;
         }
         case BLOCK_CHAIN_TYPE_ETH:
@@ -679,7 +679,7 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             BRTransaction *tid = BRWalletManagerCreateTransaction (bwm, wid, value, address,
                                                                    cryptoFeeBasisAsBTC(estimatedFeeBasis));
             transfer = NULL == tid ? NULL : cryptoTransferCreateAsBTC (unit, unitForFee, wid, tid,
-                                                                       AS_CRYPTO_BOOLEAN(BRWalletManagerHandlesBTC(bwm)));
+                                                                       AS_CRYPTO_BOOLEAN(0 == BRWalletManagerHandlesBCH(bwm)));
             break;
         }
 
@@ -784,7 +784,7 @@ cryptoWalletCreateTransferForWalletSweep (BRCryptoWallet  wallet,
                                                                        unitForFee,
                                                                        wid,
                                                                        tid,
-                                                                       AS_CRYPTO_BOOLEAN(BRWalletManagerHandlesBTC(bwm)));
+                                                                       AS_CRYPTO_BOOLEAN(0 == BRWalletManagerHandlesBCH(bwm)));
             break;
         }
         default:
@@ -820,7 +820,7 @@ cryptoWalletCreateTransferForPaymentProtocolRequest (BRCryptoWallet wallet,
                         BRTransaction *tid = BRWalletManagerCreateTransactionForOutputs (bwm, wid, outputs, array_count (outputs),
                                                                                          cryptoFeeBasisAsBTC(estimatedFeeBasis));
                         transfer = NULL == tid ? NULL : cryptoTransferCreateAsBTC (unit, unitForFee, wid, tid,
-                                                                                   AS_CRYPTO_BOOLEAN(BRWalletManagerHandlesBTC(bwm)));
+                                                                                   AS_CRYPTO_BOOLEAN(0 == BRWalletManagerHandlesBCH(bwm)));
                         array_free (outputs);
                     }
                     break;

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -571,7 +571,7 @@ cwmTransactionEventAsBTC (BRWalletManagerClientContext context,
 
             BRCryptoUnit unit         = cryptoWalletGetUnit (wallet);
             BRCryptoUnit unitForFee   = cryptoWalletGetUnitForFee(wallet);
-            BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(btcManager));
+            BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (0 == BRWalletManagerHandlesBCH(btcManager));
 
             // The transfer finally - based on the wallet's currency (BTC)
             transfer = cryptoTransferCreateAsBTC (unit,
@@ -646,7 +646,7 @@ cwmTransactionEventAsBTC (BRWalletManagerClientContext context,
             if (NULL == transfer) {
                 BRCryptoUnit unit         = cryptoWalletGetUnit (wallet);
                 BRCryptoUnit unitForFee   = cryptoWalletGetUnitForFee(wallet);
-                BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(btcManager));
+                BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (0 == BRWalletManagerHandlesBCH(btcManager));
 
                 // The transfer finally - based on the wallet's currency (BTC)
                 transfer = cryptoTransferCreateAsBTC (unit,

--- a/WalletKitCore/src/ethereum/Makefile
+++ b/WalletKitCore/src/ethereum/Makefile
@@ -20,7 +20,8 @@ CORE_SRCS=../support/BRAddress.c \
 	../bitcoin/BRWallet.c \
 	../bitcoin/BRWalletManager.c \
 	../bcash/BRBCashAddr.c \
-	../bcash/BRBCashParams.c
+	../bcash/BRBCashParams.c \
+	../bsv/BRBSVParams.c
 
 CORE_OBJS=$(CORE_SRCS:.c=.o)
 

--- a/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
@@ -306,6 +306,7 @@ extension Network {
 public enum NetworkType: CustomStringConvertible {
     case btc
     case bch
+    case bsv
     case eth
     case xrp
     case hbar
@@ -315,6 +316,7 @@ public enum NetworkType: CustomStringConvertible {
         switch core {
         case CRYPTO_NETWORK_TYPE_BTC:  self = .btc
         case CRYPTO_NETWORK_TYPE_BCH:  self = .bch
+        case CRYPTO_NETWORK_TYPE_BSV:  self = .bsv
         case CRYPTO_NETWORK_TYPE_ETH:  self = .eth
         case CRYPTO_NETWORK_TYPE_XRP:  self = .xrp
         case CRYPTO_NETWORK_TYPE_HBAR: self = .hbar
@@ -327,6 +329,7 @@ public enum NetworkType: CustomStringConvertible {
         switch self {
         case .btc: return CRYPTO_NETWORK_TYPE_BTC
         case .bch: return CRYPTO_NETWORK_TYPE_BCH
+        case .bsv: return CRYPTO_NETWORK_TYPE_BSV
         case .eth: return CRYPTO_NETWORK_TYPE_ETH
         case .xrp: return CRYPTO_NETWORK_TYPE_XRP
         case .hbar: return CRYPTO_NETWORK_TYPE_HBAR

--- a/WalletKitSwift/WalletKitDemo/Source/Base.lproj/Main.storyboard
+++ b/WalletKitSwift/WalletKitDemo/Source/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -220,14 +220,8 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MLN-bC-1fP">
-                                <rect key="frame" x="16" y="342" width="343" height="17"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XO7-1V-dpo">
-                                <rect key="frame" x="16" y="393" width="173" height="17"/>
+                                <rect key="frame" x="16" y="393" width="35.5" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -273,7 +267,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nna-wm-WQ9">
-                                <rect key="frame" x="189" y="393" width="170" height="17"/>
+                                <rect key="frame" x="51.5" y="393" width="170" height="17"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="Ky3-Hs-gQR"/>
                                 </constraints>
@@ -313,10 +307,16 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dWn-kT-uvD" userLabel="Identifier Button">
+                                <rect key="frame" x="16" y="335" width="343" height="30"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <action selector="toPasteBoard:" destination="hSS-q9-i3e" eventType="touchUpInside" id="YJm-bv-Jf7"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="MLN-bC-1fP" firstAttribute="top" secondItem="1aL-0l-OyD" secondAttribute="bottom" constant="2" id="2Ke-bt-0dl"/>
                             <constraint firstItem="IJW-uK-4cU" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="4I8-9J-ZvP"/>
                             <constraint firstItem="W6B-wc-UDS" firstAttribute="top" secondItem="F0N-Rw-q7C" secondAttribute="bottom" constant="2" id="4aB-RQ-eSi"/>
                             <constraint firstItem="Msp-ZU-V54" firstAttribute="top" secondItem="paz-yI-Rkj" secondAttribute="bottom" constant="30" id="4gg-kK-WK1"/>
@@ -334,7 +334,6 @@
                             <constraint firstItem="i29-Bu-x5Y" firstAttribute="top" secondItem="Msp-ZU-V54" secondAttribute="bottom" constant="30" id="H0k-xe-78D"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="mx1-cF-5NT" secondAttribute="trailing" constant="16" id="Ij0-LV-BeY"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="W6B-wc-UDS" secondAttribute="trailing" constant="16" id="JHK-QE-wIA"/>
-                            <constraint firstItem="Nna-wm-WQ9" firstAttribute="trailing" secondItem="MLN-bC-1fP" secondAttribute="trailing" id="KvX-Pg-1Sd"/>
                             <constraint firstItem="ZpH-5u-myO" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="Mfj-za-Ub9"/>
                             <constraint firstItem="Yrm-2z-u7B" firstAttribute="top" secondItem="Msp-ZU-V54" secondAttribute="bottom" constant="2" id="O0q-5c-TSL"/>
                             <constraint firstItem="zpy-jG-U3g" firstAttribute="top" secondItem="IJW-uK-4cU" secondAttribute="bottom" constant="2" id="OZI-40-Naj"/>
@@ -342,6 +341,7 @@
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="zpy-jG-U3g" secondAttribute="trailing" constant="16" id="Pby-vX-SQw"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="bFN-pR-hGB" secondAttribute="trailing" constant="16" id="Pkc-gx-ZaV"/>
                             <constraint firstItem="1aL-0l-OyD" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="QYc-0M-qxp"/>
+                            <constraint firstItem="dWn-kT-uvD" firstAttribute="top" secondItem="1aL-0l-OyD" secondAttribute="bottom" constant="-5" id="QYd-EI-Yfx"/>
                             <constraint firstItem="1aL-0l-OyD" firstAttribute="top" secondItem="GNr-nd-ZLG" secondAttribute="bottom" constant="30" id="Txd-pP-aIx"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="Hgu-ad-dm8" secondAttribute="trailing" constant="16" id="UIk-f2-Lsi"/>
                             <constraint firstItem="Vu4-vH-2qi" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="Uns-uV-Nzw"/>
@@ -350,11 +350,11 @@
                             <constraint firstItem="Yrm-2z-u7B" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="W1q-oI-drY"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="pSY-xF-fdu" secondAttribute="trailing" constant="16" id="YW0-WF-aXn"/>
                             <constraint firstItem="XO7-1V-dpo" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="ZOt-dV-ecq"/>
-                            <constraint firstItem="MLN-bC-1fP" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="c4v-3M-fQC"/>
+                            <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="dWn-kT-uvD" secondAttribute="trailing" constant="16" id="aIM-R2-vUU"/>
                             <constraint firstItem="ZpH-5u-myO" firstAttribute="top" secondItem="IJW-uK-4cU" secondAttribute="bottom" constant="30" id="cwW-DR-z0r"/>
+                            <constraint firstItem="dWn-kT-uvD" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="d89-Ve-gTN"/>
                             <constraint firstItem="XO7-1V-dpo" firstAttribute="top" secondItem="paz-yI-Rkj" secondAttribute="bottom" constant="2" id="eYS-Rc-OER"/>
                             <constraint firstItem="Hgu-ad-dm8" firstAttribute="leading" secondItem="DSr-Cq-WjE" secondAttribute="leading" constant="16" id="ecT-UJ-ZUo"/>
-                            <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="MLN-bC-1fP" secondAttribute="trailing" constant="16" id="fHS-vh-VKO"/>
                             <constraint firstItem="mx1-cF-5NT" firstAttribute="top" secondItem="ZpH-5u-myO" secondAttribute="bottom" constant="2" id="fe0-kN-j3m"/>
                             <constraint firstItem="DSr-Cq-WjE" firstAttribute="trailing" secondItem="Fx0-Tm-aUD" secondAttribute="trailing" constant="16" id="gZf-aV-OSo"/>
                             <constraint firstItem="YK6-7o-4uj" firstAttribute="top" secondItem="ZpH-5u-myO" secondAttribute="bottom" constant="30" id="ghd-X7-oiR"/>
@@ -389,7 +389,7 @@
                         <outlet property="dateLabel" destination="pSY-xF-fdu" id="4jQ-c0-xwD"/>
                         <outlet property="dotView" destination="rRL-RR-uWP" id="RU8-2b-0ua"/>
                         <outlet property="feeLabel" destination="mx1-cF-5NT" id="GJC-ou-ksC"/>
-                        <outlet property="identifierLabel" destination="MLN-bC-1fP" id="Uap-5B-543"/>
+                        <outlet property="identifierButton" destination="dWn-kT-uvD" id="bh2-DH-h1V"/>
                         <outlet property="nonceLabel" destination="W6B-wc-UDS" id="G3z-Dp-UgD"/>
                         <outlet property="nonceTitleLabel" destination="F0N-Rw-q7C" id="aDw-9E-5lm"/>
                         <outlet property="recvButton" destination="H0c-iL-i9U" id="r1T-cU-kxU"/>

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -120,7 +120,8 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
         currencyCodesToMode = [
             "btc" : .api_only,
             "eth" : .api_only,
-            "bch" : .p2p_only,
+            "bch" : .api_only,
+            "bsv" : .p2p_only,
             "xrp" : .api_only,
             "hbar" : .api_only
             ]
@@ -371,6 +372,7 @@ extension Network {
         switch type {
         case .btc: return "bitcoin"
         case .bch: return (isMainnet ? "bitcoincash" : "bchtest")
+        case .bsv: return "bitcoinsv"
         case .eth: return "ethereum"
         case .xrp: return "ripple"
         case .hbar: return "hedera"

--- a/WalletKitSwift/WalletKitDemo/Source/TransferViewController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferViewController.swift
@@ -78,7 +78,7 @@ class TransferViewController: UIViewController, TransferListener, WalletManagerL
         sendButton.setTitle(transfer.source?.description ?? "<unknown>", for: .normal)
         recvButton.setTitle(transfer.target?.description ?? "<unknown>", for: .normal)
 
-        identifierLabel.text = hash.map { $0.description } ?? "<pending>"
+        identifierButton.setTitle(hash.map { $0.description } ?? "<pending>", for: .normal)
 
         confLabel.text = transfer.confirmation.map { "Yes @ \($0.blockNumber)" } ?? "No"
         confCountLabel.text = transfer.confirmations?.description ?? ""
@@ -227,7 +227,7 @@ class TransferViewController: UIViewController, TransferListener, WalletManagerL
     @IBOutlet var dateLabel: UILabel!
     @IBOutlet var sendButton: UIButton!
     @IBOutlet var recvButton: UIButton!
-    @IBOutlet var identifierLabel: UILabel!
+    @IBOutlet var identifierButton: UIButton!
     @IBOutlet var confLabel: UILabel!
     @IBOutlet var confCountLabel: UILabel!
     @IBOutlet var stateLabel: UILabel!


### PR DESCRIPTION
Added network definition and chain params for BSV mainnet and testnet. Update logic for BTC/BCH address handling to support BSV (legacy) addresses.
