### PR TITLE
CORE-1000: Set transfer attributes recovered from bundle

### DIFF
--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -148,6 +148,12 @@ extern "C" {
                                             OwnershipKept BRCryptoTransferAttribute *attribute,
                                             BRCryptoBoolean *validates);
 
+    extern BRCryptoBoolean
+    cryptoWalletHasTransferAttributeForKey (BRCryptoWallet wallet,
+                                            BRCryptoAddress target,
+                                            const char *key,
+                                            BRCryptoBoolean *isRequired);
+
     /**
      * Create a transfer.
      *

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -718,4 +718,10 @@ cryptoTransferAttributeIsRequired (BRCryptoTransferAttribute attribute) {
     return attribute->isRequired;
 }
 
+private_extern void
+cryptoTransferAttributeReleaseAll (OwnershipGiven BRArrayOf(BRCryptoTransferAttribute) attributes) {
+    if (NULL == attributes) return;
+    array_free_all (attributes, cryptoTransferAttributeRelease);
+}
+
 DECLARE_CRYPTO_GIVE_TAKE (BRCryptoTransferAttribute, cryptoTransferAttribute);

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -719,9 +719,9 @@ cryptoTransferAttributeIsRequired (BRCryptoTransferAttribute attribute) {
 }
 
 private_extern void
-cryptoTransferAttributeReleaseAll (OwnershipGiven BRArrayOf(BRCryptoTransferAttribute) attributes) {
+cryptoTransferAttributeArrayRelease (BRArrayOf(BRCryptoTransferAttribute) attributes) {
     if (NULL == attributes) return;
-    array_free_all (attributes, cryptoTransferAttributeRelease);
+    array_free_all (attributes, cryptoTransferAttributeGive);
 }
 
 DECLARE_CRYPTO_GIVE_TAKE (BRCryptoTransferAttribute, cryptoTransferAttribute);

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -136,9 +136,13 @@ cryptoTransferSetAttributes (BRCryptoTransfer transfer,
                              size_t attributesCount,
                              OwnershipKept BRCryptoTransferAttribute *attributes);
 
+private_extern void
+cryptoTransferAttributeReleaseAll (OwnershipGiven BRArrayOf(BRCryptoTransferAttribute) attributes);
+
 static inline void
 cryptoTransferGenerateEvent (BRCryptoTransfer transfer,
                              BRCryptoTransferEvent event) {
+    if (NULL == transfer->listener.listener) return;
     cryptoListenerGenerateTransferEvent(&transfer->listener, transfer, event);
 }
 

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -137,7 +137,7 @@ cryptoTransferSetAttributes (BRCryptoTransfer transfer,
                              OwnershipKept BRCryptoTransferAttribute *attributes);
 
 private_extern void
-cryptoTransferAttributeReleaseAll (OwnershipGiven BRArrayOf(BRCryptoTransferAttribute) attributes);
+cryptoTransferAttributeArrayRelease (BRArrayOf(BRCryptoTransferAttribute) attributes);
 
 static inline void
 cryptoTransferGenerateEvent (BRCryptoTransfer transfer,

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -471,6 +471,27 @@ cryptoWalletValidateTransferAttributes (BRCryptoWallet wallet,
     return (BRCryptoTransferAttributeValidationError) 0;
 }
 
+extern BRCryptoBoolean
+cryptoWalletHasTransferAttributeForKey (BRCryptoWallet wallet,
+                                        BRCryptoAddress target,
+                                        const char *key,
+                                        BRCryptoBoolean *isRequired) {
+    assert(NULL != isRequired);
+    
+    size_t count = cryptoWalletGetTransferAttributeCount (wallet, target);
+    for (size_t index = 0; index < count; index++) {
+        BRCryptoTransferAttribute attribute = cryptoWalletGetTransferAttributeAt (wallet, target, index);
+        if (0 == strcasecmp(key, cryptoTransferAttributeGetKey (attribute))) {
+            *isRequired = cryptoTransferAttributeIsRequired (attribute);
+            return CRYPTO_TRUE;
+        }
+        cryptoTransferAttributeGive (attribute);
+    }
+    
+    *isRequired = CRYPTO_FALSE;
+    return CRYPTO_FALSE;
+}
+
 extern BRCryptoTransfer
 cryptoWalletCreateTransferMultiple (BRCryptoWallet wallet,
                                     size_t outputsCount,

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -463,9 +463,9 @@ cryptoWalletValidateTransferAttributes (BRCryptoWallet wallet,
     *validates = CRYPTO_TRUE;
 
     for (size_t index = 0; index <attributesCount; index++) {
-        cryptoWalletValidateTransferAttribute (wallet, attributes[index], validates);
+        BRCryptoTransferAttributeValidationError error = cryptoWalletValidateTransferAttribute (wallet, attributes[index], validates);
         if (CRYPTO_FALSE == *validates)
-            return CRYPTO_TRANSFER_ATTRIBUTE_VALIDATION_ERROR_RELATIONSHIP_INCONSISTENCY;
+            return error;
     }
 
     return (BRCryptoTransferAttributeValidationError) 0;

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1560,7 +1560,7 @@ cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (BRCryptoWallet w
         }
         
         cryptoTransferSetAttributes (transfer, array_count(attributes), attributes);
-        cryptoTransferAttributeReleaseAll (attributes);
+        cryptoTransferAttributeArrayRelease (attributes);
         cryptoAddressGive (target);
     }
 }

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -236,6 +236,11 @@ private_extern void
 cryptoWalletManagerRecoverTransferFromTransferBundle (BRCryptoWalletManager cwm,
                                                       OwnershipKept BRCryptoClientTransferBundle bundle);
 
+private_extern void
+cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (BRCryptoWallet wallet,
+                                                                BRCryptoTransfer transfer,
+                                                                OwnershipKept BRCryptoClientTransferBundle bundle);
+
 //private_extern void
 //cryptoWalletManagerGenerateTransferEvent (BRCryptoWalletManager cwm,
 //                                          BRCryptoWallet wallet,

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -103,7 +103,7 @@ cryptoWalletHasAddressHBAR (BRCryptoWallet wallet,
 extern size_t
 cryptoWalletGetTransferAttributeCountHBAR (BRCryptoWallet wallet,
                                            BRCryptoAddress target) {
-    BRHederaAddress hbarTarget = cryptoAddressAsHBAR (target);
+    BRHederaAddress hbarTarget = (NULL == target) ? NULL : cryptoAddressAsHBAR (target);
     
     size_t countRequired, countOptional;
     hederaWalletGetTransactionAttributeKeys (hbarTarget, 1, &countRequired);
@@ -115,7 +115,7 @@ extern BRCryptoTransferAttribute
 cryptoWalletGetTransferAttributeAtHBAR (BRCryptoWallet wallet,
                                         BRCryptoAddress target,
                                         size_t index) {
-    BRHederaAddress hbarTarget = cryptoAddressAsHBAR (target);
+    BRHederaAddress hbarTarget = (NULL == target) ? NULL : cryptoAddressAsHBAR (target);
     
     size_t countRequired, countOptional;
     const char **keysRequired = hederaWalletGetTransactionAttributeKeys (hbarTarget, 1, &countRequired);

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -239,6 +239,8 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
 
         cryptoWalletAddTransfer (wallet, baseTransfer);
     }
+    
+    cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
 
     bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
                        (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status &&
@@ -263,7 +265,6 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
     
     cryptoFeeBasisGive (feeBasis);
 
-    //TODO:HBAR attributes
     //TODO:HBAR save to fileService
 
     if (hbarTransactionNeedFree)

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoSupportXRP.c
@@ -77,7 +77,7 @@ rippleAddressGetTransactionAttributeKeys (BRRippleAddress address,
                                           int asRequired,
                                           size_t *count) {
     
-    if (rippleRequiresDestinationTag ((BRRippleAddress) address)) {
+    if (rippleRequiresDestinationTag (address)) {
         static size_t requiredCount = 1;
         static const char *requiredNames[] = {
             FIELD_OPTION_DESTINATION_TAG,

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -65,12 +65,6 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
         xrpTransfer
     };
 
-#if EXAMPLE
-    // Set the state from `transferGeneric`.  This is where we move from 'submitted' to 'included'
-    BRCryptoTransferState oldState = cryptoTransferGetState (transfer);
-    BRCryptoTransferState newState = cryptoTransferStateCreateGEN (genTransferGetState(transferGeneric), unitForFee);
-    cryptoTransferSetState (transfer, newState);
-#endif
     BRCryptoTransfer transfer = cryptoTransferAllocAndInit (sizeof (struct BRCryptoTransferXRPRecord),
                                                             CRYPTO_NETWORK_TYPE_XRP,
                                                             listener,

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -236,6 +236,8 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
         cryptoWalletAddTransfer (wallet, baseTransfer);
     }
     
+    cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
+    
     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsXRP (wallet->unitForFee, feeDrops);
 
     bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
@@ -259,7 +261,6 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
 
     cryptoFeeBasisGive (feeBasis);
 
-    //TODO:XRP attributes
     //TODO:XRP save to fileService
 
     if (xrpTransactionNeedFree)

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -103,7 +103,7 @@ cryptoWalletHasAddressXRP (BRCryptoWallet wallet,
 extern size_t
 cryptoWalletGetTransferAttributeCountXRP (BRCryptoWallet wallet,
                                           BRCryptoAddress target) {
-    BRRippleAddress xrpTarget = cryptoAddressAsXRP (target);
+    BRRippleAddress xrpTarget = (NULL == target) ? NULL : cryptoAddressAsXRP (target);
     
     size_t countRequired, countOptional;
     rippleAddressGetTransactionAttributeKeys (xrpTarget, 1, &countRequired);
@@ -115,7 +115,7 @@ extern BRCryptoTransferAttribute
 cryptoWalletGetTransferAttributeAtXRP (BRCryptoWallet wallet,
                                        BRCryptoAddress target,
                                        size_t index) {
-    BRRippleAddress xrpTarget = cryptoAddressAsXRP (target);
+    BRRippleAddress xrpTarget = (NULL == target) ? NULL : cryptoAddressAsXRP (target);
     
     size_t countRequired, countOptional;
     const char **keysRequired = rippleAddressGetTransactionAttributeKeys (xrpTarget, 1, &countRequired);

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -260,6 +260,8 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXTZ (BRCryptoWalletManager m
         cryptoWalletAddTransfer (wallet, baseTransfer);
     }
     
+    cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
+    
     bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
                        (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status &&
                         0 != bundle->blockNumber &&

--- a/WalletKitSwift/WalletKit/BRCryptoWallet.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWallet.swift
@@ -579,6 +579,11 @@ public final class Wallet: Equatable {
         }
     }
     
+    internal func defaultFeeBasis () -> TransferFeeBasis? {
+        return cryptoWalletGetDefaultFeeBasis (core)
+            .map { TransferFeeBasis (core: $0, take: false) }
+    }
+    
     ///
     /// Create a wallet
     ///

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
@@ -62,9 +62,8 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
         let feeBasisPricePerCostFactor = Amount.create (integer: 5000, unit: network.baseUnitFor(currency: network.currency)!)
         let feeBasisCostFactor = 1.0
-        let feeBasis: TransferFeeBasis! =
-            wallet.createTransferFeeBasis (pricePerCostFactor: feeBasisPricePerCostFactor,
-                                           costFactor: feeBasisCostFactor)
+        let feeBasis: TransferFeeBasis! = wallet.defaultFeeBasis()
+        
         XCTAssertNotNil(feeBasis)
         XCTAssertEqual (feeBasis.currency, wallet.unitForFee.currency)
         XCTAssertEqual (feeBasis.pricePerCostFactor, feeBasisPricePerCostFactor)
@@ -134,7 +133,8 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         var feeEstimateResult: Result<TransferFeeBasis, Wallet.FeeEstimationError>!
         wallet.estimateFee (target: transferTargetAddress,
                             amount: transferAmount,
-                            fee: network.minimumFee) { (res: Result<TransferFeeBasis, Wallet.FeeEstimationError>) in
+                            fee: network.minimumFee,
+                            attributes: nil) { (res: Result<TransferFeeBasis, Wallet.FeeEstimationError>) in
                                 feeEstimateResult = res
                                 feeEstimateExpectation.fulfill()
         }
@@ -427,9 +427,7 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         /// Transfer
         let feeBasisPricePerCostFactor = Amount.create (integer: 10, unit: network.baseUnitFor(currency: network.currency)!)
         let feeBasisCostFactor = 1.0
-        let feeBasis: TransferFeeBasis! =
-            wallet.createTransferFeeBasis (pricePerCostFactor: feeBasisPricePerCostFactor,
-                                           costFactor: feeBasisCostFactor)
+        let feeBasis: TransferFeeBasis! = wallet.defaultFeeBasis()
 
         attributes = Set(wallet.transferAttributesFor(target: coinbase)
             .compactMap {


### PR DESCRIPTION
- added an internal interface for `defaultFeeBasis` in `BRCryptoWallet` for use by unit tests (replacement for deprecated `createTransferFeeBasis`)