### PR TITLE
CORE-1025: In Tezos, use counter value from estimate_fee response

### DIFF
--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -106,6 +106,25 @@ cryptoWalletNeedsRevealXTZ (BRCryptoWallet wallet) {
     return true;
 }
 
+private_extern BRCryptoTransfer
+cryptoWalletGetTransferByHashAndTargetXTZ (BRCryptoWallet wallet,
+                                           BRCryptoHash hashToMatch,
+                                           BRCryptoAddress targetToMatch) {
+    BRCryptoTransfer transfer = NULL;
+    
+    pthread_mutex_lock (&wallet->lock);
+    for (size_t index = 0; NULL == transfer && index < array_count(wallet->transfers); index++) {
+        BRCryptoHash hash = cryptoTransferGetHash (wallet->transfers[index]);
+        if (CRYPTO_TRUE == cryptoHashEqual(hash, hashToMatch) &&
+            cryptoAddressIsEqual(wallet->transfers[index]->targetAddress, targetToMatch))
+            transfer = wallet->transfers[index];
+        cryptoHashGive(hash);
+    }
+    pthread_mutex_unlock (&wallet->lock);
+    
+    return cryptoTransferTake (transfer);
+}
+
 extern size_t
 cryptoWalletGetTransferAttributeCountXTZ (BRCryptoWallet wallet,
                                           BRCryptoAddress target) {

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -29,7 +29,6 @@ cryptoWalletCoerce (BRCryptoWallet wallet) {
 
 typedef struct {
     BRTezosAccount xtzAccount;
-    int64_t counter;
 } BRCryptoWalletCreateContextXTZ;
 
 static void
@@ -39,7 +38,6 @@ cryptoWalletCreateCallbackXTZ (BRCryptoWalletCreateContext context,
     BRCryptoWalletXTZ walletXTZ = cryptoWalletCoerce (wallet);
 
     walletXTZ->xtzAccount = contextXTZ->xtzAccount;
-    walletXTZ->counter = contextXTZ->counter;
 }
 
 private_extern BRCryptoWallet
@@ -56,8 +54,7 @@ cryptoWalletCreateAsXTZ (BRCryptoWalletListener listener,
     BRCryptoFeeBasis feeBasis   = cryptoFeeBasisCreateAsXTZ (unitForFee, feeBasisXTZ);
 
     BRCryptoWalletCreateContextXTZ contextXTZ = {
-        xtzAccount,
-        0
+        xtzAccount
     };
 
     BRCryptoWallet wallet = cryptoWalletAllocAndInit (sizeof (struct BRCryptoWalletXTZRecord),
@@ -107,20 +104,6 @@ cryptoWalletNeedsRevealXTZ (BRCryptoWallet wallet) {
         if (CRYPTO_TRANSFER_SENT == direction) return false;
     }
     return true;
-}
-
-private_extern int64_t
-cryptoWalletGetCounterXTZ (BRCryptoWallet wallet) {
-    BRCryptoWalletXTZ walletXTZ = cryptoWalletCoerce (wallet);
-    return walletXTZ->counter;
-}
-
-private_extern void
-cryptoWalletSetCounterXTZ (BRCryptoWallet wallet, int64_t counter) {
-    BRCryptoWalletXTZ walletXTZ = cryptoWalletCoerce (wallet);
-    if (counter > walletXTZ->counter) {
-        walletXTZ->counter = counter;
-    }
 }
 
 extern size_t
@@ -212,7 +195,7 @@ cryptoWalletCreateTransferXTZ (BRCryptoWallet  wallet,
     BRTezosUnitMutez mutez = tezosMutezCreate (amount);
     BRTezosFeeBasis feeBasis = cryptoFeeBasisCoerceXTZ (estimatedFeeBasis)->xtzFeeBasis;
     assert (FEE_BASIS_ESTIMATE == feeBasis.type);
-    int64_t counter = MAX (walletXTZ->counter, feeBasis.u.estimate.counter);
+    int64_t counter = feeBasis.u.estimate.counter;
     
     bool delegationOp = false;
     

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -210,9 +210,9 @@ cryptoWalletCreateTransferXTZ (BRCryptoWallet  wallet,
     BRTezosAddress source  = tezosAccountGetAddress (walletXTZ->xtzAccount);
     BRTezosAddress xtzTarget  = cryptoAddressAsXTZ (target);
     BRTezosUnitMutez mutez = tezosMutezCreate (amount);
-    int64_t counter = walletXTZ->counter;
-
     BRTezosFeeBasis feeBasis = cryptoFeeBasisCoerceXTZ (estimatedFeeBasis)->xtzFeeBasis;
+    assert (FEE_BASIS_ESTIMATE == feeBasis.type);
+    int64_t counter = MAX (walletXTZ->counter, feeBasis.u.estimate.counter);
     
     bool delegationOp = false;
     

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
@@ -89,6 +89,11 @@ cryptoWalletCreateTransferXTZ (BRCryptoWallet  wallet,
 private_extern bool
 cryptoWalletNeedsRevealXTZ (BRCryptoWallet wallet);
 
+private_extern BRCryptoTransfer
+cryptoWalletGetTransferByHashAndTargetXTZ (BRCryptoWallet wallet,
+                                           BRCryptoHash hashToMatch,
+                                           BRCryptoAddress targetToMatch);
+
 // MARK: - Wallet Manager
 
 typedef struct BRCryptoWalletManagerXTZRecord {

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
@@ -65,7 +65,6 @@ cryptoTransferCreateAsXTZ (BRCryptoTransferListener listener,
 typedef struct BRCryptoWalletXTZRecord {
     struct BRCryptoWalletRecord base;
     BRTezosAccount xtzAccount;
-    int64_t counter;
 } *BRCryptoWalletXTZ;
 
 extern BRCryptoWalletHandlers cryptoWalletHandlersXTZ;
@@ -89,12 +88,6 @@ cryptoWalletCreateTransferXTZ (BRCryptoWallet  wallet,
 
 private_extern bool
 cryptoWalletNeedsRevealXTZ (BRCryptoWallet wallet);
-
-private_extern int64_t
-cryptoWalletGetCounterXTZ (BRCryptoWallet wallet);
-
-private_extern void
-cryptoWalletSetCounterXTZ (BRCryptoWallet wallet, int64_t counter);
 
 // MARK: - Wallet Manager
 

--- a/WalletKitCore/src/tezos/BRTezosFeeBasis.c
+++ b/WalletKitCore/src/tezos/BRTezosFeeBasis.c
@@ -34,6 +34,7 @@ tezosDefaultFeeBasis(BRTezosUnitMutez mutezPerByte) {
             // https://github.com/TezTech/eztz/blob/master/PROTO_004_FEES.md
             1040000, // hard gas limit, actual will be given by node estimate_fee
             60000, // hard limit, actual will be given by node estimate_fee
+            0 // counter will be given by estimate_fee
         } }
     };
 }
@@ -42,14 +43,16 @@ extern BRTezosFeeBasis
 tezosFeeBasisCreateEstimate(BRTezosUnitMutez mutezPerByte,
                             size_t sizeInBytes,
                             int64_t gasLimit,
-                            int64_t storageLimit) {
+                            int64_t storageLimit,
+                            int64_t counter) {
     return (BRTezosFeeBasis) {
         FEE_BASIS_ESTIMATE,
         { .estimate = {
             mutezPerByte,
             sizeInBytes,
             gasLimit,
-            MAX(storageLimit, TEZOS_MINIMAL_STORAGE_LIMIT)
+            MAX(storageLimit, TEZOS_MINIMAL_STORAGE_LIMIT),
+            counter
         } }
     };
 }

--- a/WalletKitCore/src/tezos/BRTezosFeeBasis.h
+++ b/WalletKitCore/src/tezos/BRTezosFeeBasis.h
@@ -34,6 +34,7 @@ typedef struct
             size_t              sizeInBytes;
             int64_t             gasLimit;
             int64_t             storageLimit;
+            int64_t             counter;
         } estimate;
         
         struct {
@@ -50,7 +51,8 @@ extern BRTezosFeeBasis
 tezosFeeBasisCreateEstimate(BRTezosUnitMutez mutezPerByte,
                             size_t sizeInBytes,
                             int64_t gasLimit,
-                            int64_t storageLimit);
+                            int64_t storageLimit,
+                            int64_t counter);
 
 extern BRTezosFeeBasis
 tezosFeeBasisCreateActual(BRTezosUnitMutez fee);


### PR DESCRIPTION
- removed logic to pull timer from transfer metadata
- added counter to BRTezosFeeBasis, populated from Blockset `estimate_fee` response
- fee estimation transfer is created with a 0 counter (Blockset replaces this with correct value for fee estimation RPC request)
- unrelated cleanup: refactored transaction-by-hash lookup for Tezos to handle unknown transfers (CORE-1023)