### PR TITLE
CORE-978: Reduce 'Balance Updated' event during API Sync and FS read.

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerClient.c
@@ -2236,7 +2236,7 @@ cwmAnnounceGetTransferItemGEN (BRCryptoWalletManager cwm,
         // similar events.
         //
         // genManagerAnnounceTransfer (cwm->u.gen, callbackState->rid, transfer);
-        cryptoWalletManagerHandleTransferGEN (cwm, genTransfer);
+        cryptoWalletManagerHandleTransferGENFilter (cwm, genTransfer, CRYPTO_FALSE);
     }
 
     if (NULL != wallet) cryptoWalletGive (wallet);
@@ -2261,8 +2261,6 @@ cwmAnnounceGetTransfersComplete (OwnershipKept BRCryptoWalletManager cwm,
     } else {
         assert (0);
     }
-
-    // TODO: This even occurs even when the balance doesn't change (no new transfers).
 
     // Synchronizing of transfers is complete - calculate the new balance
     BRCryptoAmount balance = cryptoWalletGetBalance(cwm->wallet);

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -123,6 +123,11 @@ extern void
 cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
                                       OwnershipGiven BRGenericTransfer transferGeneric);
 
+extern void
+cryptoWalletManagerHandleTransferGENFilter (BRCryptoWalletManager cwm,
+                                            OwnershipGiven BRGenericTransfer transferGeneric,
+                                            BRCryptoBoolean needBalanceEvent);
+
 private_extern void
 cryptoWalletManagerSetTransferStateGEN (BRCryptoWalletManager cwm,
                                         BRCryptoWallet wallet,

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoListener.swift
@@ -208,7 +208,7 @@ class CoreDemoListener: SystemListener {
 
     func handleManagerEvent(system: System, manager: WalletManager, event: WalletManagerEvent) {
         CoreDemoListener.eventQueue.async {
-            print ("APP: Manager (\(manager.name)): \(event)")
+ //           print ("APP: Manager (\(manager.name)): \(event)")
             self.managerListeners.forEach {
                 $0.handleManagerEvent(system: system,
                                       manager: manager,
@@ -219,7 +219,7 @@ class CoreDemoListener: SystemListener {
 
     func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
         CoreDemoListener.eventQueue.async {
-            print ("APP: Wallet (\(manager.name):\(wallet.name)): \(event)")
+//            print ("APP: Wallet (\(manager.name):\(wallet.name)): \(event)")
             self.walletListeners.forEach {
                 $0.handleWalletEvent (system: system,
                                       manager: manager,
@@ -231,7 +231,7 @@ class CoreDemoListener: SystemListener {
 
     func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
         CoreDemoListener.eventQueue.async {
-            print ("APP: Transfer (\(manager.name):\(wallet.name)): \(event)")
+//            print ("APP: Transfer (\(manager.name):\(wallet.name)): \(event)")
             self.transferListeners.forEach {
                 $0.handleTransferEvent (system: system,
                                         manager: manager,

--- a/WalletKitSwift/WalletKitDemo/Source/SummaryViewController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/SummaryViewController.swift
@@ -204,10 +204,11 @@ class SummaryViewController: UITableViewController, WalletListener {
                             wallet: Wallet,
                             event: WalletEvent) {
         DispatchQueue.main.async {
-            print ("APP: SVC: WalletEvent (\(manager.name):\(wallet.name)): \(event)")
             // if visible ...
             switch event {
             case .created:
+                print ("APP: SVC: WalletEvent (\(manager.name):\(wallet.name)): Created")
+
                 precondition (!self.wallets.contains (wallet))
 
                 self.wallets.append (wallet)
@@ -215,7 +216,9 @@ class SummaryViewController: UITableViewController, WalletListener {
                 let path = IndexPath (row: (self.wallets.count - 1), section: 0)
                 self.tableView.insertRows (at: [path], with: .automatic)
 
-            case .balanceUpdated:
+            case let .balanceUpdated (amount):
+                print ("APP: SVC: WalletEvent (\(manager.name):\(wallet.name)): BalanceUpdated: \(amount)")
+
                 if let index = self.wallets.firstIndex (of: wallet) {
                     let path = IndexPath (row: index, section: 0)
                     if let cell = self.tableView.cellForRow(at: path) as? WalletTableViewCell {
@@ -224,6 +227,7 @@ class SummaryViewController: UITableViewController, WalletListener {
                 }
 
             case .deleted:
+                print ("APP: SVC: WalletEvent (\(manager.name):\(wallet.name)): Deleted")
                 if let index = self.wallets.firstIndex (of: wallet) {
                     self.wallets.remove (at: index)
 


### PR DESCRIPTION
During an 'API Sync' we get the full list of transfers/transactions and process them one-by-one; this generates a 'balance updated' event for each one.  Change the logic to generate a single 'balance updated' event after all transfers/transactions in the 'API Sync' response are processed.

Same thing when recovering the list of transfers/transactions from the FileService (persistent storage).  One 'balance updated' event after all are processed (added to the wallet).

There still are many events as each transfer is added to the wallet (allowing the UI to fill them in the 'list view').  If the App does `wallet.getBalance()` it will get the current balance, based on the added transfers/transactions.