### PR TITLE
CORE-956: Improve System.configure()

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -548,10 +548,12 @@ cryptoWalletManagerRegisterWallet (BRCryptoWalletManager cwm,
 
             case BLOCK_CHAIN_TYPE_ETH: {
                 const char *issuer = cryptoCurrencyGetIssuer (currency);
-                BREthereumAddress ethAddress = ethAddressCreate (issuer);
-                BREthereumToken ethToken = ewmLookupToken (cwm->u.eth, ethAddress);
-                assert (NULL != ethToken);
-                ewmGetWalletHoldingToken (cwm->u.eth, ethToken);
+                if (NULL != issuer) {
+                    BREthereumAddress ethAddress = ethAddressCreate (issuer);
+                    BREthereumToken ethToken = ewmLookupToken (cwm->u.eth, ethAddress);
+                    assert (NULL != ethToken);
+                    ewmGetWalletHoldingToken (cwm->u.eth, ethToken);
+                }
                 break;
             }
             case BLOCK_CHAIN_TYPE_GEN:

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
@@ -38,6 +38,7 @@ final class NetworkDiscovery {
     /* package */
     interface Callback {
         void discovered(Network network);
+        void updated(Network network);
         void complete(List<com.breadwallet.crypto.Network> networks);
     }
 
@@ -144,6 +145,9 @@ final class NetworkDiscovery {
 
                         // Keep a running total of discovered networks
                         networks.add(network);
+                    }
+                    else {
+                        callback.updated(network);
                     }
                 }
                 return null;

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
@@ -50,54 +50,60 @@ final class NetworkDiscovery {
 
         CountUpAndDownLatch latch = new CountUpAndDownLatch(() -> callback.complete(networks));
 
+        // The existing networks
+        final List<com.breadwallet.crypto.Network> existingNetworks = networks;
+
         // The 'supportedNetworks' will be builtin networks matching isMainnet.
         final List<Network> supportedNetworks = findBuiltinNetworks(isMainnet);
 
-        getBlockChains(latch, query, isMainnet, remoteModels -> {
-            // We ONLY support built-in blockchains; but the remotes have some
-            // needed values - specifically the network fees and block height.
+         getBlockChains(latch, query, isMainnet, remoteModels -> {
+             // If there are no 'remoteModels' the query might have failed.
+             //
+             // We ONLY support built-in blockchains; but the remotes have some
+             // needed values - specifically the network fees and block height.
 
-            // Process each supportedNetwork based on the remote model
-            for (Network network: supportedNetworks) {
-                String blockchainModelId = network.getUids();
+             getCurrencies(latch, query, isMainnet, appCurrencies, currencyModels -> {
+                 // If there are no 'currencyModels' the query might have failed.
+                 //
+                 // Process each supportedNetwork based on the remote model
+                 for (Network network: supportedNetworks) {
+                    boolean existing = existingNetworks.contains(network);
+                    String blockchainModelId = network.getUids();
 
-                final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> applicationCurrencies = new ArrayList<>();
-                for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency: appCurrencies) {
-                    if (currency.getBlockchainId().equals(blockchainModelId)) {
-                        applicationCurrencies.add(currency);
-                    }
-                }
-
-                getCurrencies(latch, query, blockchainModelId, applicationCurrencies, currencyModels -> {
                     for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currencyModel : currencyModels) {
-                        Currency currency = Currency.create(
-                                currencyModel.getId(),
-                                currencyModel.getName(),
-                                currencyModel.getCode(),
-                                currencyModel.getType(),
-                                currencyModel.getAddress().orNull());
+                        if (currencyModel.getBlockchainId().equals(blockchainModelId)) {
+                            Currency currency = Currency.create(
+                                    currencyModel.getId(),
+                                    currencyModel.getName(),
+                                    currencyModel.getCode(),
+                                    currencyModel.getType(),
+                                    currencyModel.getAddress().orNull());
 
-                        Optional<CurrencyDenomination> baseDenomination = findFirstBaseDenomination(currencyModel.getDenominations());
-                        List<CurrencyDenomination> nonBaseDenominations = findAllNonBaseDenominations(currencyModel.getDenominations());
+                            Optional<CurrencyDenomination> baseDenomination = findFirstBaseDenomination(currencyModel.getDenominations());
+                            List<CurrencyDenomination> nonBaseDenominations = findAllNonBaseDenominations(currencyModel.getDenominations());
 
-                        Unit baseUnit = baseDenomination.isPresent() ? currencyDenominationToBaseUnit(currency, baseDenomination.get()) :
-                                currencyToDefaultBaseUnit(currency);
+                            Unit baseUnit = baseDenomination.isPresent()
+                                    ? currencyDenominationToBaseUnit(currency, baseDenomination.get())
+                                    : currencyToDefaultBaseUnit(currency);
 
-                        List<Unit> units = currencyDenominationToUnits(currency, nonBaseDenominations, baseUnit);
+                            List<Unit> units = currencyDenominationToUnits(currency, nonBaseDenominations, baseUnit);
 
-                        units.add(0, baseUnit);
-                        Collections.sort(units, (o1, o2) -> o2.getDecimals().compareTo(o1.getDecimals()));
-                        Unit defaultUnit = units.get(0);
+                            units.add(0, baseUnit);
+                            Collections.sort(units, (o1, o2) -> o2.getDecimals().compareTo(o1.getDecimals()));
+                            Unit defaultUnit = units.get(0);
 
-                        // The currency and unit here will not override builtins.
-                        network.addCurrency(currency, baseUnit, defaultUnit);
-                        for (Unit u: units) {
-                            network.addUnitFor(currency, u);
+                            // The currency and unit here will not override builtins.
+                            network.addCurrency(currency, baseUnit, defaultUnit);
+                            for (Unit u : units) {
+                                network.addUnitFor(currency, u);
+                            }
                         }
                     }
 
-                    Unit feeUnit = network.baseUnitFor (network.getCurrency()).orNull();
-                    if (null == feeUnit) { /* never here */ return null; }
+                    Unit feeUnit = network.baseUnitFor(network.getCurrency()).orNull();
+                    if (null == feeUnit) { /* never here */
+                        return null;
+                    }
 
                     // Find a blockchainModel for this network; there might not be one.
                     Blockchain blockchainModel = null;
@@ -112,7 +118,7 @@ final class NetworkDiscovery {
 
                         // Update the network's height
                         if (blockchainModel.getBlockHeight().isPresent())
-                            network.setHeight (blockchainModel.getBlockHeightValue());
+                            network.setHeight(blockchainModel.getBlockHeightValue());
 
                         // Extract the network fees
                         List<NetworkFee> fees = new ArrayList<>();
@@ -125,24 +131,23 @@ final class NetworkDiscovery {
 
                         if (fees.isEmpty()) {
                             Log.log(Level.FINE, String.format("Missed Fees %s", blockchainModel.getName()));
-                            return null;
+                        } else {
+                            network.setFees(fees);
                         }
-
-                        network.setFees(fees);
-                    }
-                    else {
+                    } else {
                         Log.log(Level.FINE, String.format("Missed Model for Network: %s", blockchainModelId));
                     }
 
-                    // Announce the network
-                    callback.discovered(network);
+                    if (!existing) {
+                        // Announce the network
+                        callback.discovered(network);
 
-                    // Keep a running total of discovered networks
-                    networks.add(network);
-
-                    return null;
-                });
-            }
+                        // Keep a running total of discovered networks
+                        networks.add(network);
+                    }
+                }
+                return null;
+             });
             return null;
         });
     }
@@ -216,6 +221,49 @@ final class NetworkDiscovery {
                         if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
                             merged.put(currency.getId(), currency);
                         }
+                    }
+
+                    func.apply(merged.values());
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+    }
+
+    private static void getCurrencies(CountUpAndDownLatch latch,
+                                      BlockchainDb query,
+                                      boolean mainnet,
+                                      Collection<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> applicationCurrencies,
+                                      Function<Collection<com.breadwallet.crypto.blockchaindb.models.bdb.Currency>, Void> func) {
+        latch.countUp();
+        query.getCurrencies(mainnet, new CompletionHandler<List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency>, QueryError>() {
+            @Override
+            public void handleData(List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> newCurrencies) {
+                try {
+                    // On success, always merge `default` INTO the result.  We merge defaultUnit
+                    // into `result` to always bias to the blockchainDB result.
+
+                    Map<String, com.breadwallet.crypto.blockchaindb.models.bdb.Currency> merged = new HashMap<>();
+                    for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : newCurrencies) {
+                        merged.put(currency.getId(), currency);
+                    }
+
+                    func.apply(merged.values());
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void handleError(QueryError error) {
+                try {
+                    // On error, use `apps` merged INTO defaults.  We merge into `defaults` to ensure that we get
+                    // BTC, BCH, ETH, BRD and that they are correct (don't rely on the App).
+
+                    Map<String, com.breadwallet.crypto.blockchaindb.models.bdb.Currency> merged = new HashMap<>();
+                    for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : applicationCurrencies) {
+                        merged.put(currency.getId(), currency);
                     }
 
                     func.apply(merged.values());

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -53,8 +53,9 @@ import com.breadwallet.crypto.errors.MigratePeerError;
 import com.breadwallet.crypto.errors.MigrateTransactionError;
 import com.breadwallet.crypto.errors.NetworkFeeUpdateError;
 import com.breadwallet.crypto.errors.NetworkFeeUpdateFeesUnavailableError;
-import com.breadwallet.crypto.events.network.NetworkCreatedEvent;
 import com.breadwallet.crypto.events.network.NetworkEvent;
+import com.breadwallet.crypto.events.network.NetworkCreatedEvent;
+import com.breadwallet.crypto.events.network.NetworkUpdatedEvent;
 import com.breadwallet.crypto.events.network.NetworkFeesUpdatedEvent;
 import com.breadwallet.crypto.events.system.SystemCreatedEvent;
 import com.breadwallet.crypto.events.system.SystemDiscoveredNetworksEvent;
@@ -380,6 +381,11 @@ final class System implements com.breadwallet.crypto.System {
                     announceNetworkEvent(network, new NetworkCreatedEvent());
                     announceSystemEvent(new SystemNetworkAddedEvent(network));
                 }
+            }
+
+            @Override
+            public void updated(Network network) {
+                announceNetworkEvent(network, new NetworkUpdatedEvent());
             }
 
             @Override

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -185,6 +185,14 @@ public class BlockchainDb {
         );
     }
 
+    public void getCurrencies(boolean mainnet,
+                              CompletionHandler<List<Currency>, QueryError> handler) {
+        currencyApi.getCurrencies(
+                mainnet,
+                handler
+        );
+    }
+
     public void getCurrency(String id,
                             CompletionHandler<Currency, QueryError> handler) {
         currencyApi.getCurrency(

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/CurrencyApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/CurrencyApi.java
@@ -14,7 +14,6 @@ import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 
 import java.util.List;
 
@@ -34,6 +33,16 @@ public class CurrencyApi {
                               CompletionHandler<List<Currency>, QueryError> handler) {
         ImmutableListMultimap.Builder<String, String> paramsBuilder = ImmutableListMultimap.builder();
         if (id != null) paramsBuilder.put("blockchain_id", id);
+        paramsBuilder.put("verified", "true");
+        ImmutableMultimap<String, String> params = paramsBuilder.build();
+
+        jsonClient.sendGetForArray("currencies", params, Currency.class, handler);
+    }
+
+    public void getCurrencies(boolean mainnet,
+                              CompletionHandler<List<Currency>, QueryError> handler) {
+        ImmutableListMultimap.Builder<String, String> paramsBuilder = ImmutableListMultimap.builder();
+        paramsBuilder.put("testnet", (mainnet ? "false" : "true"));
         paramsBuilder.put("verified", "true");
         ImmutableMultimap<String, String> params = paramsBuilder.build();
 

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/DefaultNetworkEventVisitor.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/DefaultNetworkEventVisitor.java
@@ -17,6 +17,11 @@ public abstract class DefaultNetworkEventVisitor<T> implements NetworkEventVisit
     }
 
     @Nullable
+    public T visit(NetworkUpdatedEvent event) {
+        return null;
+    }
+
+    @Nullable
     public T visit(NetworkFeesUpdatedEvent event) {
         return null;
     }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/NetworkEventVisitor.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/NetworkEventVisitor.java
@@ -11,5 +11,7 @@ public interface NetworkEventVisitor<T> {
 
     T visit(NetworkCreatedEvent event);
 
+    T visit(NetworkUpdatedEvent event);
+
     T visit(NetworkFeesUpdatedEvent event);
 }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/NetworkUpdatedEvent.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/events/network/NetworkUpdatedEvent.java
@@ -1,0 +1,10 @@
+package com.breadwallet.crypto.events.network;
+
+public final class NetworkUpdatedEvent implements NetworkEvent {
+
+    @Override
+    public <T> T accept(NetworkEventVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+}

--- a/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
@@ -340,7 +340,13 @@ public enum NetworkType: CustomStringConvertible {
 }
 
 public enum NetworkEvent {
+    /// The network was created.
     case created
+
+    /// The network had its currencies, fees and/or blockHeight updated.
+    case updated
+
+    // The netwok had its fees updated.
     case feesUpdated
 }
 

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -534,21 +534,14 @@ public final class System {
         // If called when we've no networks, then we've never been configured.  Ignore resuming.
         if !networks.isEmpty {
             print ("SYS: Resume")
+            configure(withCurrencyModels: [])
             managers.forEach { $0.connect() }
         }
     }
 
-     ///
-    /// Configure the system.  This will query various BRD services, notably the BlockChainDB, to
-    /// establish the available networks (aka blockchains) and their currencies.  For each
-    /// `Network` there will be `SystemEvent` which can be used by the App to create a
-    /// `WalletManager`
-    ///
-    /// - Parameter applicationCurrencies: If the BlockChainDB does not return any currencies, then
-    ///     use `applicationCurrencies` merged into the deafults.  Appropriate currencies can be
-    ///     created from `System::asBlockChainDBModelCurrency` (see below)
-    ///
-    public func configure (withCurrencyModels applicationCurrencies: [BlockChainDB.Model.Currency]) {
+    // MARK: - Configure
+
+    func configure (network: Network, currenciesFrom currencyModels: [BlockChainDB.Model.Currency]) {
         func currencyDenominationToBaseUnit (currency: Currency, model: BlockChainDB.Model.CurrencyDenomination) -> Unit {
             return Unit (currency: currency,
                          code:   model.code,
@@ -572,179 +565,166 @@ public final class System {
                          decimals: model.decimals)
         }
 
-        // Query for blockchains on the system.queue - thus system.configure() returns instantly
-        // and only System (and other types of) Events allow access to networds, wallets, etc.
-        self.queue.async {
-            // This semaphore is used only to block this async block until at least one group
-            // is entered.  Then this async block will wait until all groups have been left.
-            let blockchainsSemaphore = DispatchSemaphore (value: 0)
+        currencyModels
+            .filter { $0.blockchainID == network.uids }
+            .forEach { (currencyModel: BlockChainDB.Model.Currency) in
+                // Create the currency
+                let currency = Currency (uids: currencyModel.id,
+                                         name: currencyModel.name,
+                                         code: currencyModel.code,
+                                         type: currencyModel.type,
+                                         issuer: currencyModel.address)
 
-            // This group will be entered and left multiple times as blockchain models and their
-            // currencies are processed
-            let blockchainsGroup = DispatchGroup ()
+                // Create the base unit
+                let baseUnit: Unit = currencyModel.demoninations.first { 0 == $0.decimals }
+                    .map { currencyDenominationToBaseUnit(currency: currency, model: $0) }
+                    ?? currencyToDefaultBaseUnit (currency: currency)
 
-            // The 'discovered networks' will all be announced at once.
-            var discoveredNetworks:[Network] = []
+                // Create the other units
+                var units: [Unit] = [baseUnit]
+                units += currencyModel.demoninations.filter { 0 != $0.decimals }
+                    .map { currencyDenominationToUnit (currency: currency, model: $0, base: baseUnit) }
 
-            func announceNetwork (_ network: Network) {
-                // Save the network
-                 self.networks.append (network)
+                // Find the default unit
+                let maximumDecimals = units.reduce (0) { max ($0, $1.decimals) }
+                let defaultUnit = units.first { $0.decimals == maximumDecimals }!
 
-                 self.listenerQueue.async {
-                     // Announce NetworkEvent.created...
-                     self.listener?.handleNetworkEvent (system: self, network: network, event: NetworkEvent.created)
+                // Add the currency - this will not replace an existing currency
+                // Note, a builtin network *always* has a native currency at
+                // least which is set as the network's currency.
+                network.addCurrency (currency, baseUnit: baseUnit, defaultUnit: defaultUnit)
 
-                     // Announce SystemEvent.networkAdded - this will likely be handled with
-                     // system.createWalletManager(network:...) which will then announce
-                     // numerous events as wallets are created.
-                     self.listener?.handleSystemEvent  (system: self, event: SystemEvent.networkAdded(network: network))
-                 }
+                // Add the units - this will not replace an existing unti
+                units.forEach { network.addUnitFor (currency: currency, unit: $0) }
+        }
+    }
 
-                 // Keep a running total of discovered networks
-                 discoveredNetworks.append(network)
+    func configure (network: Network, feesFrom blockchainModel: BlockChainDB.Model.Blockchain) {
+        // The feeUnit is always the network currency's base unit
+        guard let feeUnit = network.baseUnitFor (currency: network.currency)
+            else { return }
+
+        // Extract the network fees from the blockchainModel
+        let fees = blockchainModel.feeEstimates
+            // Well, quietly ignore a fee if we can't parse the amount.
+            .compactMap { (fee: BlockChainDB.Model.BlockchainFee) -> NetworkFee? in
+                let timeInterval  = fee.confirmationTimeInMilliseconds
+                return Amount.create (string: fee.amount, unit: feeUnit)
+                    .map { NetworkFee (timeIntervalInMilliseconds: timeInterval,
+                                       pricePerCostFactor: $0) }
+        }
+
+        // We require fees
+        guard !fees.isEmpty
+            else { print ("SYS: CONFIGURE: Missed Fees (\(blockchainModel.name)) on '\(blockchainModel.network)'"); return }
+
+        // Update the network's fees.
+        network.fees = fees
+    }
+
+     ///
+    /// Configure the system.  This will query various BRD services, notably the BlockChainDB, to
+    /// establish the available networks (aka blockchains) and their currencies.  For each
+    /// `Network` there will be `SystemEvent` which can be used by the App to create a
+    /// `WalletManager`
+    ///
+    /// - Parameter applicationCurrencies: If the BlockChainDB does not return any currencies, then
+    ///     use `applicationCurrencies` merged into the deafults.  Appropriate currencies can be
+    ///     created from `System::asBlockChainDBModelCurrency` (see below)
+    ///
+    public func configure (withCurrencyModels applicationCurrencies: [BlockChainDB.Model.Currency]) {
+        // The networks we've already processed
+        let existingNetworks   = networks
+
+        // The 'discovered networks' will all be announced at once.
+        var discoveredNetworks = [Network]()
+
+        // The 'supported networks' will be the built-in networks matching 'onMainnet'.  There is
+        // no harm in calling this multiple times.
+        let supportedNetworks = Network.installBuiltins()
+            .filter { self.onMainnet == $0.isMainnet}
+
+        func announceNetwork (_ network: Network) {
+            // Save the network
+             self.networks.append (network)
+
+             self.listenerQueue.async {
+                 // Announce NetworkEvent.created...
+                 self.listener?.handleNetworkEvent (system: self, network: network, event: NetworkEvent.created)
+
+                 // Announce SystemEvent.networkAdded - this will likely be handled with
+                 // system.createWalletManager(network:...) which will then announce
+                 // numerous events as wallets are created.
+                 self.listener?.handleSystemEvent  (system: self, event: SystemEvent.networkAdded(network: network))
+             }
+
+             // Keep a running total of discovered networks
+             discoveredNetworks.append(network)
+        }
+
+        // Query for blockchains.
+        self.query.getBlockchains (mainnet: self.onMainnet) {
+            (blockchainResult: Result<[BlockChainDB.Model.Blockchain],BlockChainDB.QueryError>) in
+
+            // If the query failed, soldier on without any models
+            let blockchainModels = blockchainResult
+                .getWithRecovery {
+                    print ("SYS: CONFIGURE: Missed Blockchains Query: \($0)")
+                    return []
             }
 
-            // The 'supported networks' will be the built-in networks matching 'onMainnet'
-            let supportedNetworks = Network.installBuiltins()
-                .filter { self.onMainnet == $0.isMainnet}
+            // Make a map from the supported models
+            let blockchainModelsMap = Dictionary (uniqueKeysWithValues:
+                blockchainModels.map { ($0.id, $0) })
 
-            // Query for blockchains.
-            self.query.getBlockchains (mainnet: self.onMainnet) {
-                (blockchainResult: Result<[BlockChainDB.Model.Blockchain],BlockChainDB.QueryError>) in
+            // Query currencies for all blockchains on mainnet/testnet
+            self.query.getCurrencies (mainnet: self.onMainnet) {
+                (currencyResult: Result<[BlockChainDB.Model.Currency],BlockChainDB.QueryError>) in
 
-                // If there was a QueryError then we are done
-                if case let .failure (error) = blockchainResult {
-                    // TODO: Handle a Query Error appropriately.  Must recover/retry
-                    print ("SYS: CONFIGURE: Missed Blockchains Query: \(error)")
-                    supportedNetworks.forEach { announceNetwork($0) }
-                    return // from getBlockchains
+                // If the query failed, soldier on with the `applicationCurrencies`.  We may have
+                // a mixture of 'mainnet' and 'testnet' in this result.
+                let currencyModels = currencyResult
+                    .getWithRecovery {
+                        print ("SYS: CONFIGURE: Missed Currencies Query: \($0)")
+                        return applicationCurrencies
+                            .filter { $0.verified == true }
                 }
-
-                // Make a map from of the supported models
-                let blockchainModelsMap = Dictionary (uniqueKeysWithValues:
-                    blockchainResult.getWithRecovery { (ignore) in return [] }
-                        .map { ($0.id, $0) })
-
-                // Enter the group once for each model; we'll leave as each currency is processed.
-                // When all have left, self.queue will unblock (see blockchainsGroup.wait() below).
-                supportedNetworks.forEach { (ignore) in blockchainsGroup.enter() }
-
-                // Signal the dispatch semaphore, the self.queue will now start blocking
-                // on the dispatch group.
-                blockchainsSemaphore.signal()
 
                 // Handle each network
                 supportedNetworks
                     .forEach { (network: Network) in
 
-                        // query currencies based on the (Network <==> BlockchainMode) id
-                        self.query.getCurrencies (blockchainId: network.uids) {
-                            (currencyResult: Result<[BlockChainDB.Model.Currency],BlockChainDB.QueryError>) in
+                        // Record if we already know about `network`
+                        let existing = existingNetworks.contains(network)
 
-                            // We get one `currencyResult` per blockchain.  If we leave the group
-                            // upon completion of this block, we'll match the `enter` calls.
-                            defer {
-                                blockchainsGroup.leave()
+                        // Configure the network using the currencyModels.  If currency models have
+                        // been added, then we'll add those to `network`.
+                        //
+                        // TODO: If `existing`, announce new currencies
+                        self.configure (network: network, currenciesFrom: currencyModels)
+
+                        // If we have a blockChainModel, configure the network fees.
+                        if let blockchainModel = blockchainModelsMap[network.uids] {
+                            if let blockHeight = blockchainModel.blockHeight {
+                                cryptoNetworkSetHeight (network.core, blockHeight)
                             }
 
-                            // Don't process a network that we've added already.
-                            guard nil == self.networkBy (uids: network.uids)
-                                else { print ("SYS: CONFIGURE: Skipped Duplicate Network: \(network.name)"); return }
+                            self.configure (network: network, feesFrom: blockchainModel)
+                        }
+                        else { print ("SYS: CONFIGURE: Missed model for network: \(network.uids)") }
 
-                            // Get the built-in network
-//                            guard let network = supportedNetworks.first (where: { network.uids == $0.uids })
-//                                else { print ("SYS: CONFIGURE: Missed network for model: \(network.uids)"); return }
-
-                            // If there was a QueryError, then we are done
-                            if case let .failure(error) = currencyResult {
-                                print ("SYS: CONFIGURE: Missed Currencies Query (\(network.uids)): \(error)")
-                                // Continue on to use the applicationCurrencies
-                             }
-
-                            currencyResult.getWithRecovery { (ignore) in
-                                return applicationCurrencies
-                                    .filter { $0.blockchainID == network.uids }
-                            }
-                                // TODO: Only needed if getCurrencies returns the wrong stuff.
-                                .filter { $0.blockchainID == network.uids }
-                                .filter { $0.verified }
-                                .forEach { (currencyModel: BlockChainDB.Model.Currency) in
-
-                                    // Create the currency
-                                    let currency = Currency (uids: currencyModel.id,
-                                                             name: currencyModel.name,
-                                                             code: currencyModel.code,
-                                                             type: currencyModel.type,
-                                                             issuer: currencyModel.address)
-
-                                    // Create the base unit
-                                    let baseUnit: Unit = currencyModel.demoninations.first { 0 == $0.decimals }
-                                        .map { currencyDenominationToBaseUnit(currency: currency, model: $0) }
-                                        ?? currencyToDefaultBaseUnit (currency: currency)
-
-                                    // Create the other units
-                                    var units: [Unit] = [baseUnit]
-                                    units += currencyModel.demoninations.filter { 0 != $0.decimals }
-                                        .map { currencyDenominationToUnit (currency: currency, model: $0, base: baseUnit) }
-
-                                    // Find the default unit
-                                    let maximumDecimals = units.reduce (0) { max ($0, $1.decimals) }
-                                    let defaultUnit = units.first { $0.decimals == maximumDecimals }!
-
-                                    // Add the currency - this will not replace an existing currency
-                                    // Note, a builtin network *always* has a native currency at
-                                    // least which is set as the network's currency.
-                                    network.addCurrency (currency, baseUnit: baseUnit, defaultUnit: defaultUnit)
-
-                                    // Add the units - this will not replace an existing unti
-                                    units.forEach { network.addUnitFor (currency: currency, unit: $0) }
-                            }
-
-                            // The feeUnit is always the network currency's base unit
-                            guard let feeUnit = network.baseUnitFor (currency: network.currency)
-                                else { return }
-
-                            // If we have a blockchain model for this network, process it.
-                            if let blockchainModel = blockchainModelsMap[network.uids] {
-
-                                if let blockHeight = blockchainModel.blockHeight {
-                                    cryptoNetworkSetHeight (network.core, blockHeight)
-                                }
-
-                                // Extract the network fees from the blockchainModel
-                                let fees = blockchainModel.feeEstimates
-                                    // Well, quietly ignore a fee if we can't parse the amount.
-                                    .compactMap { (fee: BlockChainDB.Model.BlockchainFee) -> NetworkFee? in
-                                        let timeInterval  = fee.confirmationTimeInMilliseconds
-                                        return Amount.create (string: fee.amount, unit: feeUnit)
-                                            .map { NetworkFee (timeIntervalInMilliseconds: timeInterval,
-                                                               pricePerCostFactor: $0) }
-                                }
-
-                                // We require fees
-                                guard !fees.isEmpty
-                                    else { print ("SYS: CONFIGURE: Missed Fees (\(blockchainModel.name)) on '\(blockchainModel.network)'"); return }
-
-                                // Update the network's fees.
-                                network.fees = fees
-                            }
-                            else { print ("SYS: CONFIGURE: Missed model for network: \(network.uids)") }
-
-                            // Finally, announce the network
+                        // If this is the first we've learn of this network, then announce it
+                        if !existing {
                             announceNetwork(network)
                         }
                 }
-            }
-            
-            // Wait on the semaphore - indicates that the DispatchGroup is 'active'
-            blockchainsSemaphore.wait()
 
-            // Wait on the group - indicates that all models+currencies have entered and left.
-            blockchainsGroup.wait()
-
-            // Always announce the discoveredNetworks on competion of `getBlockchains`
-            self.listenerQueue.async {
-                self.listener?.handleSystemEvent(system: self, event: SystemEvent.discoveredNetworks (networks: discoveredNetworks))
+                // Announce the newly discoveredNetworks on completion
+                if existingNetworks.isEmpty || !discoveredNetworks.isEmpty {
+                    self.listenerQueue.async {
+                        self.listener?.handleSystemEvent(system: self, event: SystemEvent.discoveredNetworks (networks: discoveredNetworks))
+                    }
+                }
             }
         }
     }

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -79,7 +79,7 @@ public final class WalletManager: Equatable, CustomStringConvertible {
     ///
     /// Ensure that a wallet for currency exists.  If the wallet already exists, it is returned.
     /// If the wallet needs to be created then `nil` is returned and a series of events will
-    //// occur - notably WalletEvent.created and WalletManagerEvent.walletAdded if the wallet is
+    /// occur - notably WalletEvent.created and WalletManagerEvent.walletAdded if the wallet is
     /// created
     ///
     /// - Note: There is a precondition on `currency` being one in the managers' network

--- a/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
+++ b/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
@@ -660,14 +660,16 @@ public class BlockChainDB {
         }
     }
 
-    public func getCurrencies (blockchainId: String? = nil, completion: @escaping (Result<[Model.Currency],QueryError>) -> Void) {
+    public func getCurrencies (blockchainId: String? = nil, mainnet: Bool = true, completion: @escaping (Result<[Model.Currency],QueryError>) -> Void) {
         let queryKeysBase = [
             blockchainId.map { (_) in "blockchain_id" },
+            "testnet",
             "verified"]
             .compactMap { $0 } // Remove `nil` from blockchainId
 
         let queryValsBase: [String] = [
             blockchainId,
+            (!mainnet).description,
             "true"]
             .compactMap { $0 }  // Remove `nil` from blockchainId
 

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -166,7 +166,7 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-         system.pause()
+        system.pause()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
@@ -20,6 +20,7 @@ class CoreDemoListener: SystemListener {
     private var managerListeners: [WalletManagerListener] = []
     private var walletListeners: [WalletListener] = []
     private var transferListeners: [TransferListener] = []
+    private var networkListeners: [NetworkListener] = []
 
     private let networkCurrencyCodesToMode: [String:WalletManagerMode]
     private let registerCurrencyCodes: [String]
@@ -82,6 +83,22 @@ class CoreDemoListener: SystemListener {
         }
     }
     
+    func add(networkListener: NetworkListener) {
+        CoreDemoListener.eventQueue.async {
+            if !self.networkListeners.contains (where: { $0 === networkListener }) {
+                self.networkListeners.append (networkListener)
+            }
+        }
+    }
+
+    func remove(networkListener: NetworkListener) {
+        CoreDemoListener.eventQueue.async {
+            if let i = self.networkListeners.firstIndex (where: { $0 === networkListener }) {
+                self.networkListeners.remove (at: i)
+            }
+        }
+    }
+
     func handleSystemEvent(system: System, event: SystemEvent) {
         print ("APP: System: \(event)")
         switch event {
@@ -226,7 +243,28 @@ class CoreDemoListener: SystemListener {
     }
 
     func handleNetworkEvent(system: System, network: Network, event: NetworkEvent) {
-        print ("APP: Network: \(event)")
+        CoreDemoListener.eventQueue.async {
+            print ("APP: Network: \(event)")
+            switch event {
+            case .updated:
+                // On .updated, register a wallet for any new currencies.
+                network.currencies
+                    .forEach {
+                        if let manager = system.managerBy(network: network) {
+                            let _ = manager.registerWalletFor (currency: $0)
+                        }
+                }
+                break
+            default:
+                break
+            }
+            
+            self.networkListeners.forEach {
+                $0.handleNetworkEvent (system: system,
+                                       network: network,
+                                       event: event)
+            }
+        }
     }
 }
 

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoDebugSupport.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoDebugSupport.swift
@@ -96,6 +96,8 @@ extension NetworkEvent:       MatchableEvent {
             return true
         case (.feesUpdated, .feesUpdated):
             return true
+        case (.updated, .updated):
+            return true
         default:
             return false
         }


### PR DESCRIPTION
Changes:
- Replace N calls to 'GET /currencies', one for each network, with one call.  
- When calling `System.configure()` multiple times, on background/foreground, announce `NetworkEvent.updated`
- Add `NetworkEvent.updated`
- Fix an error with `cryptoWalletManagerRegisterWallet()`

Also, in the Core Demo App, on foregrounding handle `NetworkEvent.updated` by registering all wallets - which will create a wallet for any currencies not previously registered.
