### PR TITLE
CORE-1009: Add `BRCryptoWalletAnnounceTransfer`

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -243,7 +243,8 @@ cryptoTransferGetAttributeAt (BRCryptoTransfer transfer,
 
 private_extern void
 cryptoTransferSetAttributes (BRCryptoTransfer transfer,
-                             OwnershipKept BRArrayOf(BRCryptoTransferAttribute) attributes) {
+                             size_t attributesCount,
+                             OwnershipKept BRCryptoTransferAttribute *attributes) {
     pthread_mutex_lock (&transfer->lock);
 
     // Give existing attributes and empty `transfer->attributes`
@@ -253,7 +254,7 @@ cryptoTransferSetAttributes (BRCryptoTransfer transfer,
 
     if (NULL != attributes)
         // Take new attributes.
-        for (size_t index = 0; index < array_count(attributes); index++)
+        for (size_t index = 0; index < attributesCount; index++)
             array_add (transfer->attributes, cryptoTransferAttributeTake (attributes[index]));
     pthread_mutex_unlock (&transfer->lock);
 }

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -127,7 +127,8 @@ cryptoTransferSetState (BRCryptoTransfer transfer,
 
 private_extern void
 cryptoTransferSetAttributes (BRCryptoTransfer transfer,
-                             OwnershipKept BRArrayOf(BRCryptoTransferAttribute) attributes);
+                             size_t attributesCount,
+                             OwnershipKept BRCryptoTransferAttribute *attributes);
 
 static inline void
 cryptoTransferGenerateEvent (BRCryptoTransfer transfer,

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -524,13 +524,8 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
                                                                   unit,
                                                                   unitForFee);
 
-    if (NULL != transfer && attributesCount > 0) {
-        BRArrayOf (BRCryptoTransferAttribute) transferAttributes;
-        array_new (transferAttributes, attributesCount);
-        array_add_array (transferAttributes, attributes, attributesCount);
-        cryptoTransferSetAttributes (transfer, transferAttributes);
-        array_free (transferAttributes);
-    }
+    if (NULL != transfer && attributesCount > 0)
+        cryptoTransferSetAttributes (transfer, attributesCount, attributes);
 
     cryptoCurrencyGive(currency);
     cryptoUnitGive (unitForFee);

--- a/WalletKitCore/src/crypto/BRCryptoWalletP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletP.h
@@ -76,6 +76,11 @@ typedef BRCryptoTransfer
 typedef OwnershipGiven BRSetOf(BRCryptoAddress)
 (*BRCryptoWalletGetAddressesForRecoveryHandler) (BRCryptoWallet wallet);
 
+typedef void
+(*BRCryptoWalletAnnounceTransfer) (BRCryptoWallet wallet,
+                                   BRCryptoTransfer transfer,
+                                   BRCryptoWalletEventType type); // TRANSFER_{ADDED,DELETED}
+
 typedef bool
 (*BRCryptoWalletIsEqualHandler) (BRCryptoWallet wallet1, BRCryptoWallet wallet2);
 
@@ -89,6 +94,7 @@ typedef struct {
     BRCryptoWalletCreateTransferHandler createTransfer;
     BRCryptoWalletCreateTransferMultipleHandler createTransferMultiple;
     BRCryptoWalletGetAddressesForRecoveryHandler getAddressesForRecovery;
+    BRCryptoWalletAnnounceTransfer announceTransfer; // May be NULL
     BRCryptoWalletIsEqualHandler isEqual;
 } BRCryptoWalletHandlers;
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
@@ -380,6 +380,7 @@ BRCryptoWalletHandlers cryptoWalletHandlersBTC = {
     cryptoWalletCreateTransferBTC,
     cryptoWalletCreateTransferMultipleBTC,
     cryptoWalletGetAddressesForRecoveryBTC,
+    NULL,
     cryptoWalletIsEqualBTC
 };
 
@@ -393,6 +394,7 @@ BRCryptoWalletHandlers cryptoWalletHandlersBCH = {
     cryptoWalletCreateTransferBTC,
     cryptoWalletCreateTransferMultipleBTC,
     cryptoWalletGetAddressesForRecoveryBTC,
+    NULL,
     cryptoWalletIsEqualBTC
 };
 
@@ -406,5 +408,6 @@ BRCryptoWalletHandlers cryptoWalletHandlersBSV = {
     cryptoWalletCreateTransferBTC,
     cryptoWalletCreateTransferMultipleBTC,
     cryptoWalletGetAddressesForRecoveryBTC,
+    NULL,
     cryptoWalletIsEqualBTC
 };

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
@@ -254,13 +254,8 @@ cryptoWalletCreateTransferETH (BRCryptoWallet  wallet,
     transfer->feeBasisEstimated = cryptoFeeBasisCreateAsETH (unitForFee, transactionGetFeeBasisLimit(ethTransaction));
 #endif
     
-    if (NULL != transfer && attributesCount > 0) {
-        BRArrayOf (BRCryptoTransferAttribute) transferAttributes;
-        array_new (transferAttributes, attributesCount);
-        array_add_array (transferAttributes, attributes, attributesCount);
-        cryptoTransferSetAttributes (transfer, transferAttributes);
-        array_free (transferAttributes);
-    }
+    if (NULL != transfer && attributesCount > 0)
+        cryptoTransferSetAttributes (transfer, attributesCount, attributes);
 
     cryptoAddressGive(source);
 

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
@@ -422,5 +422,6 @@ BRCryptoWalletHandlers cryptoWalletHandlersETH = {
     cryptoWalletCreateTransferETH,
     cryptoWalletCreateTransferMultipleETH,
     cryptoWalletGetAddressesForRecoveryETH,
+    NULL,
     cryptoWalletIsEqualETH
 };

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -254,5 +254,6 @@ BRCryptoWalletHandlers cryptoWalletHandlersHBAR = {
     cryptoWalletCreateTransferHBAR,
     cryptoWalletCreateTransferMultipleHBAR,
     cryptoWalletGetAddressesForRecoveryHBAR,
+    NULL,
     cryptoWalletIsEqualHBAR
 };

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -209,7 +209,7 @@ cryptoWalletCreateTransferHBAR (BRCryptoWallet  wallet,
                                                             unitForFee,
                                                             walletHBAR->hbarAccount,
                                                             tid);
-    cryptoTransferSetAttributes (transfer, attributes);
+    cryptoTransferSetAttributes (transfer, attributesCount, attributes);
     
     return transfer;
 }

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -29,6 +29,12 @@ typedef struct {
     BRRippleTransfer xrpTransfer;
 } BRCryptoTransferCreateContextXRP;
 
+extern BRRippleTransfer
+cryptoTransferAsXRP (BRCryptoTransfer transfer) {
+    BRCryptoTransferXRP transferXRP = cryptoTransferCoerceXRP (transfer);
+    return transferXRP->xrpTransfer;
+}
+
 static void
 cryptoTransferCreateCallbackXRP (BRCryptoTransferCreateContext context,
                                     BRCryptoTransfer transfer) {

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -229,7 +229,7 @@ cryptoWalletCreateTransferXRP (BRCryptoWallet  wallet,
                                                            unitForFee,
                                                            walletXRP->xrpAccount,
                                                            xrpTransfer);
-    cryptoTransferSetAttributes (transfer, attributes);
+    cryptoTransferSetAttributes (transfer, attributesCount, attributes);
     
     return transfer;
 }

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
@@ -61,6 +61,9 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                            BRRippleAccount xrpAccount,
                            BRRippleTransfer xrpTransfer);
 
+extern BRRippleTransfer
+cryptoTransferAsXRP (BRCryptoTransfer transfer);
+
 // MARK: - Wallet
 
 typedef struct BRCryptoWalletXRPRecord {

--- a/WalletKitCore/src/ripple/BRRippleTransfer.c
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.c
@@ -185,6 +185,12 @@ rippleTransferHasError(BRRippleTransfer transfer) {
     return transfer->error;
 }
 
+extern int
+rippleTransferIsInBlock (BRRippleTransfer transfer) {
+    assert(transfer);
+    return transfer->blockHeight == 0 ? 0 : 1;
+}
+
 extern uint64_t rippleTransferGetBlockHeight (BRRippleTransfer transfer) {
     assert(transfer);
     return transfer->blockHeight;

--- a/WalletKitCore/src/ripple/BRRippleTransfer.h
+++ b/WalletKitCore/src/ripple/BRRippleTransfer.h
@@ -61,4 +61,8 @@ extern BRRippleUnitDrops rippleTransferGetAmountDirected (BRRippleTransfer trans
                                                           int *negative);
 
 extern uint64_t rippleTransferGetBlockHeight (BRRippleTransfer transfer);
+
+extern int
+rippleTransferIsInBlock (BRRippleTransfer transfer);
+
 #endif


### PR DESCRIPTION
Adds a 'Wallet Handler' that gets called on BRCryptoWallet{Add,Rem}Transfers; the handler allows subtypes to perform some actions when the wallet's transfers change.

For XRP, when a transfer is added/removed, the sequence number values are updated in BRCryptoWalletXRP.  Confirmed by sending an XRP transfer.

Note: For XRP there is no Blockset meta data with a sequence number and, generally no 'GET /accountState' endpoint.  Must iterate over the transfers to compute the sequence number.