### PR TITLE
CORE-957: BlockchainDB 'GET /currencies' might be paged.

### DIFF
--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -103,7 +103,7 @@ public class BlockchainDb {
         this.client = client;
         this.blockApi = new BlockApi(bdbClient, executorService);
         this.blockchainApi = new BlockchainApi(bdbClient);
-        this.currencyApi = new CurrencyApi(bdbClient);
+        this.currencyApi = new CurrencyApi(bdbClient, executorService);
         this.subscriptionApi = new SubscriptionApi(bdbClient);
         this.transferApi = new TransferApi(bdbClient, executorService);
         this.transactionApi = new TransactionApi(bdbClient, executorService);

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/CurrencyApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/CurrencyApi.java
@@ -9,21 +9,27 @@ package com.breadwallet.crypto.blockchaindb.apis.bdb;
 
 import android.support.annotation.Nullable;
 
+import com.breadwallet.crypto.blockchaindb.apis.PagedData;
 import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.utility.CompletionHandler;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 public class CurrencyApi {
 
     private final BdbApiClient jsonClient;
+    private final ExecutorService executorService;
 
-    public CurrencyApi(BdbApiClient jsonClient) {
+    public CurrencyApi(BdbApiClient jsonClient,
+                       ExecutorService executorService) {
         this.jsonClient = jsonClient;
+        this.executorService = executorService;
     }
 
     public void getCurrencies(CompletionHandler<List<Currency>, QueryError> handler) {
@@ -37,7 +43,8 @@ public class CurrencyApi {
         paramsBuilder.put("verified", "true");
         ImmutableMultimap<String, String> params = paramsBuilder.build();
 
-        jsonClient.sendGetForArray("currencies", params, Currency.class, handler);
+        CompletionHandler<PagedData<Currency>, QueryError> pagedHandler = createPagedResultsHandler(handler);
+        jsonClient.sendGetForArrayWithPaging("currencies", params, Currency.class, pagedHandler);
     }
 
     public void getCurrency(String id,
@@ -45,4 +52,34 @@ public class CurrencyApi {
         jsonClient.sendGetWithId("currencies", id, ImmutableMultimap.of(), Currency.class, handler);
     }
 
+    private void submitGetNextBlocks(String nextUrl, CompletionHandler<PagedData<Currency>, QueryError> handler) {
+        executorService.submit(() -> getNextBlocks(nextUrl, handler));
+    }
+
+    private void getNextBlocks(String nextUrl, CompletionHandler<PagedData<Currency>, QueryError> handler) {
+        jsonClient.sendGetForArrayWithPaging("blocks", nextUrl, Currency.class, handler);
+    }
+
+    private CompletionHandler<PagedData<Currency>, QueryError> createPagedResultsHandler(CompletionHandler<List<Currency>, QueryError> handler) {
+        List<Currency> allResults = new ArrayList<>();
+        return new CompletionHandler<PagedData<Currency>, QueryError>() {
+            @Override
+            public void handleData(PagedData<Currency> results) {
+                Optional<String> nextUrl = results.getNextUrl();
+                allResults.addAll(results.getData());
+
+                if (nextUrl.isPresent()) {
+                    submitGetNextBlocks(nextUrl.get(), this);
+
+                } else {
+                    handler.handleData(allResults);
+                }
+            }
+
+            @Override
+            public void handleError(QueryError error) {
+                handler.handleError(error);
+            }
+        };
+    }
 }

--- a/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
+++ b/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
@@ -661,6 +661,28 @@ public class BlockChainDB {
     }
 
     public func getCurrencies (blockchainId: String? = nil, completion: @escaping (Result<[Model.Currency],QueryError>) -> Void) {
+        let results = ChunkedResults (queue: self.queue,
+                                      transform: Model.asCurrency,
+                                      completion: completion,
+                                      resultsExpected: 1)
+
+        func handleResult (more: URL?, result: Result<[JSON], QueryError>) {
+            results.extend (result)
+
+            // If `more` and no `error`, make a followup request
+            if let url = more, !results.completed {
+                self.bdbMakeRequest (url: url,
+                                     embedded: true,
+                                     embeddedPath: "currencies",
+                                     completion: handleResult)
+            }
+
+                // Otherwise, we completed one.
+            else {
+                results.extendedOne()
+            }
+        }
+
         let queryKeysBase = [
             blockchainId.map { (_) in "blockchain_id" },
             "verified"]
@@ -671,13 +693,9 @@ public class BlockChainDB {
             "true"]
             .compactMap { $0 }  // Remove `nil` from blockchainId
 
-        bdbMakeRequest (path: "currencies", query: zip (queryKeysBase, queryValsBase)) {
-            (more: URL?, res: Result<[JSON], QueryError>) in
-            precondition (nil == more)
-            completion (res.flatMap {
-                BlockChainDB.getManyExpected(data: $0, transform: Model.asCurrency)
-            })
-        }
+        bdbMakeRequest (path: "currencies",
+                        query: zip (queryKeysBase, queryValsBase),
+                        completion: handleResult)
     }
 
     public func getCurrency (currencyId: String, completion: @escaping (Result<Model.Currency,QueryError>) -> Void) {


### PR DESCRIPTION
Given the number of ETH 'currencies', the 'GET  /currencies' might be paged.

Follows the same patterns for '/currencies' as for '/transfers', '/transactions', and '/blocks'.