### PR TITLE
CORE-952: ETH Unit Tests using mainnet 'loan(C)' paperKey

### DIFF
--- a/WalletKitJava/CoreNative/CMakeLists.txt
+++ b/WalletKitJava/CoreNative/CMakeLists.txt
@@ -40,364 +40,364 @@ add_library( # Sets the name of the library.
 # Support
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/support/BRAddress.c
-                src/main/cpp/core/support/BRAddress.h
-                src/main/cpp/core/support/BRAssert.c
-                src/main/cpp/core/support/BRAssert.h
-                src/main/cpp/core/support/BRArray.h
-                src/main/cpp/core/support/BRBase.h
-                src/main/cpp/core/support/BRBIP32Sequence.c
-                src/main/cpp/core/support/BRBIP32Sequence.h
-                src/main/cpp/core/support/BRBIP39Mnemonic.c
-                src/main/cpp/core/support/BRBIP39Mnemonic.h
-                src/main/cpp/core/support/BRBIP39WordsEn.h
-                src/main/cpp/core/support/BRBase58.c
-                src/main/cpp/core/support/BRBase58.h
-                src/main/cpp/core/support/BRBech32.c
-                src/main/cpp/core/support/BRBech32.h
-                src/main/cpp/core/support/BRCrypto.c
-                src/main/cpp/core/support/BRCrypto.h
-                src/main/cpp/core/support/BRFileService.c
-                src/main/cpp/core/support/BRFileService.h
-                src/main/cpp/core/support/BRInt.h
-                src/main/cpp/core/support/BRKey.c
-                src/main/cpp/core/support/BRKey.h
-                src/main/cpp/core/support/BRKeyECIES.c
-                src/main/cpp/core/support/BRKeyECIES.h
-                src/main/cpp/core/support/BRSet.c
-                src/main/cpp/core/support/BRSet.h)
+                src/main/cpp/core/src/support/BRAddress.c
+                src/main/cpp/core/src/support/BRAddress.h
+                src/main/cpp/core/src/support/BRAssert.c
+                src/main/cpp/core/src/support/BRAssert.h
+                src/main/cpp/core/src/support/BRArray.h
+                src/main/cpp/core/src/support/BRBase.h
+                src/main/cpp/core/src/support/BRBIP32Sequence.c
+                src/main/cpp/core/src/support/BRBIP32Sequence.h
+                src/main/cpp/core/src/support/BRBIP39Mnemonic.c
+                src/main/cpp/core/src/support/BRBIP39Mnemonic.h
+                src/main/cpp/core/src/support/BRBIP39WordsEn.h
+                src/main/cpp/core/src/support/BRBase58.c
+                src/main/cpp/core/src/support/BRBase58.h
+                src/main/cpp/core/src/support/BRBech32.c
+                src/main/cpp/core/src/support/BRBech32.h
+                src/main/cpp/core/src/support/BRCrypto.c
+                src/main/cpp/core/src/support/BRCrypto.h
+                src/main/cpp/core/src/support/BRFileService.c
+                src/main/cpp/core/src/support/BRFileService.h
+                src/main/cpp/core/src/support/BRInt.h
+                src/main/cpp/core/src/support/BRKey.c
+                src/main/cpp/core/src/support/BRKey.h
+                src/main/cpp/core/src/support/BRKeyECIES.c
+                src/main/cpp/core/src/support/BRKeyECIES.h
+                src/main/cpp/core/src/support/BRSet.c
+                src/main/cpp/core/src/support/BRSet.h)
 
 # Support Tests
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_sources (corecrypto
                     PRIVATE
-                    src/main/cpp/core/support/testSup.c)
+                    src/main/cpp/core/src/support/testSup.c)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # Bitcoin
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/bitcoin/BRBIP38Key.c
-                src/main/cpp/core/bitcoin/BRBIP38Key.h
-                src/main/cpp/core/bitcoin/BRBloomFilter.c
-                src/main/cpp/core/bitcoin/BRBloomFilter.h
-                src/main/cpp/core/bitcoin/BRChainParams.h
-                src/main/cpp/core/bitcoin/BRChainParams.c
-                src/main/cpp/core/bitcoin/BRMerkleBlock.c
-                src/main/cpp/core/bitcoin/BRMerkleBlock.h
-                src/main/cpp/core/bitcoin/BRPaymentProtocol.c
-                src/main/cpp/core/bitcoin/BRPaymentProtocol.h
-                src/main/cpp/core/bitcoin/BRPeer.c
-                src/main/cpp/core/bitcoin/BRPeer.h
-                src/main/cpp/core/bitcoin/BRPeerManager.c
-                src/main/cpp/core/bitcoin/BRPeerManager.h
-                src/main/cpp/core/bitcoin/BRSyncManager.c
-                src/main/cpp/core/bitcoin/BRSyncManager.h
-                src/main/cpp/core/bitcoin/BRTransaction.c
-                src/main/cpp/core/bitcoin/BRTransaction.h
-                src/main/cpp/core/bitcoin/BRWallet.c
-                src/main/cpp/core/bitcoin/BRWallet.h
-                src/main/cpp/core/bitcoin/BRWalletManager.c
-                src/main/cpp/core/bitcoin/BRWalletManager.h
-                src/main/cpp/core/bitcoin/BRWalletManagerEvent.c
-                src/main/cpp/core/bitcoin/BRWalletManagerPrivate.h)
+                src/main/cpp/core/src/bitcoin/BRBIP38Key.c
+                src/main/cpp/core/src/bitcoin/BRBIP38Key.h
+                src/main/cpp/core/src/bitcoin/BRBloomFilter.c
+                src/main/cpp/core/src/bitcoin/BRBloomFilter.h
+                src/main/cpp/core/src/bitcoin/BRChainParams.h
+                src/main/cpp/core/src/bitcoin/BRChainParams.c
+                src/main/cpp/core/src/bitcoin/BRMerkleBlock.c
+                src/main/cpp/core/src/bitcoin/BRMerkleBlock.h
+                src/main/cpp/core/src/bitcoin/BRPaymentProtocol.c
+                src/main/cpp/core/src/bitcoin/BRPaymentProtocol.h
+                src/main/cpp/core/src/bitcoin/BRPeer.c
+                src/main/cpp/core/src/bitcoin/BRPeer.h
+                src/main/cpp/core/src/bitcoin/BRPeerManager.c
+                src/main/cpp/core/src/bitcoin/BRPeerManager.h
+                src/main/cpp/core/src/bitcoin/BRSyncManager.c
+                src/main/cpp/core/src/bitcoin/BRSyncManager.h
+                src/main/cpp/core/src/bitcoin/BRTransaction.c
+                src/main/cpp/core/src/bitcoin/BRTransaction.h
+                src/main/cpp/core/src/bitcoin/BRWallet.c
+                src/main/cpp/core/src/bitcoin/BRWallet.h
+                src/main/cpp/core/src/bitcoin/BRWalletManager.c
+                src/main/cpp/core/src/bitcoin/BRWalletManager.h
+                src/main/cpp/core/src/bitcoin/BRWalletManagerEvent.c
+                src/main/cpp/core/src/bitcoin/BRWalletManagerPrivate.h)
 
 # Bitcoin Tests
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_sources (corecrypto
                     PRIVATE
-                    src/main/cpp/core/bitcoin/test.c
-                    src/main/cpp/core/bitcoin/testBwm.c)
+                    src/main/cpp/core/src/bitcoin/test.c
+                    src/main/cpp/core/src/bitcoin/testBwm.c)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # BCash
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/bcash/BRBCashAddr.c
-                src/main/cpp/core/bcash/BRBCashAddr.h
-                src/main/cpp/core/bcash/BRBCashParams.h
-                src/main/cpp/core/bcash/BRBCashParams.c)
+                src/main/cpp/core/src/bcash/BRBCashAddr.c
+                src/main/cpp/core/src/bcash/BRBCashAddr.h
+                src/main/cpp/core/src/bcash/BRBCashParams.h
+                src/main/cpp/core/src/bcash/BRBCashParams.c)
 
 # Ethereum
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/ethereum/BREthereum.h
+                src/main/cpp/core/src/ethereum/BREthereum.h
                 # Util
