### PR TITLE
CORE-1041: Update Java Event Structure Definitions

### DIFF
--- a/WalletKitCore/include/event/BRCryptoNetwork.h
+++ b/WalletKitCore/include/event/BRCryptoNetwork.h
@@ -22,6 +22,7 @@ extern "C" {
 typedef enum {
     CRYPTO_NETWORK_EVENT_CREATED,
     CRYPTO_NETWORK_EVENT_FEES_UPDATED,
+    CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED,
     CRYPTO_NETWORK_EVENT_DELETED,
 } BRCryptoNetworkEventType;
 
@@ -30,9 +31,7 @@ cryptoNetworkEventTypeString (BRCryptoNetworkEventType t);
 
 typedef struct {
     BRCryptoNetworkEventType type;
-    union {
-        // fees
-    } u;
+    // No union; no data (at this time).
 } BRCryptoNetworkEvent;
 
 #ifdef __cplusplus

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkEvent.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkEvent.java
@@ -10,63 +10,6 @@ import java.util.List;
 public class BRCryptoNetworkEvent extends Structure {
 
     public int typeEnum;
-    public u_union u;
-
-    public static class u_union extends Union {
-
-//        public state_struct state;
-//
-//        public static class state_struct extends Structure {
-//
-//            public BRCryptoTransferState oldState;
-//            public BRCryptoTransferState newState;
-//
-//            public state_struct() {
-//                super();
-//            }
-//
-//            protected List<String> getFieldOrder() {
-//                return Arrays.asList("oldState", "newState");
-//            }
-//
-//            public state_struct(BRCryptoTransferState oldState, BRCryptoTransferState newState) {
-//                super();
-//                this.oldState = oldState;
-//                this.newState = newState;
-//            }
-//
-//            public state_struct(Pointer peer) {
-//                super(peer);
-//            }
-//
-//            public static class ByReference extends state_struct implements Structure.ByReference {
-//
-//            }
-//            public static class ByValue extends state_struct implements Structure.ByValue {
-//
-//            }
-//        }
-
-        public u_union() {
-            super();
-        }
-
-//        public u_union(state_struct state) {
-//            super();
-//            this.state = state;
-//            setType(state_struct.class);
-//        }
-
-        public u_union(Pointer peer) {
-            super(peer);
-        }
-
-        public static class ByReference extends u_union implements Structure.ByReference {
-        }
-
-        public static class ByValue extends u_union implements Structure.ByValue {
-        }
-    }
 
     public BRCryptoNetworkEvent() {
         super();
@@ -77,13 +20,12 @@ public class BRCryptoNetworkEvent extends Structure {
     }
 
     protected List<String> getFieldOrder() {
-        return Arrays.asList("typeEnum", "u");
+        return Arrays.asList("typeEnum");
     }
 
-    public BRCryptoNetworkEvent(int type, BRCryptoNetworkEvent.u_union u) {
+    public BRCryptoNetworkEvent(int type) {
         super();
         this.typeEnum = type;
-        this.u = u;
     }
 
     public BRCryptoNetworkEvent(Pointer peer) {
@@ -93,10 +35,6 @@ public class BRCryptoNetworkEvent extends Structure {
     @Override
     public void read() {
         super.read();
-//        if (type() == BRCryptoNetworkEventType.CRYPTO_TRANSFER_EVENT_CHANGED) {
-//            u.setType(BRCryptoNetworkEvent.u_union.state_struct.class);
-//            u.read();
-//        }
     }
 
     public static class ByReference extends BRCryptoNetworkEvent implements Structure.ByReference {

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkEventType.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkEventType.java
@@ -15,6 +15,13 @@ public enum BRCryptoNetworkEventType {
         }
     },
 
+    CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED {
+        @Override
+        public int toCore() {
+            return CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED_VALUE;
+        }
+    },
+
     CRYPTO_NETWORK_EVENT_DELETED {
         @Override
         public int toCore() {
@@ -24,12 +31,14 @@ public enum BRCryptoNetworkEventType {
 
     private static final int CRYPTO_NETWORK_EVENT_CREATED_VALUE = 0;
     private static final int CRYPTO_NETWORK_EVENT_FEES_UPDATED_VALUE = 1;
-    private static final int CRYPTO_NETWORK_EVENT_DELETED_VALUE = 2;
+    private static final int CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED_VALUE = 2;
+    private static final int CRYPTO_NETWORK_EVENT_DELETED_VALUE = 3;
 
     public static BRCryptoNetworkEventType fromCore(int nativeValue) {
         switch (nativeValue) {
             case CRYPTO_NETWORK_EVENT_CREATED_VALUE: return CRYPTO_NETWORK_EVENT_CREATED;
             case CRYPTO_NETWORK_EVENT_FEES_UPDATED_VALUE: return CRYPTO_NETWORK_EVENT_FEES_UPDATED;
+            case CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED_VALUE: return CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED;
             case CRYPTO_NETWORK_EVENT_DELETED_VALUE: return CRYPTO_NETWORK_EVENT_DELETED;
             default: throw new IllegalArgumentException("Invalid core value");
         }

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoSystemEvent.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoSystemEvent.java
@@ -15,11 +15,13 @@ public class BRCryptoSystemEvent extends Structure {
     public static class u_union extends Union {
 
         public state_struct state;
+        public BRCryptoNetwork network;
+        public BRCryptoWalletManager walletManager;
 
         public static class state_struct extends Structure {
 
-            public BRCryptoSystemState oldState;
-            public BRCryptoSystemState newState;
+            public int oldState;
+            public int newState;
 
             public state_struct() {
                 super();
@@ -29,7 +31,7 @@ public class BRCryptoSystemEvent extends Structure {
                 return Arrays.asList("oldState", "newState");
             }
 
-            public state_struct(BRCryptoSystemState oldState, BRCryptoSystemState newState) {
+            public state_struct(int oldState, int newState) {
                 super();
                 this.oldState = oldState;
                 this.newState = newState;
@@ -37,6 +39,14 @@ public class BRCryptoSystemEvent extends Structure {
 
             public state_struct(Pointer peer) {
                 super(peer);
+            }
+
+            public BRCryptoSystemState oldState () {
+                return BRCryptoSystemState.fromCore(oldState);
+            }
+
+            public BRCryptoSystemState newState () {
+                return BRCryptoSystemState.fromCore(newState);
             }
 
             public static class ByReference extends state_struct implements Structure.ByReference {
@@ -54,6 +64,18 @@ public class BRCryptoSystemEvent extends Structure {
             super();
             this.state = state;
             setType(state_struct.class);
+        }
+
+        public u_union(BRCryptoNetwork network) {
+            super ();
+            this.network = network;
+            setType(BRCryptoNetwork.class);
+        }
+
+        public u_union (BRCryptoWalletManager walletManager) {
+            super ();
+            this.walletManager = walletManager;
+            setType(BRCryptoWalletManager.class);
         }
 
         public u_union(Pointer peer) {
@@ -92,17 +114,17 @@ public class BRCryptoSystemEvent extends Structure {
     @Override
     public void read() {
         super.read();
-        if (type() == BRCryptoSystemEventType.CRYPTO_SYSTEM_EVENT_CHANGED) {
-            u.setType(u_union.state_struct.class);
-            u.read();
+        switch (type()) {
+            case CRYPTO_SYSTEM_EVENT_CHANGED:
+                u.setType(u_union.state_struct.class);
+                u.read();
+                break;
         }
     }
 
     public static class ByReference extends BRCryptoSystemEvent implements Structure.ByReference {
-
     }
 
     public static class ByValue extends BRCryptoSystemEvent implements Structure.ByValue {
-
     }
 }

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletEvent.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletEvent.java
@@ -21,7 +21,7 @@ public class BRCryptoWalletEvent extends Structure {
     public static class u_union extends Union {
 
         public state_struct state;
-        public transfer_struct transfer;
+        public BRCryptoTransfer transfer;
         public balanceUpdated_struct balanceUpdated;
         public feeBasisUpdated_struct feeBasisUpdated;
         public feeBasisEstimated_struct feeBasisEstimated;
@@ -62,36 +62,6 @@ public class BRCryptoWalletEvent extends Structure {
             }
 
             public static class ByValue extends state_struct implements Structure.ByValue {
-
-            }
-        }
-
-        public static class transfer_struct extends Structure {
-
-            public BRCryptoTransfer value;
-
-            public transfer_struct() {
-                super();
-            }
-
-            protected List<String> getFieldOrder() {
-                return Arrays.asList("value");
-            }
-
-            public transfer_struct(BRCryptoTransfer value) {
-                super();
-                this.value = value;
-            }
-
-            public transfer_struct(Pointer peer) {
-                super(peer);
-            }
-
-            public static class ByReference extends transfer_struct implements Structure.ByReference {
-
-            }
-
-            public static class ByValue extends transfer_struct implements Structure.ByValue {
 
             }
         }
@@ -204,10 +174,10 @@ public class BRCryptoWalletEvent extends Structure {
             setType(state_struct.class);
         }
 
-        public u_union(transfer_struct transfer) {
+        public u_union(BRCryptoTransfer transfer) {
             super();
             this.transfer = transfer;
-            setType(transfer_struct.class);
+            setType(BRCryptoTransfer.class);
         }
 
         public u_union(balanceUpdated_struct balanceUpdated) {
@@ -275,7 +245,7 @@ public class BRCryptoWalletEvent extends Structure {
             case CRYPTO_WALLET_EVENT_TRANSFER_DELETED:
             case CRYPTO_WALLET_EVENT_TRANSFER_CHANGED:
             case CRYPTO_WALLET_EVENT_TRANSFER_SUBMITTED:
-                u.setType(u_union.transfer_struct.class);
+                u.setType(BRCryptoTransfer.class);
                 u.read();
                 break;
             case CRYPTO_WALLET_EVENT_FEE_BASIS_UPDATED:

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEvent.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEvent.java
@@ -21,11 +21,11 @@ public class BRCryptoWalletManagerEvent extends Structure {
     public static class u_union extends Union {
 
         public state_struct state;
-        public wallet_struct wallet;
+        public BRCryptoWallet wallet;
         public syncContinues_struct syncContinues;
         public syncStopped_struct syncStopped;
         public syncRecommended_struct syncRecommended;
-        public blockHeight_struct blockHeight;
+        public long blockHeight;
 
         public static class state_struct extends Structure {
 
@@ -55,36 +55,6 @@ public class BRCryptoWalletManagerEvent extends Structure {
             }
 
             public static class ByValue extends state_struct implements Structure.ByValue {
-
-            }
-        }
-
-        public static class wallet_struct extends Structure {
-
-            public BRCryptoWallet value;
-
-            public wallet_struct() {
-                super();
-            }
-
-            protected List<String> getFieldOrder() {
-                return Arrays.asList("value");
-            }
-
-            public wallet_struct(BRCryptoWallet value) {
-                super();
-                this.value = value;
-            }
-
-            public wallet_struct(Pointer peer) {
-                super(peer);
-            }
-
-            public static class ByReference extends wallet_struct implements Structure.ByReference {
-
-            }
-
-            public static class ByValue extends wallet_struct implements Structure.ByValue {
 
             }
         }
@@ -184,35 +154,6 @@ public class BRCryptoWalletManagerEvent extends Structure {
             }
         }
 
-        public static class blockHeight_struct extends Structure {
-
-            public long value;
-
-            public blockHeight_struct() {
-                super();
-            }
-
-            protected List<String> getFieldOrder() {
-                return Arrays.asList("value");
-            }
-
-            public blockHeight_struct(long value) {
-                super();
-                this.value = value;
-            }
-
-            public blockHeight_struct(Pointer peer) {
-                super(peer);
-            }
-
-            public static class ByReference extends blockHeight_struct implements Structure.ByReference {
-
-            }
-
-            public static class ByValue extends blockHeight_struct implements Structure.ByValue {
-
-            }
-        }
 
         public u_union() {
             super();
@@ -224,10 +165,10 @@ public class BRCryptoWalletManagerEvent extends Structure {
             setType(state_struct.class);
         }
 
-        public u_union(wallet_struct wallet) {
+        public u_union(BRCryptoWallet wallet) {
             super();
             this.wallet = wallet;
-            setType(wallet_struct.class);
+            setType(BRCryptoWallet.class);
         }
 
         public u_union(syncContinues_struct syncContinues) {
@@ -248,10 +189,10 @@ public class BRCryptoWalletManagerEvent extends Structure {
             setType(syncRecommended_struct.class);
         }
 
-        public u_union(blockHeight_struct blockHeight) {
+        public u_union(long blockHeight) {
             super();
             this.blockHeight = blockHeight;
-            setType(blockHeight_struct.class);
+            setType(long.class);
         }
 
         public u_union(Pointer peer) {
@@ -294,7 +235,7 @@ public class BRCryptoWalletManagerEvent extends Structure {
         super.read();
         switch (type()){
             case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED:
-                u.setType(u_union.blockHeight_struct.class);
+                u.setType(long.class);
                 u.read();
                 break;
             case CRYPTO_WALLET_MANAGER_EVENT_CHANGED:
@@ -316,7 +257,7 @@ public class BRCryptoWalletManagerEvent extends Structure {
             case CRYPTO_WALLET_MANAGER_EVENT_WALLET_ADDED:
             case CRYPTO_WALLET_MANAGER_EVENT_WALLET_CHANGED:
             case CRYPTO_WALLET_MANAGER_EVENT_WALLET_DELETED:
-                u.setType(u_union.wallet_struct.class);
+                u.setType(BRCryptoWallet.class);
                 u.read();
                 break;
         }

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -946,7 +946,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletManagerWalletAdded(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWalletManagerEvent event) {
-        BRCryptoWallet coreWallet = event.u.wallet.value;
+        BRCryptoWallet coreWallet = event.u.wallet;
         try {
             Log.log(Level.FINE, "WalletManagerWalletAdded");
 
@@ -981,7 +981,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletManagerWalletChanged(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWalletManagerEvent event) {
-        BRCryptoWallet coreWallet = event.u.wallet.value;
+        BRCryptoWallet coreWallet = event.u.wallet;
         try {
             Log.log(Level.FINE, "WalletManagerWalletChanged");
 
@@ -1016,7 +1016,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletManagerWalletDeleted(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWalletManagerEvent event) {
-        BRCryptoWallet coreWallet = event.u.wallet.value;
+        BRCryptoWallet coreWallet = event.u.wallet;
         try {
             Log.log(Level.FINE, "WalletManagerWalletDeleted");
 
@@ -1140,7 +1140,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletManagerBlockHeightUpdated(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWalletManagerEvent event) {
-        UnsignedLong blockHeight = UnsignedLong.fromLongBits(event.u.blockHeight.value);
+        UnsignedLong blockHeight = UnsignedLong.fromLongBits(event.u.blockHeight);
 
         Log.log(Level.FINE, String.format("WalletManagerBlockHeightUpdated (%s)", blockHeight));
 
@@ -1308,7 +1308,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletTransferAdded(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWallet coreWallet, BRCryptoWalletEvent event) {
-        BRCryptoTransfer coreTransfer = event.u.transfer.value;
+        BRCryptoTransfer coreTransfer = event.u.transfer;
         try {
             Log.log(Level.FINE, "WalletTransferAdded");
 
@@ -1350,7 +1350,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletTransferChanged(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWallet coreWallet, BRCryptoWalletEvent event) {
-        BRCryptoTransfer coreTransfer = event.u.transfer.value;
+        BRCryptoTransfer coreTransfer = event.u.transfer;
         try {
             Log.log(Level.FINE, "WalletTransferChanged");
 
@@ -1392,7 +1392,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletTransferSubmitted(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWallet coreWallet, BRCryptoWalletEvent event) {
-        BRCryptoTransfer coreTransfer = event.u.transfer.value;
+        BRCryptoTransfer coreTransfer = event.u.transfer;
         try {
             Log.log(Level.FINE, "WalletTransferSubmitted");
 
@@ -1434,7 +1434,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleWalletTransferDeleted(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoWallet coreWallet, BRCryptoWalletEvent event) {
-        BRCryptoTransfer coreTransfer = event.u.transfer.value;
+        BRCryptoTransfer coreTransfer = event.u.transfer;
         try {
             Log.log(Level.FINE, "WalletTransferDeleted");
 

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -815,6 +815,8 @@ final class System implements com.breadwallet.crypto.System {
                         break;
                     case CRYPTO_NETWORK_EVENT_FEES_UPDATED:
                         break;
+                    case CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED:
+                        break;
                     case CRYPTO_NETWORK_EVENT_DELETED:
                         break;
                     }

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -763,8 +763,8 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void handleSystemChanged(Cookie context, BRCryptoSystem coreSystem, BRCryptoSystemEvent event) {
-        SystemState oldState = Utilities.systemStateFromCrypto(event.u.state.oldState);
-        SystemState newState = Utilities.systemStateFromCrypto(event.u.state.newState);
+        SystemState oldState = Utilities.systemStateFromCrypto(event.u.state.oldState());
+        SystemState newState = Utilities.systemStateFromCrypto(event.u.state.newState());
 
         Log.log(Level.FINE, String.format("SystemChanged (%s -> %s)", oldState, newState));
 

--- a/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoNetwork.swift
@@ -375,6 +375,10 @@ public enum NetworkEvent {
 
     // The netwok had its fees updated.
     case feesUpdated
+
+    // The network had its currencies updated.
+    case currenciesUpdated
+
     case deleted
 
     init (core: BRCryptoNetworkEvent) {
@@ -384,6 +388,9 @@ public enum NetworkEvent {
 
         case CRYPTO_NETWORK_EVENT_FEES_UPDATED:
             self = .feesUpdated
+
+        case CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED:
+            self = .currenciesUpdated
 
         case CRYPTO_NETWORK_EVENT_DELETED:
             self = .deleted


### PR DESCRIPTION
Also added in `CRYPTO_NETWORK_EVENT_CURRENCIES_UPDATED`.

Note that the Java Demo App is not handling the System nor Network events yet; so nothing shows in the App.  And the Unit tests don't compile; so building the library fails because it requires running some unit tests.