### PR TITLE
CORE-966: Handle insufficientFunds from estimateLimit* in Core Demo App

### DIFF
--- a/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
@@ -160,43 +160,39 @@ UITextViewDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
 
         wallet.estimateLimitMinimum (target: target, fee: fee) {
             (res: Result<Amount, Wallet.LimitEstimationError>) in
-            switch res {
-            case .success (let minimum):
-                DispatchQueue.main.async {
-                    self.minimum = minimum
 
-                    self.amountSlider.minimumValue = Float (minimum.double (as: self.wallet.unitForFee) ?? 0.0)
-                    self.amountMinLabel.text = self.minimum.string(as: self.wallet.unit)
+            let minimum = res.getWithRecovery { (reason) in
+                print ("APP: TCC: Missed estimateLimitMinimum: \(reason)")
+                return Amount.create(double: 0.0, unit: self.wallet.unitForFee)
+            }
+            DispatchQueue.main.async {
+                self.minimum = minimum
 
-                    self.amountSlider.value = max (self.amountSlider.minimumValue, self.amountSlider.value)
-                    self.amountLabel.text = self.amount().description
+                self.amountSlider.minimumValue = Float (minimum.double (as: self.wallet.unitForFee) ?? 0.0)
+                self.amountMinLabel.text = self.minimum.string(as: self.wallet.unit)
 
-                }
-
-            case .failure:
-                break
+                self.amountSlider.value = max (self.amountSlider.minimumValue, self.amountSlider.value)
+                self.amountLabel.text = self.amount().description
             }
         }
 
         wallet.estimateLimitMaximum (target: target, fee: fee) {
             (res: Result<Amount, Wallet.LimitEstimationError>) in
-            switch res {
-            case .success (let maximum):
-                DispatchQueue.main.async {
-                    self.maximum = maximum
 
-                    self.amountSlider.maximumValue = Float (maximum.double (as: self.wallet.unitForFee) ?? 0.0)
-                    self.amountMaxLabel.text = self.maximum.string(as: self.wallet.unit)
+            let maximum = res.getWithRecovery { (reason) in
+                print ("APP: TCC: Missed estimateLimitMaximum: \(reason)")
+                return Amount.create(double: 0.0, unit: self.wallet.unitForFee)
+            }
+            DispatchQueue.main.async {
+                self.maximum = maximum
 
-                    self.amountSlider.value = min (self.amountSlider.maximumValue, self.amountSlider.value)
-                    self.amountLabel.text = self.amount().description
-                }
+                self.amountSlider.maximumValue = Float (maximum.double (as: self.wallet.unitForFee) ?? 0.0)
+                self.amountMaxLabel.text = self.maximum.string(as: self.wallet.unit)
 
-            case .failure:
-                break
+                self.amountSlider.value = min (self.amountSlider.maximumValue, self.amountSlider.value)
+                self.amountLabel.text = self.amount().description
             }
         }
-
     }
 
     func updateFee () {


### PR DESCRIPTION
Confirmed with excessive fees:
```
APP: WVC: Want to Send
APP: TCC: Missed estimateLimitMinimum: insufficientFunds
APP: TCC: Missed estimateLimitMaximum: insufficientFunds
```

Confirmed with normal fees (able to create w/ a non-zero balance):
```
APP: WVC: TransferEvent: created
APP: WVC: TransferEvent: changed(old: Created, new: Signed)
SYS: SubmitTransaction: Error: response(404) [expected, today]
```