### PR TITLE
CORE-1010: Chain-specific handlers for BRCryptoFeeBasis

### DIFF
--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -137,7 +137,10 @@ cwmAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
                                    OwnershipGiven BRCryptoClientCallbackState callbackState,
                                    BRCryptoBoolean success,
                                    OwnershipKept const char *hash,
-                                   uint64_t costUnits);
+                                   uint64_t costUnits,
+                                   size_t attributesCount,
+                                   OwnershipKept const char **attributeKeys,
+                                   OwnershipKept const char **attributeVals);
 
 typedef struct {
     BRCryptoClientContext context;

--- a/WalletKitCore/include/BRCryptoFeeBasis.h
+++ b/WalletKitCore/include/BRCryptoFeeBasis.h
@@ -21,15 +21,8 @@ extern "C" {
 
 typedef struct BRCryptoFeeBasisRecord *BRCryptoFeeBasis;
 
-extern BRCryptoFeeBasis
-cryptoFeeBasisCreate (BRCryptoAmount pricePerCostFactor,
-                      double costFactor);
-
 extern BRCryptoAmount
 cryptoFeeBasisGetPricePerCostFactor (BRCryptoFeeBasis feeBasis);
-
-extern BRCryptoUnit
-cryptoFeeBasisGetPricePerCostFactorUnit (BRCryptoFeeBasis feeBasis);
 
 extern double
 cryptoFeeBasisGetCostFactor (BRCryptoFeeBasis feeBasis);

--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -184,11 +184,6 @@ extern "C" {
     extern void
     cryptoWalletRemTransfer (BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
-//    extern BRCryptoFeeBasis
-//    cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
-//                                BRCryptoAmount pricePerCostFactor,
-//                                double costFactor);
-
     extern BRCryptoBoolean
     cryptoWalletEqual (BRCryptoWallet w1, BRCryptoWallet w2);
 

--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -184,10 +184,10 @@ extern "C" {
     extern void
     cryptoWalletRemTransfer (BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
-    extern BRCryptoFeeBasis
-    cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
-                                BRCryptoAmount pricePerCostFactor,
-                                double costFactor);
+//    extern BRCryptoFeeBasis
+//    cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
+//                                BRCryptoAmount pricePerCostFactor,
+//                                double costFactor);
 
     extern BRCryptoBoolean
     cryptoWalletEqual (BRCryptoWallet w1, BRCryptoWallet w2);

--- a/WalletKitCore/include/BRCryptoWalletManager.h
+++ b/WalletKitCore/include/BRCryptoWalletManager.h
@@ -216,7 +216,9 @@ extern "C" {
                                          BRCryptoCookie cookie,
                                          BRCryptoAddress target,
                                          BRCryptoAmount  amount,
-                                         BRCryptoNetworkFee fee);
+                                         BRCryptoNetworkFee fee,
+                                         size_t attributesCount,
+                                         OwnershipKept BRCryptoTransferAttribute *attributes);
 
     extern BRCryptoWalletSweeperStatus
     cryptoWalletManagerWalletSweeperValidateSupported (BRCryptoWalletManager cwm,

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -788,7 +788,10 @@ cwmAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
                                    OwnershipGiven BRCryptoClientCallbackState callbackState,
                                    BRCryptoBoolean success,
                                    OwnershipKept const char *hash,
-                                   uint64_t costUnits) {
+                                   uint64_t costUnits,
+                                   size_t attributesCount,
+                                   OwnershipKept const char **attributeKeys,
+                                   OwnershipKept const char **attributeVals) {
     assert (CLIENT_CALLBACK_ESTIMATE_TRANSACTION_FEE == callbackState->type);
 
     BRCryptoStatus status = (CRYPTO_TRUE == success ? CRYPTO_SUCCESS : CRYPTO_ERROR_FAILED);
@@ -798,7 +801,12 @@ cwmAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
 
     BRCryptoAmount pricePerCostFactor = cryptoNetworkFeeGetPricePerCostFactor (networkFee);
     double costFactor = (double) costUnits;
-    BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
+    BRCryptoFeeBasis feeBasis = cryptoWalletManagerRecoverFeeBasisFromEstimate(cwm,
+                                                                               networkFee,
+                                                                               costFactor,
+                                                                               attributesCount,
+                                                                               attributeKeys,
+                                                                               attributeVals);
 
     cryptoWalletGenerateEvent (cwm->wallet, (BRCryptoWalletEvent) {
         CRYPTO_WALLET_EVENT_FEE_BASIS_ESTIMATED,

--- a/WalletKitCore/src/crypto/BRCryptoFeeBasis.c
+++ b/WalletKitCore/src/crypto/BRCryptoFeeBasis.c
@@ -29,10 +29,11 @@ cryptoFeeBasisAllocAndInit (size_t sizeInBytes,
     feeBasis->type = type;
     feeBasis->handlers = cryptoHandlersLookup (type)->feeBasis;
     feeBasis->sizeInBytes = sizeInBytes;
+    feeBasis->ref  = CRYPTO_REF_ASSIGN (cryptoFeeBasisRelease);
     
     feeBasis->unit = cryptoUnitTake (unit);
     
-    feeBasis->ref  = CRYPTO_REF_ASSIGN (cryptoFeeBasisRelease);
+    if (NULL != createCallback) createCallback (createContext, feeBasis);
 
     return feeBasis;
 }

--- a/WalletKitCore/src/crypto/BRCryptoFeeBasisP.h
+++ b/WalletKitCore/src/crypto/BRCryptoFeeBasisP.h
@@ -18,11 +18,53 @@
 extern "C" {
 #endif
 
+typedef void
+(*BRCryptoFeeBasisReleaseHandler) (BRCryptoFeeBasis feeBasis);
+
+typedef double
+(*BRCryptoFeeBasisGetCostFactorHandler) (BRCryptoFeeBasis feeBasis);
+
+typedef BRCryptoAmount
+(*BRCryptoFeeBasisGetPricePerCostFactorHandler) (BRCryptoFeeBasis feeBasis);
+
+typedef BRCryptoAmount
+(*BRCryptoFeeBasisGetFeeHandler) (BRCryptoFeeBasis feeBasis);
+
+typedef BRCryptoBoolean
+(*BRCryptoFeeBasisIsEqualHandler) (BRCryptoFeeBasis feeBasis1,
+                                   BRCryptoFeeBasis feeBasis2);
+
+typedef struct {
+    BRCryptoFeeBasisReleaseHandler release;
+    BRCryptoFeeBasisGetCostFactorHandler getCostFactor;
+    BRCryptoFeeBasisGetPricePerCostFactorHandler getPricePerCostFactor;
+    BRCryptoFeeBasisGetFeeHandler getFee;
+    BRCryptoFeeBasisIsEqualHandler isEqual;
+} BRCryptoFeeBasisHandlers;
+
 struct BRCryptoFeeBasisRecord {
-    BRCryptoAmount pricePerCostFactor;
-    double costFactor;
+    BRCryptoBlockChainType type;
+    const BRCryptoFeeBasisHandlers *handlers;
     BRCryptoRef ref;
+    size_t sizeInBytes;
+    
+    BRCryptoUnit unit;
 };
+
+typedef void *BRCryptoFeeBasisCreateContext;
+typedef void (*BRCryptoFeeBasisCreateCallback) (BRCryptoFeeBasisCreateContext context,
+                                                BRCryptoFeeBasis feeBasis);
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisAllocAndInit (size_t sizeInBytes,
+                            BRCryptoBlockChainType type,
+                            BRCryptoUnit unit,
+                            BRCryptoFeeBasisCreateContext  createContext,
+                            BRCryptoFeeBasisCreateCallback createCallback);
+
+private_extern BRCryptoBlockChainType
+cryptoFeeBasisGetType (BRCryptoFeeBasis feeBasis);
+
 
 #ifdef __cplusplus
 }

--- a/WalletKitCore/src/crypto/BRCryptoHandlers.c
+++ b/WalletKitCore/src/crypto/BRCryptoHandlers.c
@@ -23,6 +23,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersBTC,
         &cryptoWalletSweeperHandlersBTC,
         &cryptoPaymentProtocolHandlersBTC,
+        &cryptoFeeBasisHandlersBTC,
         &cryptoWalletManagerHandlersBTC
     },
 
@@ -34,6 +35,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersBCH,
         &cryptoWalletSweeperHandlersBCH,
         &cryptoPaymentProtocolHandlersBTC,
+        &cryptoFeeBasisHandlersBTC,
         &cryptoWalletManagerHandlersBCH
     },
 
@@ -45,6 +47,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersBSV,
         &cryptoWalletSweeperHandlersBSV,
         &cryptoPaymentProtocolHandlersBTC,
+        &cryptoFeeBasisHandlersBTC,
         &cryptoWalletManagerHandlersBSV
     },
 
@@ -56,6 +59,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersETH,
         NULL,//BRCryptoWalletSweeperHandlers not supported
         NULL,//BRCryptoPaymentProtocolHandlers not supported
+        &cryptoFeeBasisHandlersETH,
         &cryptoWalletManagerHandlersETH
     },
 
@@ -67,6 +71,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersXRP,
         NULL,//BRCryptoWalletSweeperHandlers not supported
         NULL,//BRCryptoPaymentProtocolHandlers not supported
+        &cryptoFeeBasisHandlersXRP,
         &cryptoWalletManagerHandlersXRP
     },
 
@@ -78,6 +83,7 @@ static BRCryptoHandlers handlers[NUMBER_OF_NETWORK_TYPES] = {
         &cryptoWalletHandlersHBAR,
         NULL,//BRCryptoWalletSweeperHandlers not supported
         NULL,//BRCryptoPaymentProtocolHandlers not supported
+        &cryptoFeeBasisHandlersHBAR,
         &cryptoWalletManagerHandlersHBAR
     },
 };

--- a/WalletKitCore/src/crypto/BRCryptoHandlersP.h
+++ b/WalletKitCore/src/crypto/BRCryptoHandlersP.h
@@ -18,6 +18,7 @@
 #include "BRCryptoWalletManagerP.h"
 #include "BRCryptoWalletSweeperP.h"
 #include "BRCryptoPaymentP.h"
+#include "BRCryptoFeeBasisP.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +40,7 @@ typedef struct {
     // (cryptoWalletManagerWalletSweeperValidateSupported status is CRYPTO_WALLET_SWEEPER_UNSUPPORTED_CURRENCY)
     const BRCryptoWalletSweeperHandlers *sweeper;
     const BRCryptoPaymentProtocolHandlers *payment;
+    const BRCryptoFeeBasisHandlers *feeBasis;
     const BRCryptoWalletManagerHandlers *manager;
 } BRCryptoHandlers;
 

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -191,16 +191,21 @@ cryptoTransferGetAmountDirected (BRCryptoTransfer transfer) {
 extern BRCryptoAmount
 cryptoTransferGetAmountDirectedNet (BRCryptoTransfer transfer) {
     BRCryptoAmount amount = cryptoTransferGetAmountDirected (transfer);
-    BRCryptoAmount fee    = cryptoTransferGetFee (transfer);
 
-    if (NULL == fee) return amount;
-
-    BRCryptoAmount amountNet = cryptoAmountSub (amount, fee);
-
-    cryptoAmountGive (fee);
-    cryptoAmountGive (amount);
-
-    return amountNet;
+    if (CRYPTO_TRANSFER_SENT == cryptoTransferGetDirection (transfer)) {
+        BRCryptoAmount fee = cryptoTransferGetFee (transfer);
+        
+        if (NULL == fee) return amount;
+        
+        BRCryptoAmount amountNet = cryptoAmountSub (amount, fee);
+        
+        cryptoAmountGive (fee);
+        cryptoAmountGive (amount);
+        
+        return amountNet;
+    } else {
+        return amount;
+    }
 }
 
 extern BRCryptoUnit

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -448,21 +448,6 @@ cryptoWalletCreateTransferForPaymentProtocolRequest (BRCryptoWallet wallet,
                                             estimatedFeeBasis);
 }
 
