### PR TITLE
CORE-976: Add BRGenericWalletUpdTransfer

### DIFF
--- a/WalletKitCore/src/generic/BRGeneric.c
+++ b/WalletKitCore/src/generic/BRGeneric.c
@@ -445,6 +445,12 @@ genWalletRemTransfer (BRGenericWallet wallet,
     wallet->handlers.remTransfer (wallet->ref, transfer->ref);
 }
 
+extern void
+genWalletUpdTransfer (BRGenericWallet wallet,
+                      OwnershipKept BRGenericTransfer transfer) {
+    wallet->handlers.updTransfer (wallet->ref, transfer->ref);
+}
+
 extern BRGenericTransfer
 genWalletCreateTransfer (BRGenericWallet wallet,
                          BRGenericAddress target, // TODO: BRGenericAddress - ownership given

--- a/WalletKitCore/src/generic/BRGeneric.h
+++ b/WalletKitCore/src/generic/BRGeneric.h
@@ -208,6 +208,10 @@ extern "C" {
     genWalletRemTransfer (BRGenericWallet wallet,
                           OwnershipKept BRGenericTransfer transfer);
 
+    extern void
+    genWalletUpdTransfer (BRGenericWallet wallet,
+                          OwnershipKept BRGenericTransfer transfer);
+
     extern BRGenericTransfer
     genWalletCreateTransfer (BRGenericWallet wid,
                              BRGenericAddress target,

--- a/WalletKitCore/src/generic/BRGenericHandlers.h
+++ b/WalletKitCore/src/generic/BRGenericHandlers.h
@@ -130,6 +130,9 @@ extern "C" {
     typedef void (*BRGenericWalletRemTransfer) (BRGenericWalletRef wallet,
                                                 OwnershipKept BRGenericTransferRef transfer);
 
+    typedef void (*BRGenericWalletUpdTransfer) (BRGenericWalletRef wallet,
+                                                OwnershipKept BRGenericTransferRef transfer);
+
     typedef BRGenericTransferRef (*BRGenericWalletCreateTransfer) (BRGenericWalletRef wallet,
                                                                    BRGenericAddressRef target,
                                                                    UInt256 amount,
@@ -166,6 +169,7 @@ extern "C" {
         BRGenericWalletHasTransfer hasTransfer;
         BRGenericWalletAddTransfer addTransfer;
         BRGenericWalletRemTransfer remTransfer;
+        BRGenericWalletUpdTransfer updTransfer;
         BRGenericWalletCreateTransfer createTransfer; // Unneeded.
         BRGenericWalletEstimateFeeBasis estimateFeeBasis;
         

--- a/WalletKitCore/src/generic/BRGenericHedera.c
+++ b/WalletKitCore/src/generic/BRGenericHedera.c
@@ -254,6 +254,12 @@ genericHederaWalletRemTransfer (BRGenericWalletRef wallet,
     hederaWalletRemTransfer ((BRHederaWallet) wallet, (BRHederaTransaction) transfer);
 }
 
+static void
+genericHederaWalletUpdTransfer (BRGenericWalletRef wallet,
+                                OwnershipKept BRGenericTransferRef transfer) {
+    hederaWalletUpdateTransfer ((BRHederaWallet) wallet, (BRHederaTransaction) transfer);
+}
+
 #define TRANSFER_ATTRIBUTE_MEMO_TAG         "Memo"
 
 static int // 1 if equal, 0 if not.
@@ -490,6 +496,7 @@ struct BRGenericHandersRecord genericHederaHandlersRecord = {
         genericHederaWalletHasTransfer,
         genericHederaWalletAddTransfer,
         genericHederaWalletRemTransfer,
+        genericHederaWalletUpdTransfer,
         genericHederaWalletCreateTransfer,
         genericHederaWalletEstimateFeeBasis,
 

--- a/WalletKitCore/src/generic/BRGenericRipple.c
+++ b/WalletKitCore/src/generic/BRGenericRipple.c
@@ -241,6 +241,12 @@ genericRippleWalletRemTransfer (BRGenericWalletRef wallet,
     rippleWalletRemTransfer ((BRRippleWallet) wallet, (BRRippleTransfer) transfer);
 }
 
+static void
+genericRippleWalletUpdTransfer (BRGenericWalletRef wallet,
+                                OwnershipKept BRGenericTransferRef transfer) {
+    rippleWalletUpdateTransfer ((BRRippleWallet) wallet, (BRRippleTransfer) transfer);
+}
+
 #define FIELD_OPTION_DESTINATION_TAG        "DestinationTag"
 #define FIELD_OPTION_INVOICE_ID             "InvoiceId"
 
@@ -490,6 +496,7 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleWalletHasTransfer,
         genericRippleWalletAddTransfer,
         genericRippleWalletRemTransfer,
+        genericRippleWalletUpdTransfer,
         genericRippleWalletCreateTransfer,
         genericRippleWalletEstimateFeeBasis,
 

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -283,6 +283,34 @@ extern BRHederaUnitTinyBar hederaTransactionGetAmount(BRHederaTransaction transa
     return transaction->amount;
 }
 
+extern BRHederaUnitTinyBar hederaTransactionGetAmountDirected (BRHederaTransaction transfer,
+                                                               BRHederaAddress address,
+                                                               int *negative) {
+    BRHederaUnitTinyBar fee    = hederaTransactionGetFee(transfer);
+    BRHederaUnitTinyBar amount = (hederaTransactionHasError(transfer)
+                                  ? 0
+                                  : hederaTransactionGetAmount(transfer));
+    
+    int isSource = hederaTransactionHasSource (transfer, address);
+    int isTarget = hederaTransactionHasTarget (transfer, address);
+    
+    if (isSource && isTarget) {
+        *negative = 1;
+        return fee;
+    }
+    else if (isSource) {
+        *negative = 1;
+        return amount + fee;
+    }
+    else if (isTarget) {
+        *negative = 0;
+        return amount;
+    }
+    else {
+        assert (0);
+    }
+}
+
 extern BRHederaAddress hederaTransactionGetSource(BRHederaTransaction transaction)
 {
     assert(transaction);
@@ -293,6 +321,14 @@ extern BRHederaAddress hederaTransactionGetTarget(BRHederaTransaction transactio
 {
     assert(transaction);
     return hederaAddressClone (transaction->target);
+}
+
+extern int hederaTransactionHasSource (BRHederaTransaction tranaction, BRHederaAddress address) {
+    return hederaAddressEqual (tranaction->source, address);
+}
+
+extern int hederaTransactionHasTarget (BRHederaTransaction tranaction, BRHederaAddress address) {
+    return hederaAddressEqual (tranaction->target, address);
 }
 
 extern int hederaTransactionHasError (BRHederaTransaction transaction) {

--- a/WalletKitCore/src/hedera/BRHederaTransaction.h
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.h
@@ -118,6 +118,13 @@ extern bool hederaTransactionEqual (BRHederaTransaction t1, BRHederaTransaction 
 extern BRHederaTimeStamp hederaGenerateTimeStamp(void);
 extern BRHederaTimeStamp hederaParseTimeStamp(const char* txID);
 
+// Internal
+extern int hederaTransactionHasSource (BRHederaTransaction tranaction, BRHederaAddress address);
+extern int hederaTransactionHasTarget (BRHederaTransaction tranaction, BRHederaAddress address);
+
+extern BRHederaUnitTinyBar hederaTransactionGetAmountDirected (BRHederaTransaction transfer,
+                                                               BRHederaAddress address,
+                                                               int *negative);
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitCore/src/hedera/BRHederaWallet.h
+++ b/WalletKitCore/src/hedera/BRHederaWallet.h
@@ -129,10 +129,18 @@ extern BRHederaFeeBasis
 hederaWalletGetDefaultFeeBasis (BRHederaWallet wallet);
 
 // Wallet transfer list functions
-extern int hederaWalletHasTransfer (BRHederaWallet wallet, BRHederaTransaction transfer);
-extern void hederaWalletAddTransfer(BRHederaWallet wallet, BRHederaTransaction transfer);
+extern int hederaWalletHasTransfer (BRHederaWallet wallet,
+                                    OwnershipKept BRHederaTransaction transfer);
+
+extern void hederaWalletAddTransfer(BRHederaWallet wallet,
+                                    OwnershipKept BRHederaTransaction transfer);
+
 extern void hederaWalletRemTransfer (BRHederaWallet wallet,
                                      OwnershipKept BRHederaTransaction transaction);
+
+extern void hederaWalletUpdateTransfer (BRHederaWallet wallet,
+                                        OwnershipKept BRHederaTransaction transaction);
+
 extern int
 hederaWalletHasAddress (BRHederaWallet wallet,
                         BRHederaAddress address);

--- a/WalletKitCore/src/ripple/BRRippleTransfer.c
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.c
@@ -147,6 +147,39 @@ extern int rippleTransferHasSource (BRRippleTransfer transfer,
     return rippleAddressEqual (transfer->sourceAddress, source);
 }
 
+extern int rippleTransferHasTarget (BRRippleTransfer transfer,
+                                    BRRippleAddress target) {
+    return rippleAddressEqual (transfer->targetAddress, target);
+}
+
+extern BRRippleUnitDrops rippleTransferGetAmountDirected (BRRippleTransfer transfer,
+                                                          BRRippleAddress address,
+                                                          int *negative) {
+    BRRippleUnitDrops fee    = rippleTransferGetFee(transfer);
+    BRRippleUnitDrops amount = (rippleTransferHasError(transfer)
+                                ? 0
+                                : rippleTransferGetAmount(transfer));
+
+    int isSource = rippleTransferHasSource (transfer, address);
+    int isTarget = rippleTransferHasTarget (transfer, address);
+
+    if (isSource && isTarget) {
+        *negative = 1;
+        return fee;
+    }
+    else if (isSource) {
+        *negative = 1;
+        return amount + fee;
+    }
+    else if (isTarget) {
+        *negative = 0;
+        return amount;
+    }
+    else {
+        assert (0);
+    }
+}
+
 extern int
 rippleTransferHasError(BRRippleTransfer transfer) {
     return transfer->error;

--- a/WalletKitCore/src/ripple/BRRippleTransfer.h
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.h
@@ -53,5 +53,12 @@ extern BRRippleTransaction rippleTransferGetTransaction(BRRippleTransfer transfe
 extern int rippleTransferHasSource (BRRippleTransfer transfer,
                                     BRRippleAddress source);
 
+extern int rippleTransferHasTarget (BRRippleTransfer transfer,
+                                    BRRippleAddress source);
+
+extern BRRippleUnitDrops rippleTransferGetAmountDirected (BRRippleTransfer transfer,
+                                                          BRRippleAddress address,
+                                                          int *negative);
+
 extern uint64_t rippleTransferGetBlockHeight (BRRippleTransfer transfer);
 #endif

--- a/WalletKitCore/src/ripple/BRRippleWallet.h
+++ b/WalletKitCore/src/ripple/BRRippleWallet.h
@@ -131,4 +131,6 @@ extern void rippleWalletAddTransfer (BRRippleWallet wallet,
 extern void rippleWalletRemTransfer (BRRippleWallet wallet,
                                      OwnershipKept BRRippleTransfer transfer);
 
+extern void rippleWalletUpdateTransfer (BRRippleWallet wallet,
+                                        OwnershipKept BRRippleTransfer transfer);
 #endif


### PR DESCRIPTION
Adds a GEN function genWalletUpdTransfer with XRP, HBAR implementations for BRGenericWalletUpdTransfer.  The XRP, HBAR will call `<currency>WalletUpdateTransfer` which for XRP will update the balance + sequence number and for HBAR will update the balance based on the current transfer state.  Thus submitted->{included,errored} will be handled properly.

Also updates some XRP, HBAR code for adding/removing wallet transfers to be more uniform between the currencies and to improve the computation.  Specifically adding a transfer incrementally updates the wallet balance; but removing a transfer recomputes the balance from all remaining transfers.  (Too hard to determine if the removed transfer should be subtracted off, if it was included/errored *when it was added* - so just recompute.)