### PR TITLE
CORE-1001: Save `fee` in BRCryptoFeeBasisBTC

### DIFF
--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
@@ -208,12 +208,18 @@ typedef struct BRCryptoPaymentProtocolPaymentBTCRecord {
 
 typedef struct BRCryptoFeeBasisBTCRecord {
     struct BRCryptoFeeBasisRecord base;
+    uint64_t fee;
     uint64_t feePerKB;
-    uint32_t sizeInByte;
+    double sizeInKB;
 } *BRCryptoFeeBasisBTC;
+
+#define CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN               (UINT64_MAX)
+#define CRYPTO_FEE_BASIS_BTC_FEE_PER_KB_UNKNOWN        (UINT64_MAX)
+#define CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN              (UINT32_MAX)
 
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
+                           uint64_t fee,
                            uint64_t feePerKB,
                            uint32_t sizeInByte);
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoFeeBasisBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoFeeBasisBTC.c
@@ -22,8 +22,9 @@ cryptoFeeBasisCoerce (BRCryptoFeeBasis feeBasis) {
 }
 
 typedef struct {
+    uint64_t fee;
     uint64_t feePerKB;
-    uint32_t sizeInByte;
+    double   sizeInKB;
 } BRCryptoFeeBasisCreateContextBTC;
 
 static void
@@ -31,18 +32,37 @@ cryptoFeeBasisCreateCallbackBTC (BRCryptoFeeBasisCreateContext context,
                                  BRCryptoFeeBasis feeBasis) {
     BRCryptoFeeBasisCreateContextBTC *contextBTC = (BRCryptoFeeBasisCreateContextBTC*) context;
     BRCryptoFeeBasisBTC feeBasisBTC = cryptoFeeBasisCoerce (feeBasis);
-    
+
+    feeBasisBTC->fee = contextBTC->fee;
     feeBasisBTC->feePerKB = contextBTC->feePerKB;
-    feeBasisBTC->sizeInByte = contextBTC->sizeInByte;
+    feeBasisBTC->sizeInKB = contextBTC->sizeInKB;
 }
 
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsBTC (BRCryptoUnit unit,
+                           uint64_t fee,
                            uint64_t feePerKB,
                            uint32_t sizeInByte) {
+    // Only one of these can be unknownn
+    assert (((fee        == CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN        ? 1 : 0) +
+             (feePerKB   == CRYPTO_FEE_BASIS_BTC_FEE_PER_KB_UNKNOWN ? 1 : 0) +
+             (sizeInByte == CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN       ? 1 : 0)) <= 1);
+
     BRCryptoFeeBasisCreateContextBTC contextBTC = {
-        feePerKB,
-        sizeInByte
+        // Fee
+        (fee == CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN
+         ? (uint64_t) lround (((double) feePerKB) * sizeInByte / 1000.0)
+         : fee),
+
+        // Fee-Per-KB
+        (feePerKB == CRYPTO_FEE_BASIS_BTC_FEE_PER_KB_UNKNOWN
+         ? (((1000 * fee) + (sizeInByte/2)) / sizeInByte)
+         : feePerKB),
+
+        // Size-In-KB
+        (sizeInByte == CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN
+         ? (((double) fee) / feePerKB)
+         : (((double) sizeInByte) / 1000))
     };
     
     return cryptoFeeBasisAllocAndInit (sizeof (struct BRCryptoFeeBasisBTCRecord),
@@ -62,27 +82,25 @@ static void
 cryptoFeeBasisReleaseBTC (BRCryptoFeeBasis feeBasis) {
 }
 
-static double
+static double // as sizeInKB
 cryptoFeeBasisGetCostFactorBTC (BRCryptoFeeBasis feeBasis) {
     BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
-    return ((double) btcFeeBasis->sizeInByte) / 1000.0;
+    return btcFeeBasis->sizeInKB;
 }
 
 static BRCryptoAmount
 cryptoFeeBasisGetPricePerCostFactorBTC (BRCryptoFeeBasis feeBasis) {
-    BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
     return cryptoAmountCreate (feeBasis->unit,
                                CRYPTO_FALSE,
-                               uint256Create(btcFeeBasis->feePerKB));
+                               uint256Create (cryptoFeeBasisAsBTC (feeBasis)));
 }
 
 static BRCryptoAmount
 cryptoFeeBasisGetFeeBTC (BRCryptoFeeBasis feeBasis) {
     BRCryptoFeeBasisBTC btcFeeBasis = cryptoFeeBasisCoerce (feeBasis);
-    double fee = (((double) btcFeeBasis->feePerKB) * btcFeeBasis->sizeInByte) / 1000.0;
     return cryptoAmountCreate (feeBasis->unit,
                                CRYPTO_FALSE,
-                               uint256Create ((uint64_t) lround (fee)));
+                               uint256Create (btcFeeBasis->fee));
 }
 
 static BRCryptoBoolean
@@ -90,8 +108,9 @@ cryptoFeeBasisIsEqualBTC (BRCryptoFeeBasis feeBasis1, BRCryptoFeeBasis feeBasis2
     BRCryptoFeeBasisBTC fb1 = cryptoFeeBasisCoerce (feeBasis1);
     BRCryptoFeeBasisBTC fb2 = cryptoFeeBasisCoerce (feeBasis2);
 
-    return (fb1->feePerKB == fb2->feePerKB &&
-            fb1->sizeInByte == fb2->sizeInByte);
+    return (fb1->fee == fb2->fee &&
+            fb1->feePerKB == fb2->feePerKB &&
+            lround (1000.0 * fb1->sizeInKB) == lround (1000.0 * fb2->sizeInKB));
 }
 
 // MARK: - Handlers

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoPaymentBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoPaymentBTC.c
@@ -212,11 +212,11 @@ cryptoPaymentProtocolRequestCreateForBip70BTC (BRCryptoNetwork cryptoNetwork,
 }
 
 extern BRCryptoFeeBasis