-//extern BRCryptoFeeBasis
-//cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
-//                            BRCryptoAmount pricePerCostFactor,
-//                            double costFactor) {
-//
-//    BRCryptoCurrency feeCurrency = cryptoUnitGetCurrency (wallet->unitForFee);
-//    if (CRYPTO_FALSE == cryptoAmountHasCurrency (pricePerCostFactor, feeCurrency)) {
-//        cryptoCurrencyGive (feeCurrency);
-//        return NULL;
-//    }
-//    cryptoCurrencyGive (feeCurrency);
-//
-//    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
-//}
-
 extern BRCryptoBoolean
 cryptoWalletEqual (BRCryptoWallet w1, BRCryptoWallet w2) {
     return AS_CRYPTO_BOOLEAN (w1 == w2 ||

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -448,20 +448,20 @@ cryptoWalletCreateTransferForPaymentProtocolRequest (BRCryptoWallet wallet,
                                             estimatedFeeBasis);
 }
 
-extern BRCryptoFeeBasis
-cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
-                            BRCryptoAmount pricePerCostFactor,
-                            double costFactor) {
-
-    BRCryptoCurrency feeCurrency = cryptoUnitGetCurrency (wallet->unitForFee);
-    if (CRYPTO_FALSE == cryptoAmountHasCurrency (pricePerCostFactor, feeCurrency)) {
-        cryptoCurrencyGive (feeCurrency);
-        return NULL;
-    }
-    cryptoCurrencyGive (feeCurrency);
-
-    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
-}
+//extern BRCryptoFeeBasis
+//cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
+//                            BRCryptoAmount pricePerCostFactor,
+//                            double costFactor) {
+//
+//    BRCryptoCurrency feeCurrency = cryptoUnitGetCurrency (wallet->unitForFee);
+//    if (CRYPTO_FALSE == cryptoAmountHasCurrency (pricePerCostFactor, feeCurrency)) {
+//        cryptoCurrencyGive (feeCurrency);
+//        return NULL;
+//    }
+//    cryptoCurrencyGive (feeCurrency);
+//
+//    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
+//}
 
 extern BRCryptoBoolean
 cryptoWalletEqual (BRCryptoWallet w1, BRCryptoWallet w2) {

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1848,6 +1848,7 @@ cryptoWalletManagerRecoverFeeBasisFromEstimate (BRCryptoWalletManager cwm,
                                                 size_t attributesCount,
                                                 OwnershipKept const char **attributeKeys,
                                                 OwnershipKept const char **attributeVals) {
+    assert (NULL != cwm->handlers->recoverFeeBasisFromFeeEstimate); // not supported by chain
     return cwm->handlers->recoverFeeBasisFromFeeEstimate (cwm,
                                                           networkFee,
                                                           costUnits,

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1203,13 +1203,17 @@ cryptoWalletManagerEstimateFeeBasis (BRCryptoWalletManager manager,
                                      BRCryptoCookie cookie,
                                      BRCryptoAddress target,
                                      BRCryptoAmount  amount,
-                                     BRCryptoNetworkFee fee) {
+                                     BRCryptoNetworkFee fee,
+                                     size_t attributesCount,
+                                     OwnershipKept BRCryptoTransferAttribute *attributes) {
     BRCryptoFeeBasis feeBasis = manager->handlers->estimateFeeBasis (manager,
                                                                      wallet,
                                                                      cookie,
                                                                      target,
                                                                      amount,
-                                                                     fee);
+                                                                     fee,
+                                                                     attributesCount,
+                                                                     attributes);
     if (NULL != feeBasis)
         cryptoWalletGenerateEvent (wallet, (BRCryptoWalletEvent) {
             CRYPTO_WALLET_EVENT_FEE_BASIS_ESTIMATED,
@@ -1835,4 +1839,19 @@ private_extern void
 cryptoWalletManagerRecoverTransferFromTransferBundle (BRCryptoWalletManager cwm,
                                                       OwnershipKept BRCryptoClientTransferBundle bundle) {
     cwm->handlers->recoverTransferFromTransferBundle (cwm, bundle);
+}
+
+private_extern BRCryptoFeeBasis
+cryptoWalletManagerRecoverFeeBasisFromEstimate (BRCryptoWalletManager cwm,
+                                                BRCryptoNetworkFee networkFee,
+                                                double costUnits,
+                                                size_t attributesCount,
+                                                OwnershipKept const char **attributeKeys,
+                                                OwnershipKept const char **attributeVals) {
+    return cwm->handlers->recoverFeeBasisFromFeeEstimate (cwm,
+                                                          networkFee,
+                                                          costUnits,
+                                                          attributesCount,
+                                                          attributeKeys,
+                                                          attributeVals);
 }

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -85,7 +85,9 @@ typedef BRCryptoFeeBasis // If NULL, don't generate WalletEvent; expect QRY call
                                                  BRCryptoCookie cookie,
                                                  BRCryptoAddress target,
                                                  BRCryptoAmount amount,
-                                                 BRCryptoNetworkFee fee);
+                                                 BRCryptoNetworkFee fee,
+                                                 size_t attributesCount,
+                                                 OwnershipKept BRCryptoTransferAttribute *attributes);
 
 typedef BRCryptoClientP2PManager
 (*BRCryptoWalletManagerCreateP2PManagerHandler) (BRCryptoWalletManager cwm);
@@ -101,6 +103,14 @@ typedef void
 typedef void
 (*BRCryptoWalletManagerRecoverTransferFromTransferBundleHandler) (BRCryptoWalletManager cwm,
                                                                   OwnershipKept BRCryptoClientTransferBundle bundle);
+
+typedef BRCryptoFeeBasis
+(*BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler) (BRCryptoWalletManager cwm,
+                                                               BRCryptoNetworkFee networkFee,
+                                                               double costUnits,
+                                                               size_t attributesCount,
+                                                               OwnershipKept const char **attributeKeys,
+                                                               OwnershipKept const char **attributeVals);
 
 typedef BRCryptoWalletSweeperStatus
 (*BRCryptoWalletManagerWalletSweeperValidateSupportedHandler) (BRCryptoWalletManager cwm,
@@ -125,6 +135,7 @@ typedef struct {
     BRCryptoWalletManagerEstimateFeeBasisHandler estimateFeeBasis;
     BRCryptoWalletManagerRecoverTransfersFromTransactionBundleHandler recoverTransfersFromTransactionBundle;
     BRCryptoWalletManagerRecoverTransferFromTransferBundleHandler recoverTransferFromTransferBundle;
+    BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler recoverFeeBasisFromFeeEstimate;
     BRCryptoWalletManagerWalletSweeperValidateSupportedHandler validateSweeperSupported;
     BRCryptoWalletManagerCreateWalletSweeperHandler createSweeper;
 } BRCryptoWalletManagerHandlers;
@@ -259,6 +270,15 @@ cryptoWalletManagerRecoverTransferFromTransferBundle (BRCryptoWalletManager cwm,
 //                                          BRCryptoWallet wallet,
 //                                          BRCryptoWalletEvent event);
 //
+
+
+private_extern BRCryptoFeeBasis
+cryptoWalletManagerRecoverFeeBasisFromEstimate (BRCryptoWalletManager cwm,
+                                                BRCryptoNetworkFee networkFee,
+                                                double costUnits,
+                                                size_t attributesCount,
+                                                OwnershipKept const char **attributeKeys,
+                                                OwnershipKept const char **attributeVals);
 
 static inline void
 cryptoWalletManagerGenerateEvent (BRCryptoWalletManager manager,

--- a/WalletKitCore/src/crypto/handlers/BRCryptoHandlersExport.h
+++ b/WalletKitCore/src/crypto/handlers/BRCryptoHandlersExport.h
@@ -25,6 +25,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersBTC;
 extern BRCryptoWalletHandlers cryptoWalletHandlersBTC;
 extern BRCryptoWalletSweeperHandlers cryptoWalletSweeperHandlersBTC;
 extern BRCryptoPaymentProtocolHandlers cryptoPaymentProtocolHandlersBTC;
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersBTC;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBTC;
 
 // MARK: - BCH Handlers
@@ -35,6 +36,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersBCH;
 extern BRCryptoWalletHandlers cryptoWalletHandlersBCH;
 extern BRCryptoWalletSweeperHandlers cryptoWalletSweeperHandlersBCH;
 // Payment Protocol
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersBCH;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBCH;
 
 // MARK: - BSV Handlers
@@ -45,6 +47,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersBSV;
 extern BRCryptoWalletHandlers cryptoWalletHandlersBSV;
 extern BRCryptoWalletSweeperHandlers cryptoWalletSweeperHandlersBSV;
 // Payment Protocol
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersBSV;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBSV;
 
 // MARK: - ETH Handlers
@@ -55,6 +58,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersETH;
 extern BRCryptoWalletHandlers cryptoWalletHandlersETH;
 // Wallet Sweep
 // Payment Protocol
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersETH;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH;
 
 // MARK: - XRP Handlers
@@ -65,6 +69,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersXRP;
 extern BRCryptoWalletHandlers cryptoWalletHandlersXRP;
 // Wallet Sweep
 // Payment Protocol
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersXRP;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXRP;
 
 // MARK: - HBAR Handlers
@@ -75,6 +80,7 @@ extern BRCryptoTransferHandlers cryptoTransferHandlersHBAR;
 extern BRCryptoWalletHandlers cryptoWalletHandlersHBAR;
 // Wallet Sweep
 // Payment Protocol
+extern BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersHBAR;
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersHBAR;
 
 #ifdef __cplusplus

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
@@ -16,6 +16,7 @@
 
 #include "crypto/BRCryptoWalletSweeperP.h"
 #include "crypto/BRCryptoPaymentP.h"
+#include "crypto/BRCryptoFeeBasisP.h"
 
 #include "bitcoin/BRWallet.h"
 #include "bitcoin/BRTransaction.h"
@@ -203,7 +204,13 @@ typedef struct BRCryptoPaymentProtocolPaymentBTCRecord {
     BRPaymentProtocolPayment *payment; // only used for BIP70
 } *BRCryptoPaymentProtocolPaymentBTC;
 
-// MARK: - Support
+// MARK: - Fee Basis
+
+typedef struct BRCryptoFeeBasisBTCRecord {
+    struct BRCryptoFeeBasisRecord base;
+    uint64_t feePerKB;
+    uint32_t sizeInByte;
+} *BRCryptoFeeBasisBTC;
 
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
@@ -212,6 +219,8 @@ cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
 
 private_extern uint64_t // SAT-per-KB
 cryptoFeeBasisAsBTC (BRCryptoFeeBasis feeBasis);
+
+// MARK: - Support
 
 private_extern BRCryptoHash
 cryptoHashCreateAsBTC (UInt256 btc);

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoFeeBasisBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoFeeBasisBTC.c
@@ -1,0 +1,105 @@
+//
+//  BRCryptoFeeBasisBTC.c
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-09-04.
+//  Copyright © 2019 Breadwallet AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#include "BRCryptoBTC.h"
+#include "crypto/BRCryptoFeeBasisP.h"
+#include "crypto/BRCryptoAmountP.h"
+#include "ethereum/util/BRUtil.h"
+
+#include <math.h>
+
+static BRCryptoFeeBasisBTC
+cryptoFeeBasisCoerce (BRCryptoFeeBasis feeBasis) {
+    assert (CRYPTO_NETWORK_TYPE_BTC == feeBasis->type);
+    return (BRCryptoFeeBasisBTC) feeBasis;
+}
+
+typedef struct {
+    uint64_t feePerKB;
+    uint32_t sizeInByte;
+} BRCryptoFeeBasisCreateContextBTC;
+
+static void
+cryptoFeeBasisCreateCallbackBTC (BRCryptoFeeBasisCreateContext context,
+                                 BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisCreateContextBTC *contextBTC = (BRCryptoFeeBasisCreateContextBTC*) context;
+    BRCryptoFeeBasisBTC feeBasisBTC = cryptoFeeBasisCoerce (feeBasis);
+    
+    feeBasisBTC->feePerKB = contextBTC->feePerKB;
+    feeBasisBTC->sizeInByte = contextBTC->sizeInByte;
+}
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
+                           uint64_t feePerKB,
+                           uint32_t sizeInByte) {
+    BRCryptoFeeBasisCreateContextBTC contextBTC = {
+        feePerKB,
+        sizeInByte
+    };
+    
+    return cryptoFeeBasisAllocAndInit (sizeof (struct BRCryptoFeeBasisBTCRecord),
+                                       CRYPTO_NETWORK_TYPE_BTC,
+                                       unit,
+                                       &contextBTC,
+                                       cryptoFeeBasisCreateCallbackBTC);
+}
+
+private_extern uint64_t // SAT-per-KB
+cryptoFeeBasisAsBTC (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    return btcFeeBasis->feePerKB;
+}
+
+static void
+cryptoFeeBasisReleaseBTC (BRCryptoFeeBasis feeBasis) {
+}
+
+static double
+cryptoFeeBasisGetCostFactorBTC (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    return ((double) btcFeeBasis->sizeInByte) / 1000.0;
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetPricePerCostFactorBTC (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    return cryptoAmountCreate (feeBasis->unit,
+                               CRYPTO_FALSE,
+                               uint256Create(btcFeeBasis->feePerKB));
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetFeeBTC (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    double fee = (((double) btcFeeBasis->feePerKB) * btcFeeBasis->sizeInByte) / 1000.0;
+    return cryptoAmountCreate (feeBasis->unit,
+                               CRYPTO_FALSE,
+                               uint256Create ((uint64_t) lround (fee)));
+}
+
+static BRCryptoBoolean
+cryptoFeeBasisIsEqualBTC (BRCryptoFeeBasis feeBasis1, BRCryptoFeeBasis feeBasis2) {
+    BRCryptoFeeBasisBTC fb1 = cryptoFeeBasisCoerce (feeBasis1);
+    BRCryptoFeeBasisBTC fb2 = cryptoFeeBasisCoerce (feeBasis2);
+
+    return (fb1->feePerKB == fb2->feePerKB &&
+            fb1->sizeInByte == fb2->sizeInByte);
+}
+
+// MARK: - Handlers
+
+BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersBTC = {
+    cryptoFeeBasisReleaseBTC,
+    cryptoFeeBasisGetCostFactorBTC,
+    cryptoFeeBasisGetPricePerCostFactorBTC,
+    cryptoFeeBasisGetFeeBTC,
+    cryptoFeeBasisIsEqualBTC
+};

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoPaymentBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoPaymentBTC.c
@@ -213,10 +213,10 @@ cryptoPaymentProtocolRequestCreateForBip70BTC (BRCryptoNetwork cryptoNetwork,
 
 extern BRCryptoFeeBasis
 cryptoPaymentProtocolRequestEstimateFeBasisBTC (BRCryptoPaymentProtocolRequest protoReqBase,
-                                                         BRCryptoWalletManager cwm,
-                                                         BRCryptoWallet wallet,
-                                                         BRCryptoCookie cookie,
-                                                         BRCryptoNetworkFee networkFee) {
+                                                BRCryptoWalletManager cwm,
+                                                BRCryptoWallet wallet,
+                                                BRCryptoCookie cookie,
+                                                BRCryptoNetworkFee networkFee) {
     BRWallet *wid = cryptoWalletAsBTC (wallet);
     uint64_t btcFeePerKB = 1000 * cryptoNetworkFeeAsBTC (networkFee);
     uint64_t btcFee = 0;

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoSupportBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoSupportBTC.c
@@ -14,28 +14,6 @@
 #include "crypto/BRCryptoAmountP.h"
 #include "ethereum/util/BRUtilMath.h"
 
-private_extern BRCryptoFeeBasis
-cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
-                           uint64_t feePerKB,
-                           uint32_t sizeInByte) {
-    return cryptoFeeBasisCreate (cryptoAmountCreate (unit,
-                                                     CRYPTO_FALSE,
-                                                     uint256Create(feePerKB)),
-                                 sizeInByte / 1000.0);
-}
-
-private_extern uint64_t // SAT-per-KB
-cryptoFeeBasisAsBTC (BRCryptoFeeBasis feeBasis) {
-#ifdef REFACTOR
-    assert (BLOCK_CHAIN_TYPE_BTC == feeBasis->type);
-#endif
-    BRCryptoBoolean overflow;
-    BRCryptoAmount costPerPriceFactor = cryptoFeeBasisGetPricePerCostFactor(feeBasis);
-    uint64_t satPerKb = cryptoAmountGetIntegerRaw(costPerPriceFactor, &overflow);
-
-    assert (CRYPTO_FALSE == overflow);
-    return satPerKb;
-}
 
 private_extern BRCryptoHash
 cryptoHashCreateAsBTC (UInt256 btc) {

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
@@ -648,7 +648,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBTC = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
-    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };
@@ -666,7 +666,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBCH = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
-    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };
@@ -684,7 +684,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBSV = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
-    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
@@ -208,7 +208,9 @@ cryptoWalletManagerEstimateFeeBasisBTC (BRCryptoWalletManager cwm,
                                         BRCryptoCookie cookie,
                                         BRCryptoAddress target,
                                         BRCryptoAmount amount,
-                                        BRCryptoNetworkFee networkFee) {
+                                        BRCryptoNetworkFee networkFee,
+                                        size_t attributesCount,
+                                        OwnershipKept BRCryptoTransferAttribute *attributes) {
     BRWallet *btcWallet = cryptoWalletAsBTC(wallet);
 
     BRCryptoBoolean overflow = CRYPTO_FALSE;
@@ -646,6 +648,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBTC = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };
@@ -663,6 +666,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBCH = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };
@@ -680,6 +684,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBSV = {
     cryptoWalletManagerEstimateFeeBasisBTC,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleBTC,
     cryptoWalletManagerRecoverTransferFromTransferBundleBTC,
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
     cryptoWalletManagerWalletSweeperValidateSupportedBTC,
     cryptoWalletManagerCreateWalletSweeperBTC
 };

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoETH.h
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoETH.h
@@ -215,15 +215,21 @@ private_extern BRCryptoCurrency
 cryptoNetworkGetCurrencyforTokenETH (BRCryptoNetwork network,
                                      BREthereumToken token);
 
-// MARK: - Support
+// MARK: - Fee Basis
+
+typedef struct BRCryptoFeeBasisETHRecord {
+    struct BRCryptoFeeBasisRecord base;
+    BREthereumFeeBasis ethFeeBasis;
+} *BRCryptoFeeBasisETH;
 
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsETH (BRCryptoUnit unit,
                            BREthereumFeeBasis feeBasis);
 
-
 private_extern BREthereumFeeBasis
 cryptoFeeBasisAsETH (BRCryptoFeeBasis feeBasis);
+
+// MARK: - Support
 
 private_extern BRCryptoHash
 cryptoHashCreateAsETH (BREthereumHash hash);

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoFeeBasisETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoFeeBasisETH.c
@@ -1,0 +1,107 @@
+//
+//  BRCryptoFeeBasisETH.c
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-09-04.
+//  Copyright © 2019 Breadwallet AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#include "BRCryptoETH.h"
+#include "crypto/BRCryptoFeeBasisP.h"
+#include "crypto/BRCryptoAmountP.h"
+
+static BRCryptoFeeBasisETH
+cryptoFeeBasisCoerce (BRCryptoFeeBasis feeBasis) {
+    assert (CRYPTO_NETWORK_TYPE_ETH == feeBasis->type);
+    return (BRCryptoFeeBasisETH) feeBasis;
+}
+
+typedef struct {
+    BREthereumFeeBasis ethFeeBasis;
+} BRCryptoFeeBasisCreateContextETH;
+
+static void
+cryptoFeeBasisCreateCallbackETH (BRCryptoFeeBasisCreateContext context,
+                                 BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisCreateContextETH *contextETH = (BRCryptoFeeBasisCreateContextETH*) context;
+    BRCryptoFeeBasisETH feeBasisETH = cryptoFeeBasisCoerce (feeBasis);
+    
+    feeBasisETH->ethFeeBasis = contextETH->ethFeeBasis;
+}
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsETH (BRCryptoUnit unit,
+                           BREthereumFeeBasis ethFeeBasis) {
+    BRCryptoFeeBasisCreateContextETH contextETH = {
+        ethFeeBasis
+    };
+    
+    return cryptoFeeBasisAllocAndInit (sizeof (struct BRCryptoFeeBasisETHRecord),
+                                       CRYPTO_NETWORK_TYPE_ETH,
+                                       unit,
+                                       &contextETH,
+                                       cryptoFeeBasisCreateCallbackETH);
+}
+
+private_extern BREthereumFeeBasis
+cryptoFeeBasisAsETH (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisETH ethFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    return ethFeeBasis->ethFeeBasis;
+}
+
+static void
+cryptoFeeBasisReleaseETH (BRCryptoFeeBasis feeBasis) {
+}
+
+static double
+cryptoFeeBasisGetCostFactorETH (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisETH ethFeeBasis = cryptoFeeBasisCoerce (feeBasis);
+    return ethFeeBasis->ethFeeBasis.u.gas.limit.amountOfGas;
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetPricePerCostFactorETH (BRCryptoFeeBasis feeBasis) {
+    BREthereumFeeBasis ethFeeBasis = cryptoFeeBasisCoerce (feeBasis)->ethFeeBasis;
+    return cryptoAmountCreate (feeBasis->unit,
+                               CRYPTO_FALSE,
+                               ethFeeBasis.u.gas.price.etherPerGas.valueInWEI);
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetFeeETH (BRCryptoFeeBasis feeBasis) {
+    BREthereumFeeBasis ethFeeBasis = cryptoFeeBasisCoerce (feeBasis)->ethFeeBasis;
+    UInt256 gasPrice = ethFeeBasis.u.gas.price.etherPerGas.valueInWEI;
+    double  gasAmount = cryptoFeeBasisGetCostFactor (feeBasis);
+    
+    int overflow = 0, negative = 0;
+    double rem;
+    
+    UInt256 value = uint256Mul_Double (gasPrice, gasAmount, &overflow, &negative, &rem);
+    
+    return (overflow
+            ? NULL
+            : cryptoAmountCreateInternal (feeBasis->unit,
+                                          CRYPTO_FALSE,
+                                          value,
+                                          1));
+}
+
+static BRCryptoBoolean
+cryptoFeeBasisIsEqualETH (BRCryptoFeeBasis feeBasis1, BRCryptoFeeBasis feeBasis2) {
+    BRCryptoFeeBasisETH fb1 = cryptoFeeBasisCoerce (feeBasis1);
+    BRCryptoFeeBasisETH fb2 = cryptoFeeBasisCoerce (feeBasis2);
+
+    return ethFeeBasisEqual (&fb1->ethFeeBasis, &fb2->ethFeeBasis);
+}
+
+// MARK: - Handlers
+
+BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersETH = {
+    cryptoFeeBasisReleaseETH,
+    cryptoFeeBasisGetCostFactorETH,
+    cryptoFeeBasisGetPricePerCostFactorETH,
+    cryptoFeeBasisGetFeeETH,
+    cryptoFeeBasisIsEqualETH
+};

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoSupportETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoSupportETH.c
@@ -14,30 +14,7 @@
 
 #include <math.h>
 
-private_extern BRCryptoFeeBasis
-cryptoFeeBasisCreateAsETH (BRCryptoUnit unit,
-                           BREthereumFeeBasis feeBasis) {
-    double costFactor = (double) feeBasis.u.gas.limit.amountOfGas;
-    BRCryptoAmount pricePerCostFactor = cryptoAmountCreate (unit,
-                                                            CRYPTO_FALSE,
-                                                            feeBasis.u.gas.price.etherPerGas.valueInWEI);
 
-    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
-}
-
-private_extern BREthereumFeeBasis
-cryptoFeeBasisAsETH (BRCryptoFeeBasis feeBasis) {
-    double         costFactor         = cryptoFeeBasisGetCostFactor(feeBasis);
-    BRCryptoAmount pricePerCostFactor = cryptoFeeBasisGetPricePerCostFactor(feeBasis);
-
-    BREthereumGas ethGas = ethGasCreate ((uint64_t) lround (costFactor));
-    BREthereumGasPrice ethGasPrice = ethGasPriceCreate (ethEtherCreate (cryptoAmountGetValue(pricePerCostFactor)));
-
-    return (BREthereumFeeBasis) {
-        FEE_BASIS_GAS,
-        { .gas = { ethGas, ethGasPrice }}
-    };
-}
 
 
 private_extern BRCryptoHash

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -251,7 +251,9 @@ cryptoWalletManagerEstimateFeeBasisETH (BRCryptoWalletManager manager,
                                         BRCryptoCookie cookie,
                                         BRCryptoAddress target,
                                         BRCryptoAmount amount,
-                                        BRCryptoNetworkFee networkFee) {
+                                        BRCryptoNetworkFee networkFee,
+                                        size_t attributesCount,
+                                        OwnershipKept BRCryptoTransferAttribute *attributes) {
     BRCryptoWalletETH walletETH = cryptoWalletCoerce (wallet);
 
     BREthereumFeeBasis ethFeeBasis = {
@@ -280,6 +282,18 @@ cryptoWalletManagerEstimateFeeBasisETH (BRCryptoWalletManager manager,
 
     // Require QRY with cookie - made above
     return NULL;
+}
+
+static BRCryptoFeeBasis
+cryptoWalletManagerRecoverFeeBasisFromEstimateETH (BRCryptoWalletManager cwm,
+                                                   BRCryptoNetworkFee networkFee,
+                                                   double costUnits,
+                                                   size_t attributesCount,
+                                                   OwnershipKept const char **attributeKeys,
+                                                   OwnershipKept const char **attributeVals) {
+    BREthereumFeeBasis feeBasis = ethFeeBasisCreate (ethGasCreate ((uint64_t) costUnits),
+                                                     cryptoNetworkFeeAsETH (networkFee));
+    return cryptoFeeBasisCreateAsETH (networkFee->pricePerCostFactorUnit, feeBasis);
 }
 
 static void
@@ -801,7 +815,10 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH = {
     cryptoWalletManagerEstimateLimitETH,
     cryptoWalletManagerEstimateFeeBasisETH,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleETH,
-    cryptoWalletManagerRecoverTransferFromTransferBundleETH
+    cryptoWalletManagerRecoverTransferFromTransferBundleETH,
+    cryptoWalletManagerRecoverFeeBasisFromEstimateETH,
+    NULL,//BRCryptoWalletManagerWalletSweeperValidateSupportedHandler
+    NULL,//BRCryptoWalletManagerCreateWalletSweeperHandler
 };
 
 #if 0

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -817,8 +817,8 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH = {
     cryptoWalletManagerRecoverTransfersFromTransactionBundleETH,
     cryptoWalletManagerRecoverTransferFromTransferBundleETH,
     cryptoWalletManagerRecoverFeeBasisFromEstimateETH,
-    NULL,//BRCryptoWalletManagerWalletSweeperValidateSupportedHandler
-    NULL,//BRCryptoWalletManagerCreateWalletSweeperHandler
+    NULL,//BRCryptoWalletManagerWalletSweeperValidateSupportedHandler not supported
+    NULL,//BRCryptoWalletManagerCreateWalletSweeperHandler not supported
 };
 
 #if 0

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
@@ -79,6 +79,7 @@ BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersHBAR = {
     cryptoFeeBasisReleaseHBAR,
     cryptoFeeBasisGetCostFactorHBAR,
     cryptoFeeBasisGetPricePerCostFactorHBAR,
-    cryptoFeeBasisGetFeeHBAR
+    cryptoFeeBasisGetFeeHBAR,
+    cryptoFeeBasisIsEqualHBAR
 };
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
@@ -1,0 +1,84 @@
+//
+//  BRCryptoFeeBasisHBAR.c
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-09-04.
+//  Copyright © 2019 Breadwallet AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#include "BRCryptoHBAR.h"
+#include "crypto/BRCryptoFeeBasisP.h"
+#include "hedera/BRHedera.h"
+
+private_extern BRCryptoFeeBasisHBAR
+cryptoFeeBasisCoerceHBAR (BRCryptoFeeBasis feeBasis) {
+    assert (CRYPTO_NETWORK_TYPE_HBAR == feeBasis->type);
+    return (BRCryptoFeeBasisHBAR) feeBasis;
+}
+
+typedef struct {
+    BRHederaFeeBasis hbarFeeBasis;
+} BRCryptoFeeBasisCreateContextHBAR;
+
+static void
+cryptoFeeBasisCreateCallbackHBAR (BRCryptoFeeBasisCreateContext context,
+                                 BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisCreateContextHBAR *contextHBAR = (BRCryptoFeeBasisCreateContextHBAR*) context;
+    BRCryptoFeeBasisHBAR feeBasisHBAR = cryptoFeeBasisCoerceHBAR (feeBasis);
+    
+    feeBasisHBAR->hbarFeeBasis = contextHBAR->hbarFeeBasis;
+}
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsHBAR (BRCryptoUnit unit,
+                            BRHederaFeeBasis hbarFeeBasis) {
+    BRCryptoFeeBasisCreateContextHBAR contextHBAR = {
+        hbarFeeBasis
+    };
+    
+    return cryptoFeeBasisAllocAndInit (sizeof (struct BRCryptoFeeBasisHBARRecord),
+                                       CRYPTO_NETWORK_TYPE_HBAR,
+                                       unit,
+                                       &contextHBAR,
+                                       cryptoFeeBasisCreateCallbackHBAR);
+}
+
+static void
+cryptoFeeBasisReleaseHBAR (BRCryptoFeeBasis feeBasis) {
+}
+
+static double
+cryptoFeeBasisGetCostFactorHBAR (BRCryptoFeeBasis feeBasis) {
+    return (double) cryptoFeeBasisCoerceHBAR (feeBasis)->hbarFeeBasis.costFactor;
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetPricePerCostFactorHBAR (BRCryptoFeeBasis feeBasis) {
+    BRHederaFeeBasis hbarFeeBasis = cryptoFeeBasisCoerceHBAR (feeBasis)->hbarFeeBasis;
+    return cryptoAmountCreateAsHBAR (feeBasis->unit, CRYPTO_FALSE, hbarFeeBasis.pricePerCostFactor);
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetFeeHBAR (BRCryptoFeeBasis feeBasis) {
+    return cryptoFeeBasisGetPricePerCostFactor (feeBasis);
+}
+
+static BRCryptoBoolean
+cryptoFeeBasisIsEqualHBAR (BRCryptoFeeBasis feeBasis1, BRCryptoFeeBasis feeBasis2) {
+    BRCryptoFeeBasisHBAR fb1 = cryptoFeeBasisCoerceHBAR (feeBasis1);
+    BRCryptoFeeBasisHBAR fb2 = cryptoFeeBasisCoerceHBAR (feeBasis2);
+
+    return hederaFeeBasisIsEqual (&fb1->hbarFeeBasis, &fb2->hbarFeeBasis);
+}
+
+// MARK: - Handlers
+
+BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersHBAR = {
+    cryptoFeeBasisReleaseHBAR,
+    cryptoFeeBasisGetCostFactorHBAR,
+    cryptoFeeBasisGetPricePerCostFactorHBAR,
+    cryptoFeeBasisGetFeeHBAR
+};
+

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -12,6 +12,7 @@
 #define BRCryptoHBAR_h
 
 #include "../BRCryptoHandlersExport.h"
+#include "crypto/BRCryptoFeeBasisP.h"
 
 #include "hedera/BRHederaBase.h"
 #include "hedera/BRHederaAddress.h"
@@ -91,7 +92,19 @@ typedef struct BRCryptoWalletManagerHBARRecord {
 
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersHBAR;
 
-// MARK: - Events
+// MARK: - Fee Basis
+
+typedef struct BRCryptoFeeBasisHBARRecord {
+    struct BRCryptoFeeBasisRecord base;
+    BRHederaFeeBasis hbarFeeBasis;
+} *BRCryptoFeeBasisHBAR;
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsHBAR (BRCryptoUnit unit,
+                            BRHederaFeeBasis hbarFeeBasis);
+
+private_extern BRCryptoFeeBasisHBAR
+cryptoFeeBasisCoerceHBAR (BRCryptoFeeBasis feeBasis);
 
 // MARK: - Support
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -50,10 +50,8 @@ cryptoTransferCreateAsHBAR (BRCryptoTransferListener listener,
                                                       CRYPTO_FALSE,
                                                       hederaTransactionGetAmount (hbarTransaction));
     
-    BRCryptoAmount feeAmount = cryptoAmountCreateAsHBAR (unitForFee,
-                                                         CRYPTO_FALSE,
-                                                         hederaTransactionGetFee (hbarTransaction));
-    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreate (feeAmount, 1.0);
+    BRHederaFeeBasis hbarFeeBasis = { hederaTransactionGetFee (hbarTransaction), 1 };
+    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsHBAR (unitForFee, hbarFeeBasis);
     
     BRCryptoAddress sourceAddress = cryptoAddressCreateAsHBAR (hederaTransactionGetSource (hbarTransaction));
     BRCryptoAddress targetAddress = cryptoAddressCreateAsHBAR (hederaTransactionGetTarget (hbarTransaction));

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -49,8 +49,7 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
     BRHederaUnitTinyBar maxBalance = hederaAccountGetBalanceLimit (hbarAccount, 1, &hasMaxBalance);
 
     BRHederaFeeBasis feeBasisHBAR = hederaAccountGetDefaultFeeBasis (hbarAccount);
-    BRCryptoFeeBasis feeBasis     = cryptoFeeBasisCreate (cryptoAmountCreateInteger(hederaFeeBasisGetPricePerCostFactor(&feeBasisHBAR), unitForFee),
-                                                          (double) hederaFeeBasisGetCostFactor(&feeBasisHBAR));
+    BRCryptoFeeBasis feeBasis     = cryptoFeeBasisCreateAsHBAR (unitForFee, feeBasisHBAR);
 
     BRCryptoWalletCreateContextHBAR contextHBAR = {
         hbarAccount
@@ -178,11 +177,7 @@ cryptoWalletCreateTransferHBAR (BRCryptoWallet  wallet,
     UInt256 value = cryptoAmountGetValue (amount);
     BRHederaUnitTinyBar thbar = (BRHederaUnitTinyBar) value.u64[0];
     BRHederaAddress nodeAddress = hederaAccountGetNodeAddress (walletHBAR->hbarAccount);
-    BRHederaFeeBasis feeBasis;
-    feeBasis.costFactor = (uint32_t) estimatedFeeBasis->costFactor;
-    int overflow = 0;
-    feeBasis.pricePerCostFactor = (BRHederaUnitTinyBar) uint64Coerce(cryptoAmountGetValue(estimatedFeeBasis->pricePerCostFactor), &overflow);
-    assert(overflow == 0);
+    BRHederaFeeBasis feeBasis = cryptoFeeBasisCoerceHBAR (estimatedFeeBasis)->hbarFeeBasis;
     
     BRHederaTransaction tid = hederaTransactionCreateNew (source,
                                                           cryptoAddressAsHBAR (target),

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -167,11 +167,15 @@ cryptoWalletManagerEstimateFeeBasisHBAR (BRCryptoWalletManager manager,
                                          BRCryptoCookie cookie,
                                          BRCryptoAddress target,
                                          BRCryptoAmount amount,
-                                         BRCryptoNetworkFee networkFee) {
-    BRCryptoAmount pricePerCostFactor = cryptoNetworkFeeGetPricePerCostFactor (networkFee);
-    double costFactor = 1.0;  // 'cost factor' is 'transaction'
-
-    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
+                                         BRCryptoNetworkFee networkFee,
+                                         size_t attributesCount,
+                                         OwnershipKept BRCryptoTransferAttribute *attributes) {
+    UInt256 value = cryptoAmountGetValue (cryptoNetworkFeeGetPricePerCostFactor (networkFee));
+    BRHederaFeeBasis hbarFeeBasis;
+    hbarFeeBasis.pricePerCostFactor = (BRHederaUnitTinyBar) value.u64[0];
+    hbarFeeBasis.costFactor = 1;  // 'cost factor' is 'transaction'
+    
+    return cryptoFeeBasisCreateAsHBAR (wallet->unitForFee, hbarFeeBasis);
 }
 
 static void
@@ -289,6 +293,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersHBAR = {
     cryptoWalletManagerEstimateFeeBasisHBAR,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleHBAR,
     cryptoWalletManagerRecoverTransferFromTransferBundleHBAR,
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
     cryptoWalletManagerWalletSweeperValidateSupportedHBAR,
     cryptoWalletManagerCreateWalletSweeperHBAR
 };

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -293,7 +293,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersHBAR = {
     cryptoWalletManagerEstimateFeeBasisHBAR,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleHBAR,
     cryptoWalletManagerRecoverTransferFromTransferBundleHBAR,
-    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     cryptoWalletManagerWalletSweeperValidateSupportedHBAR,
     cryptoWalletManagerCreateWalletSweeperHBAR
 };

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoFeeBasisXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoFeeBasisXRP.c
@@ -1,0 +1,88 @@
+//
+//  BRCryptoFeeBasisXRP.c
+//  Core
+//
+//  Created by Ehsan Rezaie on 2020-09-04.
+//  Copyright © 2019 Breadwallet AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#include "BRCryptoXRP.h"
+#include "crypto/BRCryptoFeeBasisP.h"
+#include "ripple/BRRipple.h"
+
+static BRCryptoFeeBasisXRP
+cryptoFeeBasisCoerce (BRCryptoFeeBasis feeBasis) {
+    assert (CRYPTO_NETWORK_TYPE_XRP == feeBasis->type);
+    return (BRCryptoFeeBasisXRP) feeBasis;
+}
+
+typedef struct {
+    BRRippleFeeBasis xrpFeeBasis;
+} BRCryptoFeeBasisCreateContextXRP;
+
+static void
+cryptoFeeBasisCreateCallbackXRP (BRCryptoFeeBasisCreateContext context,
+                                 BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisCreateContextXRP *contextXRP = (BRCryptoFeeBasisCreateContextXRP*) context;
+    BRCryptoFeeBasisXRP feeBasisXRP = cryptoFeeBasisCoerce (feeBasis);
+    
+    feeBasisXRP->xrpFeeBasis = contextXRP->xrpFeeBasis;
+}
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsXRP (BRCryptoUnit unit,
+                           BRRippleUnitDrops fee) {
+    BRRippleFeeBasis xrpFeeBasis;
+    xrpFeeBasis.costFactor = 1;
+    xrpFeeBasis.pricePerCostFactor = fee;
+    
+    BRCryptoFeeBasisCreateContextXRP contextXRP = {
+        xrpFeeBasis
+    };
+    
+    return cryptoFeeBasisAllocAndInit (sizeof (struct BRCryptoFeeBasisXRPRecord),
+                                       CRYPTO_NETWORK_TYPE_XRP,
+                                       unit,
+                                       &contextXRP,
+                                       cryptoFeeBasisCreateCallbackXRP);
+}
+
+static void
+cryptoFeeBasisReleaseXRP (BRCryptoFeeBasis feeBasis) {
+}
+
+static double
+cryptoFeeBasisGetCostFactorXRP (BRCryptoFeeBasis feeBasis) {
+    return (double) cryptoFeeBasisCoerce (feeBasis)->xrpFeeBasis.costFactor;
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetPricePerCostFactorXRP (BRCryptoFeeBasis feeBasis) {
+    BRRippleFeeBasis xrpFeeBasis = cryptoFeeBasisCoerce (feeBasis)->xrpFeeBasis;
+    return cryptoAmountCreateAsXRP (feeBasis->unit, CRYPTO_FALSE, xrpFeeBasis.pricePerCostFactor);
+}
+
+static BRCryptoAmount
+cryptoFeeBasisGetFeeXRP (BRCryptoFeeBasis feeBasis) {
+    return cryptoFeeBasisGetPricePerCostFactor (feeBasis);
+}
+
+static BRCryptoBoolean
+cryptoFeeBasisIsEqualXRP (BRCryptoFeeBasis feeBasis1, BRCryptoFeeBasis feeBasis2) {
+    BRCryptoFeeBasisXRP fb1 = cryptoFeeBasisCoerce (feeBasis1);
+    BRCryptoFeeBasisXRP fb2 = cryptoFeeBasisCoerce (feeBasis2);
+
+    return rippleFeeBasisIsEqual (&fb1->xrpFeeBasis, &fb2->xrpFeeBasis);
+}
+
+// MARK: - Handlers
+
+BRCryptoFeeBasisHandlers cryptoFeeBasisHandlersXRP = {
+    cryptoFeeBasisReleaseXRP,
+    cryptoFeeBasisGetCostFactorXRP,
+    cryptoFeeBasisGetPricePerCostFactorXRP,
+    cryptoFeeBasisGetFeeXRP,
+    cryptoFeeBasisIsEqualXRP
+};

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -51,10 +51,7 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                                                      CRYPTO_FALSE,
                                                      xrpTransfer->amount);
     
-    BRCryptoAmount feeAmount = cryptoAmountCreateAsXRP (unitForFee,
-                                                        CRYPTO_FALSE,
-                                                        xrpTransfer->fee);
-    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreate (feeAmount, 1.0);
+    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsXRP (unitForFee, xrpTransfer->fee);
     
     BRCryptoAddress sourceAddress = cryptoAddressCreateAsXRP (xrpTransfer->sourceAddress);
     BRCryptoAddress targetAddress = cryptoAddressCreateAsXRP (xrpTransfer->targetAddress);

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -266,18 +266,6 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     //TODO:XRP announce
 }
 
-static BRCryptoFeeBasis
-cryptoWalletManagerRecoverFeeBasisFromFeeEstimateXRP (BRCryptoWalletManager cwm,
-                                                      BRCryptoNetworkFee networkFee,
-                                                      double costUnits,
-                                                      size_t attributesCount,
-                                                      OwnershipKept const char **attributeKeys,
-                                                      OwnershipKept const char **attributeVals) {
-    // Not supported
-    assert (0);
-    return NULL;
-}
-
 extern BRCryptoWalletSweeperStatus
 cryptoWalletManagerWalletSweeperValidateSupportedXRP (BRCryptoWalletManager manager,
                                                       BRCryptoWallet wallet,
@@ -330,7 +318,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXRP = {
     cryptoWalletManagerEstimateFeeBasisXRP,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleXRP,
     cryptoWalletManagerRecoverTransferFromTransferBundleXRP,
-    cryptoWalletManagerRecoverFeeBasisFromFeeEstimateXRP,
+    NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     cryptoWalletManagerWalletSweeperValidateSupportedXRP,
     cryptoWalletManagerCreateWalletSweeperXRP
 };

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -168,11 +168,12 @@ cryptoWalletManagerEstimateFeeBasisXRP (BRCryptoWalletManager manager,
                                         BRCryptoCookie cookie,
                                         BRCryptoAddress target,
                                         BRCryptoAmount amount,
-                                        BRCryptoNetworkFee networkFee) {
-    BRCryptoAmount pricePerCostFactor = cryptoNetworkFeeGetPricePerCostFactor (networkFee);
-    double costFactor = 1.0;  // 'cost factor' is 'transaction'
-    
-    return cryptoFeeBasisCreate (pricePerCostFactor, costFactor);
+                                        BRCryptoNetworkFee networkFee,
+                                        size_t attributesCount,
+                                        OwnershipKept BRCryptoTransferAttribute *attributes) {
+    UInt256 value = cryptoAmountGetValue (cryptoNetworkFeeGetPricePerCostFactor (networkFee));
+    BRRippleUnitDrops fee = value.u64[0];
+    return cryptoFeeBasisCreateAsXRP (wallet->unitForFee, fee);
 }
 
 static void
@@ -265,6 +266,18 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     //TODO:XRP announce
 }
 
+static BRCryptoFeeBasis
+cryptoWalletManagerRecoverFeeBasisFromFeeEstimateXRP (BRCryptoWalletManager cwm,
+                                                      BRCryptoNetworkFee networkFee,
+                                                      double costUnits,
+                                                      size_t attributesCount,
+                                                      OwnershipKept const char **attributeKeys,
+                                                      OwnershipKept const char **attributeVals) {
+    // Not supported
+    assert (0);
+    return NULL;
+}
+
 extern BRCryptoWalletSweeperStatus
 cryptoWalletManagerWalletSweeperValidateSupportedXRP (BRCryptoWalletManager manager,
                                                       BRCryptoWallet wallet,
@@ -317,6 +330,7 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXRP = {
     cryptoWalletManagerEstimateFeeBasisXRP,
     cryptoWalletManagerRecoverTransfersFromTransactionBundleXRP,
     cryptoWalletManagerRecoverTransferFromTransferBundleXRP,
+    cryptoWalletManagerRecoverFeeBasisFromFeeEstimateXRP,
     cryptoWalletManagerWalletSweeperValidateSupportedXRP,
     cryptoWalletManagerCreateWalletSweeperXRP
 };

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -50,8 +50,7 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
     BRRippleUnitDrops maxBalanceDrops = rippleAccountGetBalanceLimit (xrpAccount, 1, &hasMaxBalance);
 
     BRRippleFeeBasis feeBasisXRP = rippleAccountGetDefaultFeeBasis (xrpAccount);
-    BRCryptoFeeBasis feeBasis    = cryptoFeeBasisCreate (cryptoAmountCreateInteger ((int64_t) rippleFeeBasisGetPricePerCostFactor(&feeBasisXRP), unitForFee),
-                                                         (double) rippleFeeBasisGetCostFactor(&feeBasisXRP));
+    BRCryptoFeeBasis feeBasis    = cryptoFeeBasisCreateAsXRP (unitForFee, feeBasisXRP.pricePerCostFactor);
 
     BRCryptoWalletCreateContextXRP contextXRP = {
         xrpAccount

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
@@ -12,6 +12,7 @@
 #define BRCryptoXRP_h
 
 #include "../BRCryptoHandlersExport.h"
+#include "crypto/BRCryptoFeeBasisP.h"
 
 #include "ripple/BRRipple.h"
 
@@ -88,7 +89,16 @@ typedef struct BRCryptoWalletManagerXRPRecord {
 
 extern BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXRP;
 
-// MARK: - Events
+// MARK: - Fee Basis
+
+typedef struct BRCryptoFeeBasisXRPRecord {
+    struct BRCryptoFeeBasisRecord base;
+    BRRippleFeeBasis xrpFeeBasis;
+} *BRCryptoFeeBasisXRP;
+
+private_extern BRCryptoFeeBasis
+cryptoFeeBasisCreateAsXRP (BRCryptoUnit unit,
+                           BRRippleUnitDrops fee);
 
 // MARK: - Support
 

--- a/WalletKitSwift/WalletKit/BRCryptoClient.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoClient.swift
@@ -154,7 +154,7 @@ public protocol SystemClient {
     
     typealias TransactionFee = (
         costUnits: UInt64,
-        foo: String
+        properties: Dictionary<String,String>?
     )
     
     func estimateTransactionFee (blockchainId: String,

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1696,10 +1696,29 @@ extension System {
                     (res: Result<SystemClient.TransactionFee, SystemClientError>) in
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve(
-                        success: { cwmAnnounceEstimateTransactionFee (cwm, sid, CRYPTO_TRUE, hash, $0.costUnits) },
+                        success: {
+                            let properties = $0.properties ?? [:]
+                            var metaKeysPtr = Array(properties.keys)
+                                .map { UnsafePointer<Int8>(strdup($0)) }
+                            defer { metaKeysPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
+
+                            var metaValsPtr = Array(properties.values)
+                                .map { UnsafePointer<Int8>(strdup($0)) }
+                            defer { metaValsPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
+                            
+                            cwmAnnounceEstimateTransactionFee (cwm,
+                                                               sid,
+                                                               CRYPTO_TRUE,
+                                                               hash,
+                                                               $0.costUnits,
+                                                               metaKeysPtr.count,
+                                                               &metaKeysPtr,
+                                                               &metaValsPtr)
+                            
+                    },
                         failure: { (e) in
                             print ("SYS: EstimateTransactionFee: Error: \(e)")
-                            cwmAnnounceEstimateTransactionFee (cwm, sid, CRYPTO_FALSE, hash, 0) })
+                            cwmAnnounceEstimateTransactionFee (cwm, sid, CRYPTO_FALSE, hash, 0, 0, nil, nil) })
                 }}
         )
     }

--- a/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
@@ -240,8 +240,8 @@ public class TransferFeeBasis: Equatable {
     internal init (core: BRCryptoFeeBasis, take: Bool) {
         self.core = take ? cryptoFeeBasisTake (core) : core
 
-        self.unit = Unit (core: cryptoFeeBasisGetPricePerCostFactorUnit(core), take: false)
         self.pricePerCostFactor = Amount (core: cryptoFeeBasisGetPricePerCostFactor(core), take: false)
+        self.unit = self.pricePerCostFactor.unit
         self.costFactor  = cryptoFeeBasisGetCostFactor (core)
 
         // TODO: The Core fee calculation might overflow.

--- a/WalletKitSwift/WalletKit/BRCryptoWallet.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWallet.swift
@@ -575,23 +575,6 @@ public final class Wallet: Equatable {
             }
         }
     }
-
-    ///
-    /// Create a `TransferFeeBasis` using a `pricePerCostFactor` and `costFactor`.
-    ///
-    /// - Note: This is 'private' until the parameters are described.  Meant for testing for now.
-    ///
-    /// - Parameters:
-    ///   - pricePerCostFactor:
-    ///   - costFactor:
-    ///
-    /// - Returns: An optional TransferFeeBasis
-    ///
-//    public func createTransferFeeBasis (pricePerCostFactor: Amount,
-//                                        costFactor: Double) -> TransferFeeBasis? {
-//        return cryptoWalletCreateFeeBasis (core, pricePerCostFactor.core, costFactor)
-//            .map { TransferFeeBasis (core: $0, take: false) }
-//    }
     
     ///
     /// Create a wallet

--- a/WalletKitSwift/WalletKit/BRCryptoWallet.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWallet.swift
@@ -527,14 +527,20 @@ public final class Wallet: Equatable {
     public func estimateFee (target: Address,
                              amount: Amount,
                              fee: NetworkFee,
+                             attributes: Set<TransferAttribute>? = nil,
                              completion: @escaping Wallet.EstimateFeeHandler) {
+        let coreAttributesCount = attributes?.count ?? 0
+        var coreAttributes: [BRCryptoTransferAttribute?] = attributes?.map { $0.core } ?? []
+        
         // 'Redirect' up to the 'manager'
         cryptoWalletManagerEstimateFeeBasis (self.manager.core,
                                              self.core,
                                              callbackCoordinator.addWalletFeeEstimateHandler(completion),
                                              target.core,
                                              amount.core,
-                                             fee.core)
+                                             fee.core,
+                                             coreAttributesCount,
+                                             &coreAttributes)
     }
 
     internal func estimateFee (sweeper: WalletSweeper,
@@ -581,11 +587,11 @@ public final class Wallet: Equatable {
     ///
     /// - Returns: An optional TransferFeeBasis
     ///
-    public func createTransferFeeBasis (pricePerCostFactor: Amount,
-                                        costFactor: Double) -> TransferFeeBasis? {
-        return cryptoWalletCreateFeeBasis (core, pricePerCostFactor.core, costFactor)
-            .map { TransferFeeBasis (core: $0, take: false) }
-    }
+//    public func createTransferFeeBasis (pricePerCostFactor: Amount,
+//                                        costFactor: Double) -> TransferFeeBasis? {
+//        return cryptoWalletCreateFeeBasis (core, pricePerCostFactor.core, costFactor)
+//            .map { TransferFeeBasis (core: $0, take: false) }
+//    }
     
     ///
     /// Create a wallet

--- a/WalletKitSwift/WalletKit/common/BRCryptoBlockset.swift
+++ b/WalletKitSwift/WalletKit/common/BRCryptoBlockset.swift
@@ -428,8 +428,10 @@ public class BlocksetSystemClient: SystemClient {
         static internal func asTransactionFee (json: JSON) -> SystemClient.TransactionFee? {
             guard let costUnits = json.asUInt64(name: "cost_units")
                 else { return nil }
+            
+            let properties = json.asDict(name: "properties")?.mapValues { return $0 as! String }
 
-            return (costUnits: costUnits, foo: "ignore")
+            return (costUnits: costUnits, properties: properties)
         }
 
         /// Block

--- a/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
@@ -263,6 +263,8 @@ UITextViewDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
         }
     }
 
+    //TODO:FEEBASIS
+    /*
     func updateFeeBasisETH () {
         guard let pricePerCostFactorUnit = wallet.manager.network.baseUnitFor (currency: wallet.unitForFee.currency)
             else { return }
@@ -311,6 +313,8 @@ UITextViewDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
             }
         }
     }
+ */
+    
 
     @IBAction func doUseCoinbase(_ sender: Any) {
         recvField.text = "rw2ciyaNshpHe7bCHo4bRWq6pqqynnWKQg";

--- a/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
@@ -65,9 +65,9 @@ UITextViewDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
         }
         target = Address.create (string: self.recvField.text!, network: self.wallet.manager.network)
 
-        gasPriceSegmentedController.isEnabled = isEthCurrency && canUseFeeBasis
-        gasLimitSegmentedController.isEnabled = isEthCurrency && canUseFeeBasis
-        satPerKBSegmentedController.isEnabled = isBitCurrency && canUseFeeBasis
+        gasPriceSegmentedController.isEnabled = false//isEthCurrency && canUseFeeBasis
+        gasLimitSegmentedController.isEnabled = false//isEthCurrency && canUseFeeBasis
+        satPerKBSegmentedController.isEnabled = false//isBitCurrency && canUseFeeBasis
 
         priorityPicker.dataSource = self
         priorityPicker.delegate = self


### PR DESCRIPTION
- support transfer attributes as inputs for fee estimation
- support passing down metadata from fee estimation response
- move fee basis properties and fee calculation to chain-specific handlers