### PR TITLE
CORE-1016: Check for existing transfers when recovering transfers from client bundle

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -594,12 +594,12 @@ cryptoTransferSubmitErrorPosix(int errnum) {
 }
 
 extern bool
- cryptoTransferSubmitErrorIsEqual (const BRCryptoTransferSubmitError *e1,
-                                   const BRCryptoTransferSubmitError *e2) {
-     return (e1->type == e2->type &&
-             (e1->type != CRYPTO_TRANSFER_SUBMIT_ERROR_POSIX ||
-              e1->u.posix.errnum == e2->u.posix.errnum));
- }
+cryptoTransferSubmitErrorIsEqual (const BRCryptoTransferSubmitError *e1,
+                                  const BRCryptoTransferSubmitError *e2) {
+    return (e1->type == e2->type &&
+            (e1->type != CRYPTO_TRANSFER_SUBMIT_ERROR_POSIX ||
+             e1->u.posix.errnum == e2->u.posix.errnum));
+}
 
 extern char *
 cryptoTransferSubmitErrorGetMessage (BRCryptoTransferSubmitError *e) {

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -900,9 +900,9 @@ cryptoTransferStateCreateGEN (BRGenericTransferState generic,
 
 private_extern void
 cryptoWalletManagerSetTransferState (BRCryptoWalletManager cwm,
-                                        BRCryptoWallet wallet,
-                                        BRCryptoTransfer transfer,
-                                        BRCryptoTransferState newState) {
+                                     BRCryptoWallet wallet,
+                                     BRCryptoTransfer transfer,
+                                     BRCryptoTransferState newState) {
     pthread_mutex_lock (&cwm->lock);
 
     BRCryptoTransferState oldState = cryptoTransferGetState (transfer);

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -79,8 +79,6 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
                           BRCryptoUnit unitForFee,
                           BRHederaAccount hbarAccount);
 
-
-//TODO:HBAR needed?
 private_extern BRCryptoHash
 cryptoHashCreateAsHBAR (BRHederaTransactionHash hash);
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -82,6 +82,9 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
 private_extern BRCryptoHash
 cryptoHashCreateAsHBAR (BRHederaTransactionHash hash);
 
+private_extern uint32_t
+hederaHashSetValue (const BRHederaTransactionHash *hash);
+
 // MARK: - Wallet Manager
 
 typedef struct BRCryptoWalletManagerHBARRecord {

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
@@ -11,6 +11,7 @@
 #include "BRCryptoHBAR.h"
 #include "hedera/BRHederaBase.h"
 #include "crypto/BRCryptoAmountP.h"
+#include "crypto/BRCryptoHashP.h"
 #include "ethereum/util/BRUtilMath.h"
 
 static uint64_t
@@ -24,6 +25,12 @@ cryptoAmountCreateAsHBAR (BRCryptoUnit unit,
                           BRCryptoBoolean isNegative,
                           BRHederaUnitTinyBar value) {
     return cryptoAmountCreate (unit, isNegative, uint256Create (hederaTinyBarCoerceToUInt64 (value)));
+}
+
+private_extern BRCryptoHash
+cryptoHashCreateAsHBAR (BRHederaTransactionHash hash) {
+    uint32_t setValue = (uint32_t) ((UInt256 *) hash.bytes)->u32[0];
+    return cryptoHashCreateInternal (setValue, 48, hash.bytes);
 }
 
 // MARK: -

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
@@ -33,6 +33,11 @@ cryptoHashCreateAsHBAR (BRHederaTransactionHash hash) {
     return cryptoHashCreateInternal (setValue, 48, hash.bytes);
 }
 
+private_extern uint32_t
+hederaHashSetValue (const BRHederaTransactionHash *hash) {
+    return (uint32_t) ((UInt256 *) hash->bytes)->u32[0];
+}
+
 // MARK: -
 
 static const char *knownMemoRequiringAddresses[] = {

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -90,7 +90,7 @@ static BRCryptoHash
 cryptoTransferGetHashHBAR (BRCryptoTransfer transfer) {
     BRCryptoTransferHBAR transferHBAR = cryptoTransferCoerceHBAR(transfer);
     BRHederaTransactionHash hash = hederaTransactionGetHash (transferHBAR->hbarTransaction);
-    return cryptoHashCreateInternal (CRYPTO_NETWORK_TYPE_HBAR, sizeof (hash.bytes), hash.bytes);
+    return cryptoHashCreateInternal (hederaHashSetValue (&hash), sizeof (hash.bytes), hash.bytes);
 }
 
 static uint8_t *

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -205,10 +205,10 @@ cryptoWalletCreateTransferHBAR (BRCryptoWallet  wallet,
     hederaAddressFree (nodeAddress);
     
     BRCryptoTransfer transfer = cryptoTransferCreateAsHBAR (wallet->listenerTransfer,
-                                                                unit,
-                                                                unitForFee,
-                                                                walletHBAR->hbarAccount,
-                                                                tid);
+                                                            unit,
+                                                            unitForFee,
+                                                            walletHBAR->hbarAccount,
+                                                            tid);
     cryptoTransferSetAttributes (transfer, attributes);
     
     return transfer;

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
@@ -27,6 +27,11 @@ cryptoHashCreateAsXRP (BRRippleTransactionHash hash) {
     return cryptoHashCreateInternal (setValue, 32, hash.bytes);
 }
 
+private_extern uint32_t
+rippleHashSetValue (const BRRippleTransactionHash *hash) {
+    return (uint32_t) ((UInt256 *) hash->bytes)->u32[0];
+}
+
 // MARK: -
 
 private_extern int // 1 if equal, 0 if not.

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
@@ -21,6 +21,12 @@ cryptoAmountCreateAsXRP (BRCryptoUnit unit,
     return cryptoAmountCreate (unit, isNegative, uint256Create (value));
 }
 
+private_extern BRCryptoHash
+cryptoHashCreateAsXRP (BRRippleTransactionHash hash) {
+    uint32_t setValue = (uint32_t) ((UInt256 *) hash.bytes)->u32[0];
+    return cryptoHashCreateInternal (setValue, 32, hash.bytes);
+}
+
 // MARK: -
 
 private_extern int // 1 if equal, 0 if not.

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -96,7 +96,7 @@ static BRCryptoHash
 cryptoTransferGetHashXRP (BRCryptoTransfer transfer) {
     BRCryptoTransferXRP transferXRP = cryptoTransferCoerceXRP(transfer);
     BRRippleTransactionHash hash = rippleTransferGetTransactionId (transferXRP->xrpTransfer);
-    return cryptoHashCreateInternal (CRYPTO_NETWORK_TYPE_XRP, sizeof (hash.bytes), hash.bytes);
+    return cryptoHashCreateInternal (rippleHashSetValue (&hash), sizeof (hash.bytes), hash.bytes);
 }
 
 static uint8_t *

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -239,13 +239,18 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     // create BRCryptoTransfer
     
     BRCryptoWallet wallet = cryptoWalletManagerGetWallet (manager);
+    BRCryptoHash hash = cryptoHashCreateAsXRP (txId);
     
-    BRCryptoTransfer baseTransfer = cryptoTransferCreateAsXRP (wallet->listenerTransfer,
-                                                               wallet->unit,
-                                                               wallet->unitForFee,
-                                                               xrpAccount,
-                                                               xrpTransfer);
-    cryptoWalletAddTransfer (wallet, baseTransfer);
+    BRCryptoTransfer baseTransfer = cryptoWalletGetTransferByHash (wallet, hash);
+    
+    if (NULL == baseTransfer) {
+        baseTransfer = cryptoTransferCreateAsXRP (wallet->listenerTransfer,
+                                                  wallet->unit,
+                                                  wallet->unitForFee,
+                                                  xrpAccount,
+                                                  xrpTransfer);
+        cryptoWalletAddTransfer (wallet, baseTransfer);
+    }
     
     BRCryptoTransferState transferState =
     (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status
@@ -263,7 +268,8 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     
     //TODO:XRP attributes
     //TODO:XRP save to fileService
-    //TODO:XRP announce
+    
+    rippleTransferFree (xrpTransfer);
 }
 
 extern BRCryptoWalletSweeperStatus

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
@@ -79,6 +79,9 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
 private_extern BRCryptoHash
 cryptoHashCreateAsXRP (BRRippleTransactionHash hash);
 
+private_extern uint32_t
+rippleHashSetValue (const BRRippleTransactionHash *hash);
+
 // MARK: - Wallet Manager
 
 typedef struct BRCryptoWalletManagerXRPRecord {

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
@@ -76,8 +76,6 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
                          BRCryptoUnit unitForFee,
                          BRRippleAccount xrpAccount);
 
-
-//TODO:XRP needed?
 private_extern BRCryptoHash
 cryptoHashCreateAsXRP (BRRippleTransactionHash hash);
 


### PR DESCRIPTION
- recover transfer: look up transfer by hash in wallet, skip creating if found
- fixed hash set value usage for XRP and HBAR