-                src/main/cpp/core/ethereum/util/BRKeccak.c
-                src/main/cpp/core/ethereum/util/BRKeccak.h
-                src/main/cpp/core/ethereum/util/BRUtil.h
-                src/main/cpp/core/ethereum/util/BRUtilHex.c
-                src/main/cpp/core/ethereum/util/BRUtilHex.h
-                src/main/cpp/core/ethereum/util/BRUtilMath.c
-                src/main/cpp/core/ethereum/util/BRUtilMath.h
-                src/main/cpp/core/ethereum/util/BRUtilMathParse.c
+                src/main/cpp/core/src/ethereum/util/BRKeccak.c
+                src/main/cpp/core/src/ethereum/util/BRKeccak.h
+                src/main/cpp/core/src/ethereum/util/BRUtil.h
+                src/main/cpp/core/src/ethereum/util/BRUtilHex.c
+                src/main/cpp/core/src/ethereum/util/BRUtilHex.h
+                src/main/cpp/core/src/ethereum/util/BRUtilMath.c
+                src/main/cpp/core/src/ethereum/util/BRUtilMath.h
+                src/main/cpp/core/src/ethereum/util/BRUtilMathParse.c
                 # RLP
-                src/main/cpp/core/ethereum/rlp/BRRlp.h
-                src/main/cpp/core/ethereum/rlp/BRRlpCoder.c
-                src/main/cpp/core/ethereum/rlp/BRRlpCoder.h
+                src/main/cpp/core/src/ethereum/rlp/BRRlp.h
+                src/main/cpp/core/src/ethereum/rlp/BRRlpCoder.c
+                src/main/cpp/core/src/ethereum/rlp/BRRlpCoder.h
                 # Event
-                src/main/cpp/core/ethereum/event/BREvent.c
-                src/main/cpp/core/ethereum/event/BREvent.h
-                src/main/cpp/core/ethereum/event/BREventAlarm.c
-                src/main/cpp/core/ethereum/event/BREventAlarm.h
-                src/main/cpp/core/ethereum/event/BREventQueue.c
-                src/main/cpp/core/ethereum/event/BREventQueue.h
+                src/main/cpp/core/src/ethereum/event/BREvent.c
+                src/main/cpp/core/src/ethereum/event/BREvent.h
+                src/main/cpp/core/src/ethereum/event/BREventAlarm.c
+                src/main/cpp/core/src/ethereum/event/BREventAlarm.h
+                src/main/cpp/core/src/ethereum/event/BREventQueue.c
+                src/main/cpp/core/src/ethereum/event/BREventQueue.h
                 # Base
-                src/main/cpp/core/ethereum/base/BREthereumAddress.c
-                src/main/cpp/core/ethereum/base/BREthereumAddress.h
-                src/main/cpp/core/ethereum/base/BREthereumBase.h
-                src/main/cpp/core/ethereum/base/BREthereumEther.c
-                src/main/cpp/core/ethereum/base/BREthereumEther.h
-                src/main/cpp/core/ethereum/base/BREthereumGas.c
-                src/main/cpp/core/ethereum/base/BREthereumGas.h
-                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.c
-                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.h
-                src/main/cpp/core/ethereum/base/BREthereumHash.c
-                src/main/cpp/core/ethereum/base/BREthereumHash.h
-                src/main/cpp/core/ethereum/base/BREthereumData.c
-                src/main/cpp/core/ethereum/base/BREthereumData.h
-                src/main/cpp/core/ethereum/base/BREthereumLogic.h
-                src/main/cpp/core/ethereum/base/BREthereumSignature.c
-                src/main/cpp/core/ethereum/base/BREthereumSignature.h
+                src/main/cpp/core/src/ethereum/base/BREthereumAddress.c
+                src/main/cpp/core/src/ethereum/base/BREthereumAddress.h
+                src/main/cpp/core/src/ethereum/base/BREthereumBase.h
+                src/main/cpp/core/src/ethereum/base/BREthereumEther.c
+                src/main/cpp/core/src/ethereum/base/BREthereumEther.h
+                src/main/cpp/core/src/ethereum/base/BREthereumGas.c
+                src/main/cpp/core/src/ethereum/base/BREthereumGas.h
+                src/main/cpp/core/src/ethereum/base/BREthereumFeeBasis.c
+                src/main/cpp/core/src/ethereum/base/BREthereumFeeBasis.h
+                src/main/cpp/core/src/ethereum/base/BREthereumHash.c
+                src/main/cpp/core/src/ethereum/base/BREthereumHash.h
+                src/main/cpp/core/src/ethereum/base/BREthereumData.c
+                src/main/cpp/core/src/ethereum/base/BREthereumData.h
+                src/main/cpp/core/src/ethereum/base/BREthereumLogic.h
+                src/main/cpp/core/src/ethereum/base/BREthereumSignature.c
+                src/main/cpp/core/src/ethereum/base/BREthereumSignature.h
                 # Block Chain
-                src/main/cpp/core/ethereum/blockchain/BREthereumAccountState.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumAccountState.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumBlock.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumBlock.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumBlockChain.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumBloomFilter.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumBloomFilter.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumLog.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumLog.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumNetwork.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumNetwork.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransaction.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransaction.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransactionReceipt.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransactionReceipt.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransactionStatus.c
-                src/main/cpp/core/ethereum/blockchain/BREthereumTransactionStatus.h
-                src/main/cpp/core/ethereum/blockchain/BREthereumProofOfWork.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumAccountState.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumAccountState.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumBlock.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumBlock.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumBlockChain.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumBloomFilter.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumBloomFilter.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumLog.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumLog.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumNetwork.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumNetwork.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransaction.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransaction.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransactionReceipt.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransactionReceipt.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransactionStatus.c
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumTransactionStatus.h
+                src/main/cpp/core/src/ethereum/blockchain/BREthereumProofOfWork.c
                 # Contract
-                src/main/cpp/core/ethereum/contract/BREthereumContract.c
-                src/main/cpp/core/ethereum/contract/BREthereumContract.h
-                src/main/cpp/core/ethereum/contract/BREthereumToken.c
-                src/main/cpp/core/ethereum/contract/BREthereumToken.h
+                src/main/cpp/core/src/ethereum/contract/BREthereumContract.c
+                src/main/cpp/core/src/ethereum/contract/BREthereumContract.h
+                src/main/cpp/core/src/ethereum/contract/BREthereumToken.c
+                src/main/cpp/core/src/ethereum/contract/BREthereumToken.h
                 # MPT
-                src/main/cpp/core/ethereum/mpt/BREthereumMPT.c
-                src/main/cpp/core/ethereum/mpt/BREthereumMPT.h
+                src/main/cpp/core/src/ethereum/mpt/BREthereumMPT.c
+                src/main/cpp/core/src/ethereum/mpt/BREthereumMPT.h
                 # LES Msg
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageDIS.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageDIS.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageETH.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageLES.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageLES.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageP2P.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageP2P.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessagePIP.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessagePIP.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageDIS.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageDIS.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageETH.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageLES.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageLES.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageP2P.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageP2P.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessagePIP.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessagePIP.h
                 # LES
-                src/main/cpp/core/ethereum/les/BREthereumLES.c
-                src/main/cpp/core/ethereum/les/BREthereumLES.h
-                src/main/cpp/core/ethereum/les/BREthereumLESBase.h
-                src/main/cpp/core/ethereum/les/BREthereumLESFrameCoder.c
-                src/main/cpp/core/ethereum/les/BREthereumLESFrameCoder.h
-                src/main/cpp/core/ethereum/les/BREthereumLESRandom.c
-                src/main/cpp/core/ethereum/les/BREthereumLESRandom.h
-                src/main/cpp/core/ethereum/les/BREthereumMessage.c
-                src/main/cpp/core/ethereum/les/BREthereumMessage.h
-                src/main/cpp/core/ethereum/les/BREthereumNode.c
-                src/main/cpp/core/ethereum/les/BREthereumNode.h
-                src/main/cpp/core/ethereum/les/BREthereumNodeEndpoint.c
-                src/main/cpp/core/ethereum/les/BREthereumNodeEndpoint.h
-                src/main/cpp/core/ethereum/les/BREthereumProvision.c
-                src/main/cpp/core/ethereum/les/BREthereumProvision.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageP2P.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageP2P.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageDIS.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageDIS.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageETH.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageLES.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessageLES.c
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessagePIP.h
-                src/main/cpp/core/ethereum/les/msg/BREthereumMessagePIP.c
+                src/main/cpp/core/src/ethereum/les/BREthereumLES.c
+                src/main/cpp/core/src/ethereum/les/BREthereumLES.h
+                src/main/cpp/core/src/ethereum/les/BREthereumLESBase.h
+                src/main/cpp/core/src/ethereum/les/BREthereumLESFrameCoder.c
+                src/main/cpp/core/src/ethereum/les/BREthereumLESFrameCoder.h
+                src/main/cpp/core/src/ethereum/les/BREthereumLESRandom.c
+                src/main/cpp/core/src/ethereum/les/BREthereumLESRandom.h
+                src/main/cpp/core/src/ethereum/les/BREthereumMessage.c
+                src/main/cpp/core/src/ethereum/les/BREthereumMessage.h
+                src/main/cpp/core/src/ethereum/les/BREthereumNode.c
+                src/main/cpp/core/src/ethereum/les/BREthereumNode.h
+                src/main/cpp/core/src/ethereum/les/BREthereumNodeEndpoint.c
+                src/main/cpp/core/src/ethereum/les/BREthereumNodeEndpoint.h
+                src/main/cpp/core/src/ethereum/les/BREthereumProvision.c
+                src/main/cpp/core/src/ethereum/les/BREthereumProvision.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageP2P.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageP2P.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageDIS.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageDIS.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageETH.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageLES.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessageLES.c
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessagePIP.h
+                src/main/cpp/core/src/ethereum/les/msg/BREthereumMessagePIP.c
                 # BCS
-                src/main/cpp/core/ethereum/bcs/BREthereumBCS.c
-                src/main/cpp/core/ethereum/bcs/BREthereumBCS.h
-                src/main/cpp/core/ethereum/bcs/BREthereumBCSEvent.c
-                src/main/cpp/core/ethereum/bcs/BREthereumBCSPrivate.h
-                src/main/cpp/core/ethereum/bcs/BREthereumBCSSync.c
-                src/main/cpp/core/ethereum/bcs/BREthereumBlockChainSlice.h
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBCS.c
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBCS.h
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBCSEvent.c
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBCSPrivate.h
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBCSSync.c
+                src/main/cpp/core/src/ethereum/bcs/BREthereumBlockChainSlice.h
                 #EWM
-                src/main/cpp/core/ethereum/ewm/BREthereumBase.h
-                src/main/cpp/core/ethereum/ewm/BREthereumAccount.c
-                src/main/cpp/core/ethereum/ewm/BREthereumAccount.h
-                src/main/cpp/core/ethereum/ewm/BREthereumAmount.c
-                src/main/cpp/core/ethereum/ewm/BREthereumAmount.h
-                src/main/cpp/core/ethereum/ewm/BREthereumTransfer.c
-                src/main/cpp/core/ethereum/ewm/BREthereumTransfer.h
-                src/main/cpp/core/ethereum/ewm/BREthereumWallet.c
-                src/main/cpp/core/ethereum/ewm/BREthereumWallet.h
-                src/main/cpp/core/ethereum/ewm/BREthereumClient.h
-                src/main/cpp/core/ethereum/ewm/BREthereumEWM.c
-                src/main/cpp/core/ethereum/ewm/BREthereumEWM.h
-                src/main/cpp/core/ethereum/ewm/BREthereumEWMClient.c
-                src/main/cpp/core/ethereum/ewm/BREthereumEWMEvent.c
-                src/main/cpp/core/ethereum/ewm/BREthereumEWMPersist.c
-                src/main/cpp/core/ethereum/ewm/BREthereumEWMPrivate.h)
+                src/main/cpp/core/src/ethereum/ewm/BREthereumBase.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumAccount.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumAccount.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumAmount.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumAmount.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumTransfer.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumTransfer.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumWallet.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumWallet.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumClient.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWM.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWM.h
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWMClient.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWMEvent.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWMPersist.c
+                src/main/cpp/core/src/ethereum/ewm/BREthereumEWMPrivate.h)
 
 # Ethereum Tests
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_sources (corecrypto
                     PRIVATE
-                    src/main/cpp/core/ethereum/base/testBase.c
-                    src/main/cpp/core/ethereum/blockchain/testBc.c
-                    src/main/cpp/core/ethereum/contract/testContract.c
-                    src/main/cpp/core/ethereum/event/testEvent.c
-                    src/main/cpp/core/ethereum/ewm/testEwm.c
-                    src/main/cpp/core/ethereum/rlp/testRlp.c
-                    src/main/cpp/core/ethereum/les/testLES.c
-                    src/main/cpp/core/ethereum/util/testUtil.c
-                    src/main/cpp/core/ethereum/test.c)
+                    src/main/cpp/core/src/ethereum/base/testBase.c
+                    src/main/cpp/core/src/ethereum/blockchain/testBc.c
+                    src/main/cpp/core/src/ethereum/contract/testContract.c
+                    src/main/cpp/core/src/ethereum/event/testEvent.c
+                    src/main/cpp/core/src/ethereum/ewm/testEwm.c
+                    src/main/cpp/core/src/ethereum/rlp/testRlp.c
+                    src/main/cpp/core/src/ethereum/les/testLES.c
+                    src/main/cpp/core/src/ethereum/util/testUtil.c
+                    src/main/cpp/core/src/ethereum/test.c)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # Ripple
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/ripple/BRRipplePrivateStructs.h
-                src/main/cpp/core/ripple/BRRippleBase.h
-                src/main/cpp/core/ripple/BRRipple.h
-                src/main/cpp/core/ripple/BRRippleAccount.c
-                src/main/cpp/core/ripple/BRRippleAccount.h
-                src/main/cpp/core/ripple/BRRippleAddress.c
-                src/main/cpp/core/ripple/BRRippleAddress.h
-                src/main/cpp/core/ripple/BRRippleBase58.c
-                src/main/cpp/core/ripple/BRRippleBase58.h
-                src/main/cpp/core/ripple/BRRippleFeeBasis.c
-                src/main/cpp/core/ripple/BRRippleFeeBasis.h
-                src/main/cpp/core/ripple/BRRippleSerialize.c
-                src/main/cpp/core/ripple/BRRippleSerialize.h
-                src/main/cpp/core/ripple/BRRippleSignature.c
-                src/main/cpp/core/ripple/BRRippleSignature.h
-                src/main/cpp/core/ripple/BRRippleTransaction.c
-                src/main/cpp/core/ripple/BRRippleTransaction.h
-                src/main/cpp/core/ripple/BRRippleTransfer.c
-                src/main/cpp/core/ripple/BRRippleTransfer.h
-                src/main/cpp/core/ripple/BRRippleUtils.c
-                src/main/cpp/core/ripple/BRRippleUtils.h
-                src/main/cpp/core/ripple/BRRippleWallet.c
-                src/main/cpp/core/ripple/BRRippleWallet.h)
+                src/main/cpp/core/src/ripple/BRRipplePrivateStructs.h
+                src/main/cpp/core/src/ripple/BRRippleBase.h
+                src/main/cpp/core/src/ripple/BRRipple.h
+                src/main/cpp/core/src/ripple/BRRippleAccount.c
+                src/main/cpp/core/src/ripple/BRRippleAccount.h
+                src/main/cpp/core/src/ripple/BRRippleAddress.c
+                src/main/cpp/core/src/ripple/BRRippleAddress.h
+                src/main/cpp/core/src/ripple/BRRippleBase58.c
+                src/main/cpp/core/src/ripple/BRRippleBase58.h
+                src/main/cpp/core/src/ripple/BRRippleFeeBasis.c
+                src/main/cpp/core/src/ripple/BRRippleFeeBasis.h
+                src/main/cpp/core/src/ripple/BRRippleSerialize.c
+                src/main/cpp/core/src/ripple/BRRippleSerialize.h
+                src/main/cpp/core/src/ripple/BRRippleSignature.c
+                src/main/cpp/core/src/ripple/BRRippleSignature.h
+                src/main/cpp/core/src/ripple/BRRippleTransaction.c
+                src/main/cpp/core/src/ripple/BRRippleTransaction.h
+                src/main/cpp/core/src/ripple/BRRippleTransfer.c
+                src/main/cpp/core/src/ripple/BRRippleTransfer.h
+                src/main/cpp/core/src/ripple/BRRippleUtils.c
+                src/main/cpp/core/src/ripple/BRRippleUtils.h
+                src/main/cpp/core/src/ripple/BRRippleWallet.c
+                src/main/cpp/core/src/ripple/BRRippleWallet.h)
 
 # Ripple Tests
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_sources (corecrypto
                     PRIVATE
-                    src/main/cpp/core/ripple/testRipple.c
-                    src/main/cpp/core/ripple/testRippleTxList1.h
-                    src/main/cpp/core/ripple/testRippleTxList2.h)
+                    src/main/cpp/core/src/ripple/testRipple.c
+                    src/main/cpp/core/src/ripple/testRippleTxList1.h
+                    src/main/cpp/core/src/ripple/testRippleTxList2.h)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # Generic
 target_sources (corecrypto
                 PRIVATE
-                src/main/cpp/core/generic/BRGenericBase.h
-                src/main/cpp/core/generic/BRGeneric.c
-                src/main/cpp/core/generic/BRGeneric.h
-                src/main/cpp/core/generic/BRGenericClient.c
-                src/main/cpp/core/generic/BRGenericClient.h
-                src/main/cpp/core/generic/BRGenericHandlers.c
-                src/main/cpp/core/generic/BRGenericHandlers.h
-                src/main/cpp/core/generic/BRGenericManager.c
-                src/main/cpp/core/generic/BRGenericRipple.h
-                src/main/cpp/core/generic/BRGenericRipple.c)
+                src/main/cpp/core/src/generic/BRGenericBase.h
+                src/main/cpp/core/src/generic/BRGeneric.c
+                src/main/cpp/core/src/generic/BRGeneric.h
+                src/main/cpp/core/src/generic/BRGenericClient.c
+                src/main/cpp/core/src/generic/BRGenericClient.h
+                src/main/cpp/core/src/generic/BRGenericHandlers.c
+                src/main/cpp/core/src/generic/BRGenericHandlers.h
+                src/main/cpp/core/src/generic/BRGenericManager.c
+                src/main/cpp/core/src/generic/BRGenericRipple.h
+                src/main/cpp/core/src/generic/BRGenericRipple.c)
 
 # Crypto
 target_sources (corecrypto
                 PRIVATE
                 #  Dependency Order
                 src/main/cpp/core/include/BRCryptoBase.h
-                src/main/cpp/core/crypto/BRCryptoBaseP.h
+                src/main/cpp/core/src/crypto/BRCryptoBaseP.h
 
                 src/main/cpp/core/include/BRCryptoStatus.h
-                src/main/cpp/core/crypto/BRCryptoStatusP.h
-                src/main/cpp/core/crypto/BRCryptoStatus.c
+                src/main/cpp/core/src/crypto/BRCryptoStatusP.h
+                src/main/cpp/core/src/crypto/BRCryptoStatus.c
 
                 src/main/cpp/core/include/BRCryptoHash.h
-                src/main/cpp/core/crypto/BRCryptoHashP.h
-                src/main/cpp/core/crypto/BRCryptoHash.c
+                src/main/cpp/core/src/crypto/BRCryptoHashP.h
+                src/main/cpp/core/src/crypto/BRCryptoHash.c
 
                 src/main/cpp/core/include/BRCryptoCurrency.h
-                src/main/cpp/core/crypto/BRCryptoCurrency.c
+                src/main/cpp/core/src/crypto/BRCryptoCurrency.c
 
                 src/main/cpp/core/include/BRCryptoUnit.h
-                src/main/cpp/core/crypto/BRCryptoUnit.c
+                src/main/cpp/core/src/crypto/BRCryptoUnit.c
 
                 src/main/cpp/core/include/BRCryptoAmount.h
-                src/main/cpp/core/crypto/BRCryptoAmountP.h
-                src/main/cpp/core/crypto/BRCryptoAmount.c
+                src/main/cpp/core/src/crypto/BRCryptoAmountP.h
+                src/main/cpp/core/src/crypto/BRCryptoAmount.c
 
                 src/main/cpp/core/include/BRCryptoKey.h
-                src/main/cpp/core/crypto/BRCryptoKeyP.h
-                src/main/cpp/core/crypto/BRCryptoKey.c
+                src/main/cpp/core/src/crypto/BRCryptoKeyP.h
+                src/main/cpp/core/src/crypto/BRCryptoKey.c
 
                 src/main/cpp/core/include/BRCryptoAccount.h
-                src/main/cpp/core/crypto/BRCryptoAccountP.h
-                src/main/cpp/core/crypto/BRCryptoAccount.c
+                src/main/cpp/core/src/crypto/BRCryptoAccountP.h
+                src/main/cpp/core/src/crypto/BRCryptoAccount.c
 
                 src/main/cpp/core/include/BRCryptoFeeBasis.h
-                src/main/cpp/core/crypto/BRCryptoFeeBasisP.h
-                src/main/cpp/core/crypto/BRCryptoFeeBasis.c
+                src/main/cpp/core/src/crypto/BRCryptoFeeBasisP.h
+                src/main/cpp/core/src/crypto/BRCryptoFeeBasis.c
 
                 src/main/cpp/core/include/BRCryptoNetwork.h
-                src/main/cpp/core/crypto/BRCryptoNetworkP.h
-                src/main/cpp/core/crypto/BRCryptoNetwork.c
+                src/main/cpp/core/src/crypto/BRCryptoNetworkP.h
+                src/main/cpp/core/src/crypto/BRCryptoNetwork.c
 
                 src/main/cpp/core/include/BRCryptoAddress.h
-                src/main/cpp/core/crypto/BRCryptoAddressP.h
-                src/main/cpp/core/crypto/BRCryptoAddress.c
+                src/main/cpp/core/src/crypto/BRCryptoAddressP.h
+                src/main/cpp/core/src/crypto/BRCryptoAddress.c
 
                 src/main/cpp/core/include/BRCryptoPeer.h
-                src/main/cpp/core/crypto/BRCryptoPeer.c
+                src/main/cpp/core/src/crypto/BRCryptoPeer.c
 
                 src/main/cpp/core/include/BRCryptoTransfer.h
-                src/main/cpp/core/crypto/BRCryptoTransferP.h
-                src/main/cpp/core/crypto/BRCryptoTransfer.c
+                src/main/cpp/core/src/crypto/BRCryptoTransferP.h
+                src/main/cpp/core/src/crypto/BRCryptoTransfer.c
 
                 src/main/cpp/core/include/BRCryptoPayment.h
-                src/main/cpp/core/crypto/BRCryptoPaymentP.h
-                src/main/cpp/core/crypto/BRCryptoPayment.c
+                src/main/cpp/core/src/crypto/BRCryptoPaymentP.h
+                src/main/cpp/core/src/crypto/BRCryptoPayment.c
 
                 src/main/cpp/core/include/BRCryptoWallet.h
-                src/main/cpp/core/crypto/BRCryptoWalletP.h
-                src/main/cpp/core/crypto/BRCryptoWallet.c
+                src/main/cpp/core/src/crypto/BRCryptoWalletP.h
+                src/main/cpp/core/src/crypto/BRCryptoWallet.c
 
                 src/main/cpp/core/include/BRCryptoSync.h
 
                 src/main/cpp/core/include/BRCryptoWalletManagerClient.h
-                src/main/cpp/core/crypto/BRCryptoWalletManagerClient.c
+                src/main/cpp/core/src/crypto/BRCryptoWalletManagerClient.c
 
                 src/main/cpp/core/include/BRCryptoWalletManager.h
-                src/main/cpp/core/crypto/BRCryptoWalletManagerP.h
-                src/main/cpp/core/crypto/BRCryptoWalletManager.c
+                src/main/cpp/core/src/crypto/BRCryptoWalletManagerP.h
+                src/main/cpp/core/src/crypto/BRCryptoWalletManager.c
 
                 src/main/cpp/core/include/BRCryptoCipher.h
-                src/main/cpp/core/crypto/BRCryptoCipher.c
+                src/main/cpp/core/src/crypto/BRCryptoCipher.c
 
                 src/main/cpp/core/include/BRCryptoCoder.h
-                src/main/cpp/core/crypto/BRCryptoCoder.c
+                src/main/cpp/core/src/crypto/BRCryptoCoder.c
 
                 src/main/cpp/core/include/BRCryptoHasher.h
-                src/main/cpp/core/crypto/BRCryptoHasher.c
+                src/main/cpp/core/src/crypto/BRCryptoHasher.c
 
                 src/main/cpp/core/include/BRCryptoSigner.h
-                src/main/cpp/core/crypto/BRCryptoSigner.c
+                src/main/cpp/core/src/crypto/BRCryptoSigner.c
                 )
 
 # Crypto Tests
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_sources (corecrypto
                     PRIVATE
-                    src/main/cpp/core/crypto/testCrypto.c)
+                    src/main/cpp/core/src/crypto/testCrypto.c)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 # Setup all the include paths
@@ -405,12 +405,12 @@ target_include_directories (corecrypto
                             PUBLIC
                             ${PROJECT_SOURCE_DIR}/src/main/cpp/core
                             ${PROJECT_SOURCE_DIR}/src/main/cpp/core/include
-                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/support
-                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/bitcoin
-                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/bcash
-                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/ethereum
+                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/src/support
+                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/src/bitcoin
+                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/src/bcash
+                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/src/ethereum
                             ${PROJECT_SOURCE_DIR}/src/main/cpp/core/vendor/secp256k1
-                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/crypto)
+                            ${PROJECT_SOURCE_DIR}/src/main/cpp/core/src/crypto)
 
 # Set the DEBUG define when building DEBUG builds
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/WalletKitJava/CoreNative/build.gradle
+++ b/WalletKitJava/CoreNative/build.gradle
@@ -3,36 +3,38 @@ ext {
 
     javaTestSrcDir              = projectDir.absolutePath + "/src/commonTest/java"
 
-    cppSqliteSrcDir             = projectDir.absolutePath + "/../../WalletKitCore/vendor/sqlite3"
+    cppSqliteSrcDir             = projectDir.absolutePath + "/src/main/cpp/core/vendor/sqlite3"
 
-    cppCryptoMainSrcDirs        = [projectDir.absolutePath + "/src/main/cpp/core/bcash",
-                                   projectDir.absolutePath + "/src/main/cpp/core/bitcoin",
-                                   projectDir.absolutePath + "/src/main/cpp/core/crypto",
-                                   projectDir.absolutePath + "/src/main/cpp/core/ethereum",
-                                   projectDir.absolutePath + "/src/main/cpp/core/generic",
-                                   projectDir.absolutePath + "/src/main/cpp/core/hedera",
-                                   projectDir.absolutePath + "/src/main/cpp/core/ripple",
-                                   projectDir.absolutePath + "/src/main/cpp/core/support",
-                                   projectDir.absolutePath + "/../../WalletKitCore/vendor/ed25519"]
+    cppCryptoMainSrcDirs        = [projectDir.absolutePath + "/src/main/cpp/core/src/bcash",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/bitcoin",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/crypto",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/ethereum",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/generic",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/hedera",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/ripple",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/support",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/version",
+                                   projectDir.absolutePath + "/src/main/cpp/core/vendor/ed25519"]
 
-    cppCryptoMainIncDirs        = [projectDir.absolutePath + "/../../WalletKitCore/include",
-                                   projectDir.absolutePath + "/../../WalletKitCore/src",
-                                   projectDir.absolutePath + "/../../WalletKitCore/src/support",
-                                   projectDir.absolutePath + "/../../WalletKitCore/vendor",
-                                   projectDir.absolutePath + "/../../WalletKitCore/vendor/secp256k1"]
+    cppCryptoMainIncDirs        = [projectDir.absolutePath + "/src/main/cpp/core/include",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src",
+                                   projectDir.absolutePath + "/src/main/cpp/core/src/support",
+                                   projectDir.absolutePath + "/src/main/cpp/core/vendor",
+                                   projectDir.absolutePath + "/src/main/cpp/core/vendor/secp256k1"]
 
-    cppCryptoVendorSrcDir       = projectDir.absolutePath + "/../../WalletKitCore/vendor"
+    cppCryptoVendorSrcDir       = projectDir.absolutePath + "/src/main/cpp/core/vendor"
 
-    cppCryptoTestSrcDirs        = [projectDir.absolutePath + "/src/test/cpp/core/bitcoin",
-                                   projectDir.absolutePath + "/src/test/cpp/core/crypto",
-                                   projectDir.absolutePath + "/src/test/cpp/core/ethereum",
-                                   projectDir.absolutePath + "/src/test/cpp/core/hedera",
-                                   projectDir.absolutePath + "/src/test/cpp/core/ripple",
-                                   projectDir.absolutePath + "/src/test/cpp/core/support"]
+    cppCryptoTestSrcDirs        = [projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/bitcoin",
+                                   projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/crypto",
+                                   projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/ethereum",
+                                   projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/hedera",
+                                   projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/ripple",
+                                   projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/support"]
 
-    cppCryptoTestIncDirs        = [] // cppCryptoTestSrcDirs +
-                                  [projectDir.absolutePath + "/../../WalletKitCore/include",
-                                   projectDir.absolutePath + "/../../WalletKitCore/src"]
+    cppCryptoTestIncDirs        = [projectDir.absolutePath + "/src/main/cpp/core/WalletKitCoreTests/test/include"]
+    // cppCryptoTestSrcDirs +
+    //                              [projectDir.absolutePath + "/src/main/cpp/core/include",
+    //                               projectDir.absolutePath + "/src/main/cpp/core/src"]
 
-    cmakeCMakeListsFile         = projectDir.absolutePath + "/../../WalletKitCore/CMakeLists.txt"
+    cmakeCMakeListsFile         = projectDir.absolutePath + "/src/main/cpp/core/CMakeLists.txt"
 }

--- a/WalletKitJava/CoreNative/src/main/cpp/core
+++ b/WalletKitJava/CoreNative/src/main/cpp/core
@@ -1,1 +1,1 @@
-../../../../WalletKitCore/WalletKitCore
+../../../../../WalletKitCore

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoBaseTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoBaseTests.swift
@@ -284,15 +284,19 @@ class CryptoTestSystemListener: SystemListener {
     var transferHandlers: [TransferEventHandler] = []
     var transferEvents: [TransferEvent] = []
     var transferExpectation = XCTestExpectation (description: "TransferExpectation")
+    var transferWallet: Wallet? = nil
 
     func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
+        guard transferWallet.map ({ $0 == wallet }) ?? true
+            else { return }
+
         print ("TST: Transfer Event: \(event)")
         transferEvents.append (event)
         if transferIncluded, case .included = transfer.state {
             if 1 == transferCount { transferExpectation.fulfill()}
             if 1 <= transferCount { transferCount -= 1 }
         }
-        else if case .created = transfer.state {
+        else if !transferIncluded, case .created = transfer.state {
             if 1 == transferCount { transferExpectation.fulfill()}
             if 1 <= transferCount { transferCount -= 1 }
         }

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoSystemTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoSystemTests.swift
@@ -23,8 +23,9 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
 
     func testSystemBTC() {
         isMainnet = false
-        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareAccount()
+
+        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareSystem()
 
         XCTAssertTrue (system.networks.count >= 1)
@@ -111,8 +112,9 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
 
     func testSystemModes () {
         isMainnet = false
-        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareAccount()
+
+        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareSystem()
 
         XCTAssertTrue (system.networks.count >= 1)
@@ -128,8 +130,9 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
 
     func testSystemAddressSchemes () {
         isMainnet = false
-        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareAccount()
+
+        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareSystem()
 
         XCTAssertTrue (system.networks.count >= 1)

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoTransferTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoTransferTests.swift
@@ -50,7 +50,7 @@ struct TransferResult {
 }
 
 class BRCryptoTransferTests: BRCryptoSystemBaseTests {
-    let syncTimeoutInSeconds = 120.0
+    var syncTimeoutInSeconds = 120.0
 
     /// Recv: 0.00010000
     ///
@@ -101,8 +101,9 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
 
     func runTransferBTCTest (mode: WalletManagerMode) {
         isMainnet = false
-        currencyCodesToMode = ["btc":mode]
         prepareAccount (knownAccountSpecification)
+
+        currencyCodesToMode = ["btc":mode]
         prepareSystem()
 
         let knownTransferResults = knownTransferResultsByModeStrangely(mode: mode)
@@ -135,6 +136,8 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
         // Connect and wait for a number of transfers
         listener.transferIncluded = true
         listener.transferCount = knownTransferResults.count
+        self.syncTimeoutInSeconds = 15 * 60
+
         manager.connect()
         wait (for: [listener.transferExpectation], timeout: syncTimeoutInSeconds)
 
@@ -147,6 +150,10 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
         wait (for: [walletManagerDisconnectExpectation], timeout: 5)
 
         let transfers = wallet.transfers
+            .filter { (t) -> Bool in
+                knownTransferResults.contains { (tr) -> Bool in
+                    t.hash.map { $0.description == tr.hash} ?? false }
+        }
         XCTAssertEqual  (transfers.count, knownTransferResults.count)
 
         XCTAssertTrue (zip (knownTransferResults, transfers).reduce(true) {
@@ -198,8 +205,9 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
     /// TODO: This test fails intermittently
     func testTransferBCH_P2P () {
         isMainnet = true
-        currencyCodesToMode = ["bch":WalletManagerMode.p2p_only]
         prepareAccount (identifier: "loan(C)")
+
+        currencyCodesToMode = ["bch":WalletManagerMode.p2p_only]
         prepareSystem()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
@@ -255,7 +263,10 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
         XCTAssertNotNil(wallet)
 
         // Connect and wait for a number of transfers
+        listener.transferIncluded = true
         listener.transferCount = 3
+        listener.transferWallet = wallet
+        
         manager.connect()
         wait (for: [listener.transferExpectation], timeout: 70)
 
@@ -296,14 +307,10 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
     }
 
     func testTransferETH_API () {
-        isMainnet = false
+        isMainnet = true
+        prepareAccount (identifier: "loan(C)")
+
         currencyCodesToMode = ["eth":WalletManagerMode.api_only]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
         prepareSystem()
 
         runTransferETHTest()

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletManagerTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletManagerTests.swift
@@ -39,8 +39,9 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
     func testWalletManagerBTC() {
         isMainnet = false
-        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareAccount()
+
+        currencyCodesToMode = ["btc":WalletManagerMode.api_only]
         prepareSystem()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
@@ -108,7 +109,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
         // Connect
         listener.transferCount = 5
         manager.connect()
-        wait (for: [self.listener.transferExpectation], timeout: 5)
+        wait (for: [self.listener.transferExpectation], timeout: 30)
 
         manager.disconnect()
         wait (for: [walletManagerDisconnectExpectation], timeout: 5)
@@ -118,10 +119,11 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
     }
 
     func testWalletManagerETH () {
-        isMainnet = false
+        isMainnet = true
+        prepareAccount (identifier: "loan(C)")
+
         registerCurrencyCodes = ["brd"]
         currencyCodesToMode = ["eth":WalletManagerMode.api_only]
-        prepareAccount()
 
         let listener = CryptoTestSystemListener (networkCurrencyCodesToMode: currencyCodesToMode,
                                                  registerCurrencyCodes: registerCurrencyCodes,
@@ -211,8 +213,9 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
     func testWalletManagerXRP() {
         isMainnet = true
-        currencyCodesToMode = ["xrp":WalletManagerMode.api_only]
         prepareAccount (identifier: "loan(C)")
+
+        currencyCodesToMode = ["xrp":WalletManagerMode.api_only]
         prepareSystem()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
@@ -295,13 +298,9 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
     func testWalletManagerMigrateBTC () {
         isMainnet = false
+        prepareAccount()
+
         currencyCodesToMode = ["btc":WalletManagerMode.api_only]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
         prepareSystem ()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
@@ -23,15 +23,10 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
     func runWalletBTCTest (mode: WalletManagerMode) {
         isMainnet = false
-        currencyCodesToMode = ["btc":mode]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
+        prepareAccount ()
 
-         prepareSystem ()
+        currencyCodesToMode = ["btc":mode]
+        prepareSystem ()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
         listener.managerHandlers += [
@@ -94,9 +89,10 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
         // Connect and wait for a number of transfers
         listener.transferCount = 10
+        listener.transferWallet = wallet
         manager.connect()
         // In P2P mode we should get 10 transfers in much less than 360 seconds.
-        wait (for: [listener.transferExpectation], timeout: (mode == .p2p_only ? 360 : 10))
+        wait (for: [listener.transferExpectation], timeout: (mode == .p2p_only ? 360 : 30))
 
         // Try again
         transfer = wallet.createTransfer (target: transferTargetAddress,
@@ -172,13 +168,9 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
     func testWalletBCH() {
         isMainnet = false
+        prepareAccount ()
+
         currencyCodesToMode = ["bch":WalletManagerMode.p2p_only]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
         prepareSystem ()
 
         let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
@@ -204,16 +196,12 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         XCTAssertTrue (wallet.hasAddress(walletAddress))
     }
 
-    func testWalletETH() {
-        isMainnet = false
+    func testWalletETH() {        
+        isMainnet = true
+        prepareAccount ()
+
         registerCurrencyCodes = ["brd"]
         currencyCodesToMode = ["eth":WalletManagerMode.api_only]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
         let listener = CryptoTestSystemListener (networkCurrencyCodesToMode: currencyCodesToMode,
                                                   registerCurrencyCodes: registerCurrencyCodes,
                                                   isMainnet: isMainnet)
@@ -308,9 +296,9 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
     func testWalletXRP() {
         isMainnet = true
-        currencyCodesToMode = ["xrp":WalletManagerMode.api_only]
         prepareAccount (identifier: "loan(C)")
 
+        currencyCodesToMode = ["xrp":WalletManagerMode.api_only]
         prepareSystem()
 
         // Connect and wait for a number of transfers


### PR DESCRIPTION
All Swift UnitTests pass except for: `testTransferBTC_P2P()` and `testSubscription()` - neither is ETH related.

All Java UnitTest pass except: `testNetworkETH` on a hardcoded fee basis comparison (that can't succeed with dynamic fee from Blockset) and `testAmountCreateBtc` with the number formatter producing "(...)" but expected "-..."