-cryptoPaymentProtocolRequestEstimateFeBasisBTC (BRCryptoPaymentProtocolRequest protoReqBase,
-                                                BRCryptoWalletManager cwm,
-                                                BRCryptoWallet wallet,
-                                                BRCryptoCookie cookie,
-                                                BRCryptoNetworkFee networkFee) {
+cryptoPaymentProtocolRequestEstimateFeeBasisBTC (BRCryptoPaymentProtocolRequest protoReqBase,
+                                                 BRCryptoWalletManager cwm,
+                                                 BRCryptoWallet wallet,
+                                                 BRCryptoCookie cookie,
+                                                 BRCryptoNetworkFee networkFee) {
     BRWallet *wid = cryptoWalletAsBTC (wallet);
     uint64_t btcFeePerKB = 1000 * cryptoNetworkFeeAsBTC (networkFee);
     uint64_t btcFee = 0;
@@ -235,8 +235,7 @@ cryptoPaymentProtocolRequestEstimateFeBasisBTC (BRCryptoPaymentProtocolRequest p
         array_free (outputs);
     }
     
-    uint32_t sizeInBytes = (uint32_t) ((1000 * btcFee) / btcFeePerKB);
-    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, btcFeePerKB, sizeInBytes);
+    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, btcFee, btcFeePerKB, CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN);
 }
 
 extern BRCryptoTransfer
@@ -758,7 +757,7 @@ BRCryptoPaymentProtocolHandlers cryptoPaymentProtocolHandlersBTC = {
     cryptoPaymentProtocolRequestValidateSupportedBTC,
     cryptoPaymentProtocolRequestCreateForBitPayBTC,
     cryptoPaymentProtocolRequestCreateForBip70BTC,
-    cryptoPaymentProtocolRequestEstimateFeBasisBTC,
+    cryptoPaymentProtocolRequestEstimateFeeBasisBTC,
     cryptoPaymentProtocolRequestCreateTransferBTC,
 
     cryptoPaymentProtocolRequestIsSecureBTC,

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
@@ -144,21 +144,17 @@ cryptoTransferCreateAsBTC (BRCryptoTransferListener listener,
         }
     }
 
-    //
+
     // Currently this function, cryptoTransferCreateAsBTC(), is only called in various CWM
     // event handlers based on BTC events.  Thus for a newly created BTC transfer, the
     // BRCryptoFeeBasis is long gone.  The best we can do is reconstruct the feeBasis from the
     // BRTransaction itself.
-    //
-    uint32_t feePerKB = 0;  // assume not our transaction (fee == UINT64_MAX)
-    uint32_t sizeInByte = (uint32_t) BRTransactionVSize (tid);
 
-    if (UINT64_MAX != fee) {
-        // round to nearest satoshi per kb
-        feePerKB = (uint32_t) (((1000 * fee) + (sizeInByte/2)) / sizeInByte);
-    }
-    
-    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsBTC (unitForFee, feePerKB, sizeInByte);
+    BRCryptoFeeBasis feeBasisEstimated =
+    cryptoFeeBasisCreateAsBTC (unitForFee,
+                               (fee == UINT64_MAX ? CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN        : fee),
+                               (fee == UINT64_MAX ? 0                                       : CRYPTO_FEE_BASIS_BTC_FEE_PER_KB_UNKNOWN),
+                               (uint32_t) BRTransactionVSize (tid));
 
     BRCryptoTransferCreateContextBTC contextBTC = {
         tid,

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
@@ -45,6 +45,7 @@ cryptoWalletCreateAsBTC (BRCryptoBlockChainType type,
                          BRCryptoUnit unitForFee,
                          BRWallet *wid) {
     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsBTC (unitForFee,
+                                                           CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN,
                                                            BRWalletFeePerKb(wid),
                                                            DEFAULT_FEE_BASIS_SIZE_IN_BYTES);
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
@@ -219,9 +219,8 @@ cryptoWalletManagerEstimateFeeBasisBTC (BRCryptoWalletManager cwm,
     assert(CRYPTO_FALSE == overflow);
 
     uint64_t btcFee = (0 == btcAmount ? 0 : BRWalletFeeForTxAmountWithFeePerKb (btcWallet, btcFeePerKB, btcAmount));
-    uint32_t btcSizeInBytes = (uint32_t) ((1000 * btcFee) / btcFeePerKB);
 
-    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, btcFeePerKB, btcSizeInBytes);
+    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, btcFee, btcFeePerKB, CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN);
 }
 
 static BRCryptoWallet

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletSweeperBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletSweeperBTC.c
@@ -87,9 +87,8 @@ cryptoWalletSweeperEstimateFeeBasisForWalletSweepBTC (BRCryptoWalletManager cwm,
     //            context to the caller.
     uint64_t fee = 0;
     BRWalletSweeperEstimateFee (sweeperBTC, wid, feePerKb, &fee);
-    uint32_t sizeInByte = (uint32_t) ((1000 * fee)/ feePerKb);
     
-    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, (uint32_t) feePerKb, sizeInByte);
+    return cryptoFeeBasisCreateAsBTC (wallet->unitForFee, fee, feePerKb, CRYPTO_FEE_BASIS_BTC_SIZE_UNKNOWN);
 }
 
 static BRTransaction *


### PR DESCRIPTION
Change `cryptoFeeBasisCreateAsBTC()` to take (fee, feePerKB, sizeInByte) but allow one to be 'UNKNOWN'.  The unknown one will be computed from the other two.

Also save the size as `sizeInKB`, as a `double` - ready for use as the "cost factor"