### PR TITLE
CORE-985: On Transfer Submit, Keep the Containing Wallet

### DIFF
--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -119,8 +119,7 @@ typedef void
 extern void
 cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
                            OwnershipGiven BRCryptoClientCallbackState callbackState,
-                           BRCryptoBoolean success,
-                           OwnershipKept const char *hash);
+                           BRCryptoBoolean success);
 
 // MARK: - Estimate Transaction Fee
 

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -30,13 +30,13 @@ static void
 cryptoClientP2PManagerSync (BRCryptoClientP2PManager p2p, BRCryptoSyncDepth depth, BRCryptoBlockNumber height);
 
 static void
-cryptoClientP2PManagerSend (BRCryptoClientP2PManager p2p, BRCryptoTransfer transfer);
+cryptoClientP2PManagerSend (BRCryptoClientP2PManager p2p, BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
 static void
 cryptoClientQRYManagerSync (BRCryptoClientQRYManager qry, BRCryptoSyncDepth depth, BRCryptoBlockNumber height);
 
 static void
-cryptoClientQRYManagerSend (BRCryptoClientQRYManager qry, BRCryptoTransfer transfer);
+cryptoClientQRYManagerSend (BRCryptoClientQRYManager qry,  BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
 
 // MARK: Client Sync
@@ -70,13 +70,15 @@ cryptoClientSyncPeriodic (BRCryptoClientSync sync) {
 // MARK: Client Send
 
 extern void
-cryptoClientSend (BRCryptoClientSend send, BRCryptoTransfer transfer) {
+cryptoClientSend (BRCryptoClientSend send,
+                  BRCryptoWallet wallet,
+                  BRCryptoTransfer transfer) {
     switch (send.type) {
         case CRYPTO_CLIENT_P2P_MANAGER_TYPE:
-            cryptoClientP2PManagerSend (send.u.p2pManager, transfer);
+            cryptoClientP2PManagerSend (send.u.p2pManager, wallet, transfer);
             break;
         case CRYPTO_CLIENT_QRY_MANAGER_TYPE:
-            cryptoClientQRYManagerSend (send.u.qryManager, transfer);
+            cryptoClientQRYManagerSend (send.u.qryManager, wallet, transfer);
             break;
     }
 }
@@ -124,8 +126,10 @@ cryptoClientP2PManagerSync (BRCryptoClientP2PManager p2p,
 }
 
 static void
-cryptoClientP2PManagerSend (BRCryptoClientP2PManager p2p, BRCryptoTransfer transfer) {
-    p2p->handlers->send (p2p, transfer);
+cryptoClientP2PManagerSend (BRCryptoClientP2PManager p2p,
+                            BRCryptoWallet   wallet,
+                            BRCryptoTransfer transfer) {
+    p2p->handlers->send (p2p, wallet, transfer);
 }
 
 // MARK: Client QRY (QueRY)
@@ -135,7 +139,9 @@ static void cryptoClientQRYRequestTransfers    (BRCryptoClientQRYManager qry,
                                                 OwnershipGiven BRSetOf(BRCryptoAddress) addresses);
 static void cryptoClientQRYRequestTransactions (BRCryptoClientQRYManager qry,
                                                 OwnershipGiven BRSetOf(BRCryptoAddress) addresses);
-static void cryptoClientQRYSubmitTransfer      (BRCryptoClientQRYManager qry, BRCryptoTransfer transfer);
+static void cryptoClientQRYSubmitTransfer      (BRCryptoClientQRYManager qry,
+                                                BRCryptoWallet   wallet,
+                                                BRCryptoTransfer transfer);
 
 extern BRCryptoClientQRYManager
 cryptoClientQRYManagerCreate (BRCryptoClient client,
@@ -200,8 +206,10 @@ cryptoClientQRYGetNetworkBlockHeight (BRCryptoClientQRYManager qry){
 }
 
 static void
-cryptoClientQRYManagerSend (BRCryptoClientQRYManager qry, BRCryptoTransfer transfer) {
-    cryptoClientQRYSubmitTransfer (qry, transfer);
+cryptoClientQRYManagerSend (BRCryptoClientQRYManager qry,
+                            BRCryptoWallet wallet,
+                            BRCryptoTransfer transfer) {
+    cryptoClientQRYSubmitTransfer (qry, wallet, transfer);
 }
 
 extern void
@@ -476,11 +484,15 @@ cryptoClientCallbackStateCreateGetTrans (BRCryptoClientCallbackType type,
 }
 
 static BRCryptoClientCallbackState
-cryptoClientCallbackStateCreateSubmitTransaction (BRCryptoHash hash,
+cryptoClientCallbackStateCreateSubmitTransaction (BRCryptoWallet wallet,
+                                                  BRCryptoTransfer transfer,
+                                                  BRCryptoHash hash,
                                                   size_t rid) {
     BRCryptoClientCallbackState state = cryptoClientCallbackStateCreate (CLIENT_CALLBACK_SUBMIT_TRANSACTION, rid);
 
-    state->u.submitTransaction.hash = cryptoHashTake (hash);
+    state->u.submitTransaction.hash     = cryptoHashTake (hash);
+    state->u.submitTransaction.wallet   = cryptoWalletTake   (wallet);
+    state->u.submitTransaction.transfer = cryptoTransferTake (transfer);
 
     return state;
 }
@@ -511,7 +523,9 @@ cryptoClientCallbackStateRelease (BRCryptoClientCallbackState state) {
             break;
 
         case CLIENT_CALLBACK_SUBMIT_TRANSACTION:
-            cryptoHashGive (state->u.submitTransaction.hash);
+            cryptoHashGive     (state->u.submitTransaction.hash);
+            cryptoWalletGive   (state->u.submitTransaction.wallet);
+            cryptoTransferGive (state->u.submitTransaction.transfer);
             break;
 
         case CLIENT_CALLBACK_ESTIMATE_TRANSACTION_FEE:
@@ -715,7 +729,9 @@ cwmAnnounceTransfers (OwnershipKept BRCryptoWalletManager manager,
 // MARK: Announce Submit Transfer
 
 static void
-cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry, BRCryptoTransfer transfer) {
+cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry,
+                               BRCryptoWallet   wallet,
+                               BRCryptoTransfer transfer) {
     BRCryptoWalletManager cwm = cryptoWalletManagerTakeWeak(qry->manager);
     if (NULL == cwm) return;
 
@@ -724,14 +740,14 @@ cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry, BRCryptoTransfer tr
                                                                    cwm->network,
                                                                    &serializationCount);
 
-
     BRCryptoHash hash = cryptoTransferGetHash (transfer);
-    char *hashAsHex = cryptoHashString(hash);
+    char *hashAsHex = cryptoHashString (hash);
 
-    BRCryptoClientCallbackState callbackState = cryptoClientCallbackStateCreateSubmitTransaction (hash, qry->requestId++);
+    BRCryptoClientCallbackState callbackState =
+    cryptoClientCallbackStateCreateSubmitTransaction (wallet, transfer, hash, qry->requestId++);
 
     qry->client.funcSubmitTransaction (qry->client.context,
-                                       cryptoWalletManagerTake(cwm),
+                                       cwm,
                                        callbackState,
                                        serialization,
                                        serializationCount,
@@ -745,13 +761,27 @@ cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry, BRCryptoTransfer tr
 extern void
 cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
                            OwnershipGiven BRCryptoClientCallbackState callbackState,
-                           BRCryptoBoolean success,
-                           OwnershipKept const char *hash) {
+                           BRCryptoBoolean success) {
     assert (CLIENT_CALLBACK_SUBMIT_TRANSACTION == callbackState->type);
+
+    BRCryptoWallet   wallet   = callbackState->u.submitTransaction.wallet;
+    BRCryptoTransfer transfer = callbackState->u.submitTransaction.transfer;
+
+    // Must be the case... 'belt and suspenders'
+    if (CRYPTO_TRUE == cryptoWalletHasTransfer (wallet, transfer)) {
+        // Recover the `state` as either SUBMITTED or a UNKNOWN ERROR.  We have a slight issue, as
+        // a possible race condition, whereby the transfer can already be INCLUDED by the time this
+        // `announce` is called.  That has got to be impossible right?
+        BRCryptoTransferState state = (CRYPTO_TRUE == success
+                                       ? cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_SUBMITTED)
+                                       : cryptoTransferStateErroredInit (cryptoTransferSubmitErrorUnknown()));
+
+        // Assign the state; generate events in the process.
+        cryptoTransferSetState(transfer, state);
+    }
 
     cryptoClientCallbackStateRelease(callbackState);
 }
-
 
 // MARK: - Announce Estimate Transaction Fee
 

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -74,6 +74,8 @@ struct BRCryptoClientCallbackStateRecord {
         } getTransactions;
 
         struct {
+            BRCryptoWallet wallet;
+            BRCryptoTransfer transfer;
             BRCryptoHash hash;
         } submitTransaction;
 
@@ -126,7 +128,9 @@ typedef struct {
 } BRCryptoClientSend;
 
 extern void
-cryptoClientSend (BRCryptoClientSend send, BRCryptoTransfer transfer);
+cryptoClientSend (BRCryptoClientSend send,
+                  BRCryptoWallet wallet,
+                  BRCryptoTransfer transfer);
 
 // MARK: Client P2P (Peer-to-Peer)
 
@@ -147,6 +151,7 @@ typedef void
 
 typedef void
 (*BRCryptoClientP2PManagerSendHandler) (BRCryptoClientP2PManager p2p,
+                                        BRCryptoWallet   wallet,
                                         BRCryptoTransfer transfer);
 
 typedef struct {

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1029,7 +1029,7 @@ cryptoWalletManagerSubmitSigned (BRCryptoWalletManager cwm,
 
     cryptoWalletAddTransfer (wallet, transfer);
 
-    cryptoClientSend (cwm->canSend, transfer);
+    cryptoClientSend (cwm->canSend, wallet, transfer);
 
     cryptoWalletGenerateEvent (wallet, (BRCryptoWalletEvent) {
         CRYPTO_WALLET_EVENT_TRANSFER_SUBMITTED,

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -244,6 +244,8 @@ private_extern void
 cryptoWalletManagerRecoverTransfersFromTransactionBundle (BRCryptoWalletManager cwm,
                                                           OwnershipKept BRCryptoClientTransactionBundle bundle);
 
+// Is it possible that the transfers do not have the 'submitted' state?  In some race between
+// the submit call and the included call?  Highly, highly unlikely but possible?
 private_extern void
 cryptoWalletManagerRecoverTransferFromTransferBundle (BRCryptoWalletManager cwm,
                                                       OwnershipKept BRCryptoClientTransferBundle bundle);

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerP2PBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerP2PBTC.c
@@ -123,17 +123,21 @@ cryptoClientP2PManagerSyncBTC (BRCryptoClientP2PManager baseManager,
 
 typedef struct {
     BRCryptoWalletManager manager;
+    BRCryptoWallet   wallet;
     BRCryptoTransfer transfer;
 } BRCryptoClientP2PManagerPublishInfo;
 
 static void
-cryptoClientP2PManagerSendBTC (BRCryptoClientP2PManager baseManager, BRCryptoTransfer transfer) {
+cryptoClientP2PManagerSendBTC (BRCryptoClientP2PManager baseManager,
+                               BRCryptoWallet   wallet,
+                               BRCryptoTransfer transfer) {
     BRCryptoClientP2PManagerBTC manager = cryptoClientP2PManagerCoerce (baseManager);
 
     BRTransaction *btcTransaction = cryptoTransferAsBTC (transfer);
 
     BRCryptoClientP2PManagerPublishInfo *btcInfo = calloc (1, sizeof (BRCryptoClientP2PManagerPublishInfo));
-    btcInfo->manager  = cryptoWalletManagerTake(&manager->manager->base);
+    btcInfo->manager  = cryptoWalletManagerTake (&manager->manager->base);
+    btcInfo->wallet   = cryptoWalletTake   (wallet);
     btcInfo->transfer = cryptoTransferTake (transfer);
 
     BRPeerManagerPublishTx (manager->btcPeerManager,

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerP2PETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerP2PETH.c
@@ -86,11 +86,13 @@ typedef struct {
 } BRCryptoClientP2PManagerPublishInfo;
 
 static void
-cryptoClientP2PManagerSendETH (BRCryptoClientP2PManager baseManager, BRCryptoTransfer baseTransfer) {
-    BRCryptoClientP2PManagerETH manager = cryptoClientP2PManagerCoerce (baseManager);
-    BRCryptoTransferETH transfer = cryptoTransferCoerceETH (baseTransfer);
+cryptoClientP2PManagerSendETH (BRCryptoClientP2PManager manager,
+                               BRCryptoWallet   wallet,
+                               BRCryptoTransfer transfer) {
+    BRCryptoClientP2PManagerETH managerETH = cryptoClientP2PManagerCoerce (manager);
+    BRCryptoTransferETH transferETH = cryptoTransferCoerceETH (transfer);
 
-    bcsSendTransaction (manager->bcs, transfer->originatingTransaction);
+    bcsSendTransaction (managerETH->bcs, transferETH->originatingTransaction);
 }
 
 static BRCryptoClientP2PHandlers p2pHandlersETH = {

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1676,10 +1676,10 @@ extension System {
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve(
                         success: { (_) in
-                            cwmAnnounceSubmitTransfer (cwm, sid, CRYPTO_TRUE,  hash) },
+                            cwmAnnounceSubmitTransfer (cwm, sid, CRYPTO_TRUE) },
                         failure: { (e) in
                             print ("SYS: SubmitTransaction: Error: \(e)")
-                            cwmAnnounceSubmitTransfer (cwm, sid, CRYPTO_FALSE, hash) })
+                            cwmAnnounceSubmitTransfer (cwm, sid, CRYPTO_FALSE) })
                 }},
 
             funcEstimateTransactionFee: { (context, cwm, sid, transactionBytes, transactionBytesLength, hashAsHex) in


### PR DESCRIPTION
Submitting doesn't work for ETH, XRP yet - because the nonce/sequence-number isn't handled yet; see CORE-1009.