### PR TITLE
CORE-958: In BlockChainDB, use "include_transfers"

### DIFF
--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -1750,6 +1750,7 @@ final class System implements com.breadwallet.crypto.System {
                                 endBlockNumberUnsigned.equals(BRConstants.BLOCK_HEIGHT_UNBOUND) ? null : endBlockNumberUnsigned,
                                 true,
                                 false,
+                                false,
                                 new CompletionHandler<List<Transaction>, QueryError>() {
                                     @Override
                                     public void handleData(List<Transaction> transactions) {
@@ -1934,7 +1935,9 @@ final class System implements com.breadwallet.crypto.System {
                                         begBlockNumberUnsigned.equals(BRConstants.BLOCK_HEIGHT_UNBOUND) ? null : begBlockNumberUnsigned,
                                         endBlockNumberUnsigned.equals(BRConstants.BLOCK_HEIGHT_UNBOUND) ? null : endBlockNumberUnsigned,
                                         false,
-                                        false, new CompletionHandler<List<Transaction>, QueryError>() {
+                                        false,
+                                        true,
+                                        new CompletionHandler<List<Transaction>, QueryError>() {
                                             @Override
                                             public void handleData(List<Transaction> transactions) {
                                                 boolean success = false;

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/WalletSweeper.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/WalletSweeper.java
@@ -163,6 +163,7 @@ final class WalletSweeper implements com.breadwallet.crypto.WalletSweeper {
                 network.getHeight(),
                 true,
                 false,
+                false,
                 new CompletionHandler<List<Transaction>, QueryError>() {
 
                     @Override

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -294,6 +294,7 @@ public class BlockchainDb {
                                 @Nullable UnsignedLong endBlockNumber,
                                 boolean includeRaw,
                                 boolean includeProof,
+                                boolean includeTransfers,
                                 CompletionHandler<List<Transaction>, QueryError> handler) {
         getTransactions(
                 id,
@@ -302,6 +303,7 @@ public class BlockchainDb {
                 endBlockNumber,
                 includeRaw,
                 includeProof,
+                includeTransfers,
                 null,
                 handler
         );
@@ -313,6 +315,7 @@ public class BlockchainDb {
                                 @Nullable UnsignedLong endBlockNumber,
                                 boolean includeRaw,
                                 boolean includeProof,
+                                boolean includeTransfers,
                                 @Nullable Integer maxPageSize,
                                 CompletionHandler<List<Transaction>, QueryError> handler) {
         transactionApi.getTransactions(
@@ -322,6 +325,7 @@ public class BlockchainDb {
                 endBlockNumber,
                 includeRaw,
                 includeProof,
+                includeTransfers,
                 maxPageSize,
                 handler
         );
@@ -330,11 +334,13 @@ public class BlockchainDb {
     public void getTransaction(String id,
                                boolean includeRaw,
                                boolean includeProof,
+                               boolean includeTransfers,
                                CompletionHandler<Transaction, QueryError> handler) {
         transactionApi.getTransaction(
                 id,
                 includeRaw,
                 includeProof,
+                includeTransfers,
                 handler
         );
     }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
@@ -47,6 +47,7 @@ public class TransactionApi {
                                 @Nullable UnsignedLong endBlockNumber,
                                 boolean includeRaw,
                                 boolean includeProof,
+                                boolean includeTransfers,
                                 @Nullable Integer maxPageSize,
                                 CompletionHandler<List<Transaction>, QueryError> handler) {
         List<List<String>> chunkedAddressesList = Lists.partition(addresses, ADDRESS_COUNT);
@@ -61,6 +62,8 @@ public class TransactionApi {
             paramsBuilder.put("blockchain_id", id);
             paramsBuilder.put("include_proof", String.valueOf(includeProof));
             paramsBuilder.put("include_raw", String.valueOf(includeRaw));
+            paramsBuilder.put("include_transfers", String.valueOf(includeTransfers));
+            paramsBuilder.put("include_calls", "false");
             if (beginBlockNumber != null) paramsBuilder.put("start_height", beginBlockNumber.toString());
             if (endBlockNumber != null) paramsBuilder.put("end_height", endBlockNumber.toString());
             paramsBuilder.put("max_page_size", maxPageSize.toString());
@@ -75,10 +78,13 @@ public class TransactionApi {
     public void getTransaction(String id,
                                boolean includeRaw,
                                boolean includeProof,
+                               boolean includeTransfers,
                                CompletionHandler<Transaction, QueryError> handler) {
         Multimap<String, String> params = ImmutableListMultimap.of(
                 "include_proof", String.valueOf(includeProof),
-                "include_raw", String.valueOf(includeRaw));
+                "include_raw", String.valueOf(includeRaw),
+                "include_transfers", String.valueOf(includeTransfers),
+                "include_calls", "false");
 
         jsonClient.sendGetWithId("transactions", id, params, Transaction.class, handler);
     }

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1480,7 +1480,8 @@ extension System {
                                                addresses: addresses,
                                                begBlockNumber: (begBlockNumber == BLOCK_HEIGHT_UNBOUND_VALUE ? nil : begBlockNumber),
                                                endBlockNumber: (endBlockNumber == BLOCK_HEIGHT_UNBOUND_VALUE ? nil : endBlockNumber),
-                                               includeRaw: true) {
+                                               includeRaw: true,
+                                               includeTransfers: false) {
                                                 (res: Result<[BlockChainDB.Model.Transaction], BlockChainDB.QueryError>) in
                                                 defer { cryptoWalletManagerGive (cwm!) }
                                                 res.resolve(
@@ -1598,7 +1599,8 @@ extension System {
                                                    addresses: addresses,
                                                    begBlockNumber: (begBlockNumber == BLOCK_HEIGHT_UNBOUND_VALUE ? nil : begBlockNumber),
                                                    endBlockNumber: (endBlockNumber == BLOCK_HEIGHT_UNBOUND_VALUE ? nil : endBlockNumber),
-                                                   includeRaw: false) {
+                                                   includeRaw: false,
+                                                   includeTransfers: true) {
                                                     (res: Result<[BlockChainDB.Model.Transaction], BlockChainDB.QueryError>) in
                                                     defer { cryptoWalletManagerGive(cwm) }
                                                     res.resolve(

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -451,7 +451,8 @@ public final class WalletSweeper {
                             addresses: [address],
                             begBlockNumber: 0,
                             endBlockNumber: network.height,
-                            includeRaw: true) {
+                            includeRaw: true,
+                            includeTransfers: false) {
                             (res: Result<[BlockChainDB.Model.Transaction], BlockChainDB.QueryError>) in
                                 res.resolve(
                                     success: {

--- a/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
+++ b/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
@@ -845,6 +845,7 @@ public class BlockChainDB {
                                  endBlockNumber: UInt64? = nil,
                                  includeRaw: Bool = false,
                                  includeProof: Bool = false,
+                                 includeTransfers: Bool = true,
                                  maxPageSize: Int? = nil,
                                  completion: @escaping (Result<[Model.Transaction], QueryError>) -> Void) {
 
@@ -880,6 +881,8 @@ public class BlockChainDB {
             endBlockNumber.map { (_) in "end_height" },
             "include_proof",
             "include_raw",
+            "include_transfers",
+            "include_calls",
             "max_page_size"]
             .compactMap { $0 } // Remove `nil` from {beg,end}BlockNumber
 
@@ -889,6 +892,8 @@ public class BlockChainDB {
             endBlockNumber.map { $0.description },
             includeProof.description,
             includeRaw.description,
+            includeTransfers.description,
+            "false",
             maxPageSize.description]
             .compactMap { $0 }  // Remove `nil` from {beg,end}BlockNumber
 


### PR DESCRIPTION
This avoids extraneous data from the 'GET /transactions' when 'include_raw' is 'true'.