### PR TITLE
CORE-1035: Recover Transations/Transfers from the FileService

### DIFF
--- a/WalletKitCore/include/BRCryptoBase.h
+++ b/WalletKitCore/include/BRCryptoBase.h
@@ -29,6 +29,10 @@
 #define OwnershipKept
 #endif
 
+#if !defined (Nullable)
+#define Nullable
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -109,6 +109,10 @@ extern int
 cryptoClientTransferBundleCompare (const BRCryptoClientTransferBundle b1,
                                    const BRCryptoClientTransferBundle b2);
 
+extern BRCryptoTransferState
+cryptoClientTransferBundleGetTransferState (const BRCryptoClientTransferBundle bundle,
+                                            BRCryptoFeeBasis confirmedFeeBasis);
+
 extern void
 cwmAnnounceTransfers (OwnershipKept BRCryptoWalletManager cwm,
                       OwnershipGiven BRCryptoClientCallbackState callbackState,

--- a/WalletKitCore/include/BRCryptoListener.h
+++ b/WalletKitCore/include/BRCryptoListener.h
@@ -67,6 +67,8 @@ typedef struct {
     BRCryptoSystem system;
 } BRCryptoNetworkListener;
 
+#define CRYPTO_NETWORK_LISTENER_EMPTY       ((BRCryptoNetworkListener) { NULL, NULL })
+
 extern void
 cryptoListenerGenerateNetworkEvent (const BRCryptoNetworkListener *listener,
                                     BRCryptoNetwork network,
@@ -90,6 +92,8 @@ typedef struct {
     BRCryptoTransferStateChangedCallback transferChangedCallback;
 } BRCryptoTransferListener;
 
+#define CRYPTO_TRANSFER_LISTENER_EMPTY      ((BRCryptoTransferListener) { NULL, NULL, NULL, NULL, NULL })
+
 extern void
 cryptoListenerGenerateTransferEvent (const BRCryptoTransferListener *listener,
                                      BRCryptoTransfer transfer,
@@ -103,6 +107,8 @@ typedef struct {
     BRCryptoWalletManager manager;
     BRCryptoTransferStateChangedCallback transferChangedCallback;
 } BRCryptoWalletListener;
+
+#define CRYPTO_WALLET_LISTENER_EMPTY       ((BRCryptoWalletListener) { NULL, NULL, NULL, NULL })
 
 static inline BRCryptoTransferListener
 cryptoListenerCreateTransferListener (const BRCryptoWalletListener *listener,
@@ -129,6 +135,8 @@ typedef struct {
     BRCryptoListener listener;
     BRCryptoSystem system;
 } BRCryptoWalletManagerListener;
+
+#define CRYPTO_WALLET_MANAGER_LISTENER_EMPTY       ((BRCryptoWalletManagerListener) { NULL, NULL })
 
 static inline BRCryptoWalletListener
 cryptoListenerCreateWalletListener (const BRCryptoWalletManagerListener *listener,

--- a/WalletKitCore/src/bitcoin/BRPeerManager.c
+++ b/WalletKitCore/src/bitcoin/BRPeerManager.c
@@ -1566,7 +1566,7 @@ BRPeerManager *BRPeerManagerNew(const BRChainParams *params, BRWallet *wallet, u
         block = BRSetGet(manager->orphans, &orphan);
     }
 
-    _peer_log("BPM: initialized with %u last block height", manager->lastBlock->height);
+    _peer_log("BPM: initialized with %u last block height\n", manager->lastBlock->height);
 
     array_new(manager->txRelays, 10);
     array_new(manager->txRequests, 10);

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -1052,6 +1052,26 @@ cryptoClientTransferBundleCompare (const BRCryptoClientTransferBundle b1,
                       :  0))));
 }
 
+extern BRCryptoTransferState
+cryptoClientTransferBundleGetTransferState (const BRCryptoClientTransferBundle bundle,
+                                            BRCryptoFeeBasis confirmedFeeBasis) {
+    bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
+                       (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status &&
+                        0 != bundle->blockNumber &&
+                        0 != bundle->blockTimestamp));
+
+    return (isIncluded
+            ? cryptoTransferStateIncludedInit (bundle->blockNumber,
+                                               bundle->blockTransactionIndex,
+                                               bundle->blockTimestamp,
+                                               confirmedFeeBasis,
+                                               AS_CRYPTO_BOOLEAN(CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status),
+                                               (isIncluded ? NULL : "unknown"))
+            : (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status
+               ? cryptoTransferStateErroredInit (cryptoTransferSubmitErrorUnknown())
+               : cryptoTransferStateInit (bundle->status)));
+}
+
 static BRRlpItem
 cryptoClientTransferBundleRlpEncodeAttributes (size_t count,
                                                const char **keys,

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -174,8 +174,7 @@ cryptoClientQRYManagerCreate (BRCryptoClient client,
     qry->sync.success   = false;
     qry->sync.unbounded = CRYPTO_CLIENT_QRY_IS_UNBOUNDED;
 
-    // gwm->syncContext  = syncContext;
-    // gwm->syncCallback = syncCallback;
+    qry->connected = true;
     return qry;
 }
 
@@ -187,12 +186,12 @@ cryptoClientQRYManagerRelease (BRCryptoClientQRYManager qry) {
 
 extern void
 cryptoClientQRYManagerConnect (BRCryptoClientQRYManager qry) {
-    printf ("QRY: Want to Connect\n");
+    qry->connected = true;
 }
 
 extern void
 cryptoClientQRYManagerDisconnect (BRCryptoClientQRYManager qry) {
-    printf ("QRY: Want to Disconnect\n");
+    qry->connected = false;
 }
 
 
@@ -217,6 +216,9 @@ cryptoClientQRYManagerSend (BRCryptoClientQRYManager qry,
 
 extern void
 cryptoClientQRYManagerTickTock (BRCryptoClientQRYManager qry) {
+    // Skip out if not connected.
+    if (!qry->connected) return;
+
     // Skip out if not an API sync.
     if (CRYPTO_SYNC_MODE_API_ONLY          != qry->manager->syncMode &&
         CRYPTO_SYNC_MODE_API_WITH_P2P_SEND != qry->manager->syncMode) return;

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -284,6 +284,7 @@ struct BRCryptoClientQRYManagerRecord {
         size_t rid;
     } sync;
 
+    bool connected;
     size_t requestId;
 };
 

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -33,6 +33,10 @@ struct BRCryptoClientTransactionBundleRecord {
     BRCryptoBlockNumber blockHeight;
 };
 
+private_extern OwnershipKept uint8_t *
+cryptoClientTransactionBundleGetSerialization (BRCryptoClientTransactionBundle bundle,
+                                               size_t *serializationCount);
+
 private_extern BRRlpItem
 cryptoClientTransactionBundleRlpEncode (BRCryptoClientTransactionBundle bundle,
                                         BRRlpCoder coder);

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -12,6 +12,7 @@
 #define BRCryptoClientP_h
 
 #include "support/BRSet.h"
+#include "support/rlp/BRRlp.h"
 
 #include "BRCryptoClient.h"
 #include "BRCryptoSync.h"
@@ -22,7 +23,7 @@
 extern "C" {
 #endif
 
-// MARK: - Transaction/Transfer Bundle
+// MARK: - Transaction Bundle
 
 struct BRCryptoClientTransactionBundleRecord {
     BRCryptoTransferStateType status;
@@ -31,6 +32,38 @@ struct BRCryptoClientTransactionBundleRecord {
     BRCryptoTimestamp timestamp;
     BRCryptoBlockNumber blockHeight;
 };
+
+private_extern BRRlpItem
+cryptoClientTransactionBundleRlpEncode (BRCryptoClientTransactionBundle bundle,
+                                        BRRlpCoder coder);
+
+private_extern BRCryptoClientTransactionBundle
+cryptoClientTransactionBundleRlpDecode (BRRlpItem item,
+                                        BRRlpCoder coder);
+
+// For BRSet
+private_extern size_t
+cryptoClientTransactionBundleGetHashValue (BRCryptoClientTransactionBundle bundle);
+
+// For BRSet
+private_extern bool
+cryptoClientTransactionBundleIsEqual (BRCryptoClientTransactionBundle bundle1,
+                                      BRCryptoClientTransactionBundle bundle2);
+
+static inline BRSetOf(BRCryptoClientTransactionBundle)
+cryptoClientTransactionBundleSetCreate (size_t capacity) {
+    return BRSetNew ((size_t (*) (const void *)) cryptoClientTransactionBundleGetHashValue,
+                     (int (*) (const void *, const void *)) cryptoClientTransactionBundleIsEqual,
+                    capacity);
+}
+
+static inline void
+cryptoClientTransactionBundleSetRelease (BRSetOf(BRCryptoClientTransactionBundle) bundles) {
+    BRSetFreeAll(bundles, (void (*) (void *))  cryptoClientTransactionBundleRelease);
+}
+
+
+// MARK: - Transfer Bundle
 
 struct BRCryptoClientTransferBundleRecord {
     BRCryptoTransferStateType status;
@@ -51,6 +84,35 @@ struct BRCryptoClientTransferBundleRecord {
     char **attributeKeys;
     char **attributeVals;
 };
+
+private_extern BRRlpItem
+cryptoClientTransferBundleRlpEncode (BRCryptoClientTransferBundle bundle,
+                                     BRRlpCoder coder);
+
+private_extern BRCryptoClientTransferBundle
+cryptoClientTransferBundleRlpDecode (BRRlpItem item,
+                                     BRRlpCoder coder);
+
+// For BRSet
+private_extern size_t
+cryptoClientTransferBundleGetHashValue (BRCryptoClientTransferBundle bundle);
+
+// For BRSet
+private_extern bool
+cryptoClientTransferBundleIsEqual (BRCryptoClientTransferBundle bundle1,
+                                   BRCryptoClientTransferBundle bundle2);
+
+static inline BRSetOf(BRCryptoClientTransferBundle)
+cryptoClientTransferBundleSetCreate (size_t capacity) {
+    return BRSetNew ((size_t (*) (const void *)) cryptoClientTransferBundleGetHashValue,
+                     (int (*) (const void *, const void *)) cryptoClientTransferBundleIsEqual,
+                     capacity);
+}
+
+static inline void
+cryptoClientTransferBundleSetRelease (BRSetOf(BRCryptoClientTransferBundle) bundles) {
+    BRSetFreeAll(bundles, (void (*) (void *)) cryptoClientTransferBundleRelease);
+}
 
 // MARK: - Client Callback
 

--- a/WalletKitCore/src/crypto/BRCryptoFileService.c
+++ b/WalletKitCore/src/crypto/BRCryptoFileService.c
@@ -11,168 +11,150 @@
 
 #include "BRCryptoFileService.h"
 
+#include "support/rlp/BRRlp.h"
+#include "support/BRCrypto.h"
+
+#include "BRCryptoClientP.h"
+#include "BRCryptoNetworkP.h"
+#include "BRCryptoWalletManagerP.h"
+
+// MARK: - Client Transfer Bundle
+
 private_extern UInt256
-fileServiceTypeTransferV1Identifier (BRFileServiceContext context,
+cryptoFileServiceTypeTransferV1Identifier (BRFileServiceContext context,
                                      BRFileService fs,
                                      const void *entity) {
-#ifdef REFACTOR
-    BRGenericTransfer transfer = (BRGenericTransfer) entity;
-    BRGenericHash     hash     = genTransferGetHash(transfer);
+    BRCryptoWalletManager        manager = (BRCryptoWalletManager) context;
+    BRCryptoClientTransferBundle bundle  = (BRCryptoClientTransferBundle) entity;
 
-    assert (hash.bytesCount >= sizeof(UInt256));
-    UInt256 *result = (UInt256*) hash.bytes;
+    BRCryptoHash hash = cryptoNetworkCreateHashFromString (manager->network, bundle->hash);
 
-    return *result;
-#endif
-    return UINT256_ZERO;
+    UInt256 identifier = UINT256_ZERO;
+    memcpy (identifier.u8, hash->bytes, MIN (32, hash->bytesCount));
+
+    return identifier;
 }
 
 private_extern void *
-fileServiceTypeTransferV1Reader (BRFileServiceContext context,
+cryptoFileServiceTypeTransferV1Reader (BRFileServiceContext context,
                                  BRFileService fs,
                                  uint8_t *bytes,
                                  uint32_t bytesCount) {
-#ifdef REFACTOR
-    BRGenericManager gwm = (BRGenericManager) context;
+    BRCryptoWalletManager manager = (BRCryptoWalletManager) context; (void) manager;
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpData  data  = (BRRlpData) { bytesCount, bytes };
     BRRlpItem  item  = rlpDataGetItem (coder, data);
 
-    size_t itemsCount;
-    const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
-    assert (9 == itemsCount);
-
-    BRRlpData hashData = rlpDecodeBytes(coder, items[0]);
-    char *strUids   = rlpDecodeString  (coder, items[1]);
-    char *strSource = rlpDecodeString  (coder, items[2]);
-    char *strTarget = rlpDecodeString  (coder, items[3]);
-    UInt256 amount  = rlpDecodeUInt256 (coder, items[4], 0);
-    char *currency  = rlpDecodeString  (coder, items[5]);
-    BRGenericFeeBasis feeBasis = genFeeBasisDecode (items[6], coder);
-    BRGenericTransferState state = genTransferStateDecode (items[7], coder);
-    BRArrayOf(BRGenericTransferAttribute) attributes = genTransferAttributesDecode(items[8], coder);
-
-    BRGenericHash hash = genericHashCreate(hashData.bytesCount, hashData.bytes);
-
-    char *strHash   = genericHashAsString (hash);
-    char *strAmount = uint256CoerceString (amount, 10);
-
-    int overflow = 0;
-    UInt256 fee = genFeeBasisGetFee (&feeBasis, &overflow);
-    assert (!overflow);
-    char *strFee = uint256CoerceString (fee,    10);
-
-    uint64_t timestamp = (GENERIC_TRANSFER_STATE_INCLUDED == state.type
-                          ? state.u.included.timestamp
-                          : GENERIC_TRANSFER_TIMESTAMP_UNKNOWN);
-
-    uint64_t blockHeight = (GENERIC_TRANSFER_STATE_INCLUDED == state.type
-                            ? state.u.included.blockNumber
-                            : GENERIC_TRANSFER_BLOCK_NUMBER_UNKNOWN);
-
-    // Derive `wallet` from currency
-    BRGenericWallet  wallet = genManagerGetPrimaryWallet (gwm);
-
-    BRGenericTransfer transfer = genManagerRecoverTransfer (gwm, wallet, strHash,
-                                                            strUids,
-                                                            strSource,
-                                                            strTarget,
-                                                            strAmount,
-                                                            currency,
-                                                            strFee,
-                                                            timestamp,
-                                                            blockHeight,
-                                                            GENERIC_TRANSFER_STATE_ERRORED == state.type);
-
-    // Set the transfer's `state` and `attributes` from the read values.  For`state`, this will
-    // overwrite what `genManagerRecoverTransfer()` assigned but will be correct with the saved
-    // values.  Later, perhaps based on a BlocksetDB query, the state change to 'included error'.
-    genTransferSetState (transfer, state);
-    genTransferSetAttributes (transfer, attributes);
-
-    genTransferAttributeReleaseAll(attributes);
-    free (strFee);
-    free (strAmount);
-    free (strHash);
-    free (currency);
-    free (strTarget);
-    free (strSource);
-    free (strUids);
+    BRCryptoClientTransferBundle bundle = cryptoClientTransferBundleRlpDecode(item, coder);
 
     rlpItemRelease (coder, item);
     rlpCoderRelease(coder);
 
-    return transfer;
-#endif
-    return NULL;
+    return bundle;
 }
 
 private_extern uint8_t *
-fileServiceTypeTransferWriter (BRFileServiceContext context,
-                               BRFileService fs,
-                               const void* entity,
-                               uint32_t *bytesCount,
-                               BRGenericFileServiceTransferVersion version) {
-#ifdef REFACTOR
-    BRGenericTransfer transfer = (BRGenericTransfer) entity;
+cryptoFileServiceTypeTransferV1Writer (BRFileServiceContext context,
+                                 BRFileService fs,
+                                 const void* entity,
+                                 uint32_t *bytesCount) {
+    BRCryptoWalletManager        manager = (BRCryptoWalletManager) context; (void) manager;
+    BRCryptoClientTransferBundle bundle  = (BRCryptoClientTransferBundle) entity;
 
-    BRGenericHash    hash   = genTransferGetHash (transfer);
-    BRGenericAddress source = genTransferGetSourceAddress (transfer);
-    BRGenericAddress target = genTransferGetTargetAddress (transfer);
-    UInt256 amount = genTransferGetAmount (transfer);
-    BRGenericFeeBasis feeBasis = genTransferGetFeeBasis(transfer);
-    BRGenericTransferState state = genTransferGetState (transfer);
-
-    // Code it Up!
     BRRlpCoder coder = rlpCoderCreate();
+    BRRlpItem  item  = cryptoClientTransferBundleRlpEncode (bundle, coder);
+    BRRlpData  data  = rlpItemGetData (coder, item);
 
-    char *strSource = genAddressAsString(source);
-    char *strTarget = genAddressAsString(target);
-
-    BRGenericTransferStateEncodeVersion stateEncodeVersion =
-        (GENERIC_TRANSFER_VERSION_1 == version ? GEN_TRANSFER_STATE_ENCODE_V1
-         : (GENERIC_TRANSFER_VERSION_2 == version ? GEN_TRANSFER_STATE_ENCODE_V2
-            : GEN_TRANSFER_STATE_ENCODE_V1));
-
-    BRRlpItem item = rlpEncodeList (coder, 9,
-                                    rlpEncodeBytes (coder, hash.bytes, hash.bytesCount),
-                                    rlpEncodeString (coder, transfer->uids),
-                                    rlpEncodeString (coder, strSource),
-                                    rlpEncodeString (coder, strTarget),
-                                    rlpEncodeUInt256 (coder, amount, 0),
-                                    rlpEncodeString (coder, cryptoNetworkCanonicalTypeGetCurrencyCode(transfer->type)),
-                                    genFeeBasisEncode (feeBasis, coder),
-                                    genTransferStateEncode (state, stateEncodeVersion, coder),
-                                    genTransferAttributesEncode (transfer->attributes, coder));
-
-    BRRlpData data = rlpItemGetData (coder, item);
-
-    rlpItemRelease (coder, item);
+    rlpItemRelease  (coder, item);
     rlpCoderRelease (coder);
-
-    free (strSource); genAddressRelease (source);
-    free (strTarget); genAddressRelease (target);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
-#endif
-    return NULL;
+}
+
+// MARK: - Client Transaction Bundle
+
+private_extern UInt256
+cryptoFileServiceTypeTransactionV1Identifier (BRFileServiceContext context,
+                                     BRFileService fs,
+                                     const void *entity) {
+    BRCryptoWalletManager           manager = (BRCryptoWalletManager) context; (void) manager;
+    BRCryptoClientTransactionBundle bundle  = (BRCryptoClientTransactionBundle) entity;
+
+    UInt256 identifier;
+
+    BRSHA256 (identifier.u8, bundle->serialization, bundle->serializationCount);
+
+    return identifier;
+}
+
+private_extern void *
+cryptoFileServiceTypeTransactionV1Reader (BRFileServiceContext context,
+                                 BRFileService fs,
+                                 uint8_t *bytes,
+                                 uint32_t bytesCount) {
+    BRCryptoWalletManager manager = (BRCryptoWalletManager) context;
+    (void) manager;
+
+    BRRlpCoder coder = rlpCoderCreate();
+    BRRlpData  data  = (BRRlpData) { bytesCount, bytes };
+    BRRlpItem  item  = rlpDataGetItem (coder, data);
+
+    BRCryptoClientTransactionBundle bundle = cryptoClientTransactionBundleRlpDecode(item, coder);
+
+    rlpItemRelease (coder, item);
+    rlpCoderRelease(coder);
+
+    return bundle;
 }
 
 private_extern uint8_t *
-fileServiceTypeTransferV1Writer (BRFileServiceContext context,
+cryptoFileServiceTypeTransactionV1Writer (BRFileServiceContext context,
                                  BRFileService fs,
                                  const void* entity,
                                  uint32_t *bytesCount) {
-    return fileServiceTypeTransferWriter (context, fs, entity, bytesCount, GENERIC_TRANSFER_VERSION_1);
+    BRCryptoWalletManager           manager = (BRCryptoWalletManager) context; (void) manager;
+    BRCryptoClientTransactionBundle bundle  = (BRCryptoClientTransactionBundle) entity;
+
+    BRRlpCoder coder = rlpCoderCreate();
+    BRRlpItem  item  = cryptoClientTransactionBundleRlpEncode (bundle, coder);
+    BRRlpData  data  = rlpItemGetData (coder, item);
+
+    rlpItemRelease  (coder, item);
+    rlpCoderRelease (coder);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
 }
 
-private_extern uint8_t *
-fileServiceTypeTransferV2Writer (BRFileServiceContext context,
-                                 BRFileService fs,
-                                 const void* entity,
-                                 uint32_t *bytesCount) {
-    return fileServiceTypeTransferWriter (context, fs, entity, bytesCount, GENERIC_TRANSFER_VERSION_2);
-}
+BRFileServiceTypeSpecification cryptoFileServiceSpecifications[] = {
+    {
+        CRYPTO_FILE_SERVICE_TYPE_TRANSFER,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1, // current version
+        1,
+        {
+            {
+                CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1,
+                cryptoFileServiceTypeTransferV1Identifier,
+                cryptoFileServiceTypeTransferV1Reader,
+                cryptoFileServiceTypeTransferV1Writer
+            },
+        }
+    },
 
+    {
+        CRYPTO_FILE_SERVICE_TYPE_TRANSACTION,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1, // current version
+        1,
+        {
+            {
+                CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
+                cryptoFileServiceTypeTransactionV1Identifier,
+                cryptoFileServiceTypeTransactionV1Reader,
+                cryptoFileServiceTypeTransactionV1Writer
+            },
+        }
+    }
+};
+size_t cryptoFileServiceSpecificationsCount = (sizeof (cryptoFileServiceSpecifications) / sizeof (BRFileServiceTypeSpecification));

--- a/WalletKitCore/src/crypto/BRCryptoFileService.h
+++ b/WalletKitCore/src/crypto/BRCryptoFileService.h
@@ -19,59 +19,54 @@
 extern "C" {
 #endif
 
-#define fileServiceTypeTransactions      "transactions"
+#define CRYPTO_FILE_SERVICE_TYPE_TRANSFER      "crypto_transfers"
 
 typedef enum {
-    GENERIC_TRANSFER_VERSION_1,
-    GENERIC_TRANSFER_VERSION_2,
-} BRGenericFileServiceTransferVersion;
+    CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1
+} BRCryptoFileServiceTransferVersion;
 
 private_extern UInt256
-fileServiceTypeTransferV1Identifier (BRFileServiceContext context,
+cryptoFileServiceTypeTransferV1Identifier (BRFileServiceContext context,
                                      BRFileService fs,
                                      const void *entity);
 
 private_extern void *
-fileServiceTypeTransferV1Reader (BRFileServiceContext context,
+cryptoFileServiceTypeTransferV1Reader (BRFileServiceContext context,
                                  BRFileService fs,
                                  uint8_t *bytes,
                                  uint32_t bytesCount);
 
 private_extern uint8_t *
-fileServiceTypeTransferV1Writer (BRFileServiceContext context,
+cryptoFileServiceTypeTransferV1Writer (BRFileServiceContext context,
                                  BRFileService fs,
                                  const void* entity,
                                  uint32_t *bytesCount);
+
+
+#define CRYPTO_FILE_SERVICE_TYPE_TRANSACTION      "crypto_transactions"
+
+typedef enum {
+    CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1
+} BRCryptoFileServiceTransactionVersion;
+
+private_extern UInt256
+cryptoFileServiceTypeTransactionV1Identifier (BRFileServiceContext context,
+                                        BRFileService fs,
+                                        const void *entity);
+
+private_extern void *
+cryptoFileServiceTypeTransactionV1Reader (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    uint8_t *bytes,
+                                    uint32_t bytesCount);
 
 private_extern uint8_t *
-fileServiceTypeTransferV2Writer (BRFileServiceContext context,
-                                 BRFileService fs,
-                                 const void* entity,
-                                 uint32_t *bytesCount);
+cryptoFileServiceTypeTransactionV1Writer (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    const void* entity,
+                                    uint32_t *bytesCount);
 
-static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
-    {
-        fileServiceTypeTransactions,
-        GENERIC_TRANSFER_VERSION_2, // current version
-        2,
-        {
-            {
-                GENERIC_TRANSFER_VERSION_1,
-                fileServiceTypeTransferV1Identifier,
-                fileServiceTypeTransferV1Reader,
-                fileServiceTypeTransferV1Writer
-            },
-
-            {
-                GENERIC_TRANSFER_VERSION_2,
-                fileServiceTypeTransferV1Identifier,
-                fileServiceTypeTransferV1Reader,
-                fileServiceTypeTransferV2Writer
-            },
-        }
-    }
-};
-static size_t fileServiceSpecificationsCount = (sizeof (fileServiceSpecifications) / sizeof (BRFileServiceTypeSpecification));
-
+extern BRFileServiceTypeSpecification cryptoFileServiceSpecifications[];
+extern size_t cryptoFileServiceSpecificationsCount;
 
 #endif /* BRCryptoFileService_h */

--- a/WalletKitCore/src/crypto/BRCryptoListener.c
+++ b/WalletKitCore/src/crypto/BRCryptoListener.c
@@ -50,6 +50,8 @@ extern void
 cryptoListenerGenerateTransferEvent (const BRCryptoTransferListener *listener,
                                      BRCryptoTransfer transfer,
                                      BRCryptoTransferEvent event) {
+    if (NULL == listener || NULL == listener->listener) return;
+
     BRListenerSignalTransferEvent listenerEvent =
     { { NULL, &handleListenerSignalTransferEventType},
         listener->listener,
@@ -90,6 +92,8 @@ extern void
 cryptoListenerGenerateWalletEvent (const BRCryptoWalletListener *listener,
                                    BRCryptoWallet wallet,
                                    BRCryptoWalletEvent event) {
+    if (NULL == listener || NULL == listener->listener) return;
+
     BRListenerSignalWalletEvent listenerEvent =
     { { NULL, &handleListenerSignalWalletEventType},
         listener->listener,
@@ -127,6 +131,8 @@ extern void
 cryptoListenerGenerateManagerEvent (const BRCryptoWalletManagerListener *listener,
                                     BRCryptoWalletManager manager,
                                     BRCryptoWalletManagerEvent event) {
+    if (NULL == listener || NULL == listener->listener) return;
+
     BRListenerSignalManagerEvent listenerEvent =
     { { NULL, &handleListenerSignalManagerEventType},
         listener->listener,
@@ -163,6 +169,8 @@ extern void
 cryptoListenerGenerateNetworkEvent (const BRCryptoNetworkListener *listener,
                                     BRCryptoNetwork network,
                                     BRCryptoNetworkEvent event) {
+    if (NULL == listener || NULL == listener->listener) return;
+
     BRListenerSignalNetworkEvent listenerEvent =
     { { NULL, &handleListenerSignalNetworkEventType},
         listener->listener,
@@ -199,6 +207,8 @@ extern void
 cryptoListenerGenerateSystemEvent (BRCryptoListener listener,
                                    BRCryptoSystem system,
                                    BRCryptoSystemEvent event) {
+    if (NULL == listener) return;
+
     BRListenerSignalSystemEvent listenerEvent =
     { { NULL, &handleListenerSignalSystemEventType},
         listener,

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -84,7 +84,6 @@ cryptoTransferAllocAndInit (size_t sizeInBytes,
     transfer->sizeInBytes = sizeInBytes;
 
     transfer->listener   = listener;
-    transfer->state      = (BRCryptoTransferState) { CRYPTO_TRANSFER_STATE_CREATED };
     transfer->unit       = cryptoUnitTake(unit);
     transfer->unitForFee = cryptoUnitTake(unitForFee);
     transfer->feeBasisEstimated = cryptoFeeBasisTake (feeBasisEstimated);

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -73,6 +73,7 @@ cryptoTransferAllocAndInit (size_t sizeInBytes,
                             BRCryptoTransferDirection direction,
                             BRCryptoAddress sourceAddress,
                             BRCryptoAddress targetAddress,
+                            BRCryptoTransferState state,
                             BRCryptoTransferCreateContext  createContext,
                             BRCryptoTransferCreateCallback createCallback) {
     assert (sizeInBytes >= sizeof (struct BRCryptoTransferRecord));
@@ -93,6 +94,7 @@ cryptoTransferAllocAndInit (size_t sizeInBytes,
     
     transfer->sourceAddress = cryptoAddressTake (sourceAddress);
     transfer->targetAddress = cryptoAddressTake (targetAddress);
+    transfer->state         = cryptoTransferStateCopy (&state);
 
     array_new (transfer->attributes, 1);
 

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -121,6 +121,7 @@ cryptoTransferAllocAndInit (size_t sizeInBytes,
                             BRCryptoTransferDirection direction,
                             BRCryptoAddress sourceAddress,
                             BRCryptoAddress targetAddress,
+                            BRCryptoTransferState state,
                             BRCryptoTransferCreateContext  createContext,
                             BRCryptoTransferCreateCallback createCallback);
 

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -131,14 +131,14 @@ cryptoWalletManagerInitialTransferBundlesLoad (BRCryptoWalletManager manager) {
     if (fileServiceHasType (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSFER) &&
         1 != fileServiceLoad (manager->fileService, bundles, CRYPTO_FILE_SERVICE_TYPE_TRANSFER, 1)) {
         cryptoClientTransferBundleSetRelease (bundles);
-        printf ("CRY: %4s: failed to load transfers",
+        printf ("CRY: %4s: failed to load transfer bundles",
                 cryptoBlockChainTypeGetCurrencyCode (manager->type));
         cryptoClientTransferBundleSetRelease(bundles);
         return;
     }
     size_t sortedBundlesCount = BRSetCount(bundles);
 
-    printf ("CRY: %4s: loaded %4zu transfers\n",
+    printf ("CRY: %4s: loaded %4zu transfer bundles\n",
             cryptoBlockChainTypeGetCurrencyCode (manager->type),
             sortedBundlesCount);
 
@@ -188,14 +188,14 @@ cryptoWalletManagerInitialTransactionBundlesLoad (BRCryptoWalletManager manager)
     if (fileServiceHasType (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSACTION) &&
         1 != fileServiceLoad (manager->fileService, bundles, CRYPTO_FILE_SERVICE_TYPE_TRANSACTION, 1)) {
         cryptoClientTransactionBundleSetRelease (bundles);
-        printf ("CRY: %4s: failed to load transactions",
+        printf ("CRY: %4s: failed to load transaction bundles",
                 cryptoBlockChainTypeGetCurrencyCode (manager->type));
         cryptoClientTransactionBundleSetRelease(bundles);
         return;
     }
     size_t sortedBundlesCount = BRSetCount(bundles);
 
-    printf ("CRY: %4s: loaded %4zu transactions\n",
+    printf ("CRY: %4s: loaded %4zu transaction bundles\n",
             cryptoBlockChainTypeGetCurrencyCode (manager->type),
             sortedBundlesCount);
 
@@ -1644,6 +1644,24 @@ cryptoWalletManagerPeriodicDispatcher (BREventHandler handler,
 }
 
 // MARK: - Transaction/Transfer Bundle
+
+private_extern void
+cryptoWalletManagerSaveTransactionBundle (BRCryptoWalletManager manager,
+                                          OwnershipKept BRCryptoClientTransactionBundle bundle) {
+    if (NULL != manager->handlers->saveTransactionBundle)
+        manager->handlers->saveTransactionBundle (manager, bundle);
+    else if (fileServiceHasType (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSACTION))
+        fileServiceSave (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSACTION, bundle);
+}
+
+private_extern void
+cryptoWalletManagerSaveTransferBundle (BRCryptoWalletManager manager,
+                                       OwnershipKept BRCryptoClientTransferBundle bundle) {
+    if (NULL != manager->handlers->saveTransferBundle)
+        manager->handlers->saveTransferBundle (manager, bundle);
+    else if (fileServiceHasType (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSFER))
+        fileServiceSave (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSFER, bundle);
+}
 
 private_extern void
 cryptoWalletManagerRecoverTransfersFromTransactionBundle (BRCryptoWalletManager cwm,

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -99,6 +99,14 @@ typedef BRCryptoWallet
                                              Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers);
 
 typedef void
+(*BRCryptoWalletManagerSaveTransactionBundleHandler) (BRCryptoWalletManager cwm,
+                                                      OwnershipKept BRCryptoClientTransactionBundle bundle);
+
+typedef void
+(*BRCryptoWalletManagerSaveTransferBundleHandler) (BRCryptoWalletManager cwm,
+                                                   OwnershipKept BRCryptoClientTransferBundle bundle);
+
+typedef void
 (*BRCryptoWalletManagerRecoverTransfersFromTransactionBundleHandler) (BRCryptoWalletManager cwm,
                                                                       OwnershipKept BRCryptoClientTransactionBundle bundle);
 
@@ -136,9 +144,11 @@ typedef struct {
     BRCryptoWalletManagerSignTransactionWithKeyHandler signTransactionWithKey;
     BRCryptoWalletManagerEstimateLimitHandler estimateLimit;
     BRCryptoWalletManagerEstimateFeeBasisHandler estimateFeeBasis;
+    BRCryptoWalletManagerSaveTransactionBundleHandler saveTransactionBundle;
+    BRCryptoWalletManagerSaveTransferBundleHandler    saveTransferBundle;
     BRCryptoWalletManagerRecoverTransfersFromTransactionBundleHandler recoverTransfersFromTransactionBundle;
-    BRCryptoWalletManagerRecoverTransferFromTransferBundleHandler recoverTransferFromTransferBundle;
-    BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler recoverFeeBasisFromFeeEstimate;
+    BRCryptoWalletManagerRecoverTransferFromTransferBundleHandler     recoverTransferFromTransferBundle;
+    BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler        recoverFeeBasisFromFeeEstimate;
     BRCryptoWalletManagerWalletSweeperValidateSupportedHandler validateSweeperSupported;
     BRCryptoWalletManagerCreateWalletSweeperHandler createSweeper;
 } BRCryptoWalletManagerHandlers;
@@ -230,6 +240,14 @@ cryptoWalletManagerAddWallet (BRCryptoWalletManager cwm,
 private_extern void
 cryptoWalletManagerRemWallet (BRCryptoWalletManager cwm,
                               BRCryptoWallet wallet);
+
+private_extern void
+cryptoWalletManagerSaveTransactionBundle (BRCryptoWalletManager manager,
+                                          OwnershipKept BRCryptoClientTransactionBundle bundle);
+
+private_extern void
+cryptoWalletManagerSaveTransferBundle (BRCryptoWalletManager manager,
+                                       OwnershipKept BRCryptoClientTransferBundle bundle);
 
 private_extern BRCryptoWallet
 cryptoWalletManagerCreateWalletInitialized (BRCryptoWalletManager cwm,

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -94,7 +94,9 @@ typedef BRCryptoClientP2PManager
 
 typedef BRCryptoWallet
 (*BRCryptoWalletManagerCreateWalletHandler) (BRCryptoWalletManager cwm,
-                                             BRCryptoCurrency currency);
+                                             BRCryptoCurrency currency,
+                                             Nullable OwnershipKept BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                             Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers);
 
 typedef void
 (*BRCryptoWalletManagerRecoverTransfersFromTransactionBundleHandler) (BRCryptoWalletManager cwm,
@@ -189,6 +191,9 @@ struct BRCryptoWalletManagerRecord {
     BRCryptoWalletManagerListener listener;
     BRCryptoWalletListener listenerWallet;
 //    BRCryptoListener listenerTrampoline;
+
+    Nullable BRArrayOf(BRCryptoClientTransferBundle) bundleTransfers;
+    Nullable BRArrayOf(BRCryptoClientTransactionBundle) bundleTransactions;
 };
 
 typedef void *BRCryptoWalletManagerCreateContext;
@@ -225,6 +230,12 @@ cryptoWalletManagerAddWallet (BRCryptoWalletManager cwm,
 private_extern void
 cryptoWalletManagerRemWallet (BRCryptoWalletManager cwm,
                               BRCryptoWallet wallet);
+
+private_extern BRCryptoWallet
+cryptoWalletManagerCreateWalletInitialized (BRCryptoWalletManager cwm,
+                                            BRCryptoCurrency currency,
+                                            Nullable BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                            Nullable BRArrayOf(BRCryptoClientTransferBundle) transfers);
 
 private_extern void
 cryptoWalletManagerRecoverTransfersFromTransactionBundle (BRCryptoWalletManager cwm,

--- a/WalletKitCore/src/crypto/BRCryptoWalletP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletP.h
@@ -165,6 +165,10 @@ private_extern void
 cryptoWalletAddTransfer (BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
 private_extern void
+cryptoWalletAddTransfers (BRCryptoWallet wallet,
+                          OwnershipGiven BRArrayOf(BRCryptoTransfer) transfers);
+
+private_extern void
 cryptoWalletRemTransfer (BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
 private_extern OwnershipGiven BRSetOf(BRCyptoAddress)

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
@@ -172,7 +172,7 @@ cryptoTransferCreateAsBTC (BRCryptoTransferListener listener,
                                         feeBasisEstimated,
                                         CRYPTO_TRUE,
                                         NULL)
-     : cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_SUBMITTED));
+     : cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_CREATED));
 
     BRCryptoTransfer transfer = cryptoTransferAllocAndInit (sizeof (struct BRCryptoTransferBTCRecord),
                                                             type,

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
@@ -164,6 +164,16 @@ cryptoTransferCreateAsBTC (BRCryptoTransferListener listener,
         send
     };
 
+    BRCryptoTransferState state =
+    (TX_UNCONFIRMED != tid->blockHeight
+     ? cryptoTransferStateIncludedInit (tid->blockHeight,
+                                        0,
+                                        tid->timestamp,
+                                        feeBasisEstimated,
+                                        CRYPTO_TRUE,
+                                        NULL)
+     : cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_SUBMITTED));
+
     BRCryptoTransfer transfer = cryptoTransferAllocAndInit (sizeof (struct BRCryptoTransferBTCRecord),
                                                             type,
                                                             listener,
@@ -174,6 +184,7 @@ cryptoTransferCreateAsBTC (BRCryptoTransferListener listener,
                                                             direction,
                                                             sourceAddress,
                                                             targetAddress,
+                                                            state,
                                                             &contextBTC,
                                                             cryptoTransferCreateCallbackBTC);
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerPersistBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerPersistBTC.c
@@ -285,7 +285,7 @@ initialPeersLoadBTC (BRCryptoWalletManager manager) {
     return peers;
 }
 
-static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
+static BRFileServiceTypeSpecification fileServiceSpecificationsArrayBTC[] = {
     {
         CRYPTO_FILE_SERVICE_TYPE_TRANSACTION,
         CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
@@ -347,6 +347,6 @@ const char *fileServiceTypeTransactionsBTC = FILE_SERVICE_TYPE_TRANSACTION;
 const char *fileServiceTypeBlocksBTC       = FILE_SERVICE_TYPE_BLOCK;
 const char *fileServiceTypePeersBTC        = FILE_SERVICE_TYPE_PEER;
 
-size_t fileServiceSpecificationsCountBTC = sizeof(fileServiceSpecifications)/sizeof(BRFileServiceTypeSpecification);
-BRFileServiceTypeSpecification *fileServiceSpecificationsBTC = fileServiceSpecifications;
+size_t fileServiceSpecificationsCountBTC = sizeof(fileServiceSpecificationsArrayBTC)/sizeof(BRFileServiceTypeSpecification);
+BRFileServiceTypeSpecification *fileServiceSpecificationsBTC = fileServiceSpecificationsArrayBTC;
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerPersistBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerPersistBTC.c
@@ -9,13 +9,15 @@
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 //
 #include "BRCryptoBTC.h"
+#include "crypto/BRCryptoFileService.h"
+
 
 /// MARK: - Transaction File Service
 
-#define fileServiceTypeTransactions     "transactions"
+#define FILE_SERVICE_TYPE_TRANSACTION     "transactions"
 
 enum {
-    WALLET_MANAGER_TRANSACTION_VERSION_1
+    FILE_SERVICE_TYPE_TRANSACTION_VERSION_1
 };
 
 static UInt256
@@ -78,7 +80,7 @@ fileServiceTypeTransactionV1Reader (BRFileServiceContext context,
 extern BRArrayOf(BRTransaction*)
 initialTransactionsLoadBTC (BRCryptoWalletManager manager) {
     BRSetOf(BRTransaction*) transactionSet = BRSetNew(BRTransactionHash, BRTransactionEq, 100);
-    if (1 != fileServiceLoad (manager->fileService, transactionSet, fileServiceTypeTransactions, 1)) {
+    if (1 != fileServiceLoad (manager->fileService, transactionSet, CRYPTO_FILE_SERVICE_TYPE_TRANSACTION, 1)) {
         BRSetFreeAll(transactionSet, (void (*) (void*)) BRTransactionFree);
         _peer_log ("BWM: failed to load transactions");
         return NULL;
@@ -96,12 +98,13 @@ initialTransactionsLoadBTC (BRCryptoWalletManager manager) {
     _peer_log ("BWM: loaded %zu transactions\n", transactionsCount);
     return transactions;
 }
-
+#
 /// MARK: - Block File Service
 
-#define fileServiceTypeBlocks       "blocks"
+#define FILE_SERVICE_TYPE_BLOCK         "blocks"
+
 enum {
-    WALLET_MANAGER_BLOCK_VERSION_1
+    FILE_SERVICE_TYPE_BLOCK_VERSION_1
 };
 
 static UInt256
@@ -163,7 +166,7 @@ fileServiceTypeBlockV1Reader (BRFileServiceContext context,
 extern BRArrayOf(BRMerkleBlock*)
 initialBlocksLoadBTC (BRCryptoWalletManager manager) {
     BRSetOf(BRMerkleBlock*) blockSet = BRSetNew(BRMerkleBlockHash, BRMerkleBlockEq, 100);
-    if (1 != fileServiceLoad (manager->fileService, blockSet, fileServiceTypeBlocks, 1)) {
+    if (1 != fileServiceLoad (manager->fileService, blockSet, fileServiceTypeBlocksBTC, 1)) {
         BRSetFreeAll(blockSet, (void (*) (void*)) BRMerkleBlockFree);
         _peer_log ("BWM: failed to load blocks");
         return NULL;
@@ -184,9 +187,10 @@ initialBlocksLoadBTC (BRCryptoWalletManager manager) {
 
 /// MARK: - Peer File Service
 
-#define fileServiceTypePeers        "peers"
+#define FILE_SERVICE_TYPE_PEER        "peers"
+
 enum {
-    WALLET_MANAGER_PEER_VERSION_1
+    FILE_SERVICE_TYPE_PEER_VERSION_1
 };
 
 static UInt256
@@ -263,7 +267,7 @@ extern BRArrayOf(BRPeer)
 initialPeersLoadBTC (BRCryptoWalletManager manager) {
     /// Load peers for the wallet manager.
     BRSetOf(BRPeer*) peerSet = BRSetNew(BRPeerHash, BRPeerEq, 100);
-    if (1 != fileServiceLoad (manager->fileService, peerSet, fileServiceTypePeers, 1)) {
+    if (1 != fileServiceLoad (manager->fileService, peerSet, fileServiceTypePeersBTC, 1)) {
         BRSetFreeAll(peerSet, free);
         _peer_log ("BWM: failed to load peers");
         return NULL;
@@ -283,12 +287,26 @@ initialPeersLoadBTC (BRCryptoWalletManager manager) {
 
 static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
     {
-        fileServiceTypeTransactions,
-        WALLET_MANAGER_TRANSACTION_VERSION_1,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSACTION,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
         1,
         {
             {
-                WALLET_MANAGER_TRANSACTION_VERSION_1,
+                CRYPTO_FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
+                cryptoFileServiceTypeTransactionV1Identifier,
+                cryptoFileServiceTypeTransactionV1Reader,
+                cryptoFileServiceTypeTransactionV1Writer
+            }
+        }
+    },
+
+    {
+        FILE_SERVICE_TYPE_TRANSACTION,
+        FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
+        1,
+        {
+            {
+                FILE_SERVICE_TYPE_TRANSACTION_VERSION_1,
                 fileServiceTypeTransactionV1Identifier,
                 fileServiceTypeTransactionV1Reader,
                 fileServiceTypeTransactionV1Writer
@@ -297,12 +315,12 @@ static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
     },
 
     {
-        fileServiceTypeBlocks,
-        WALLET_MANAGER_BLOCK_VERSION_1,
+        FILE_SERVICE_TYPE_BLOCK,
+        FILE_SERVICE_TYPE_BLOCK_VERSION_1,
         1,
         {
             {
-                WALLET_MANAGER_BLOCK_VERSION_1,
+                FILE_SERVICE_TYPE_BLOCK_VERSION_1,
                 fileServiceTypeBlockV1Identifier,
                 fileServiceTypeBlockV1Reader,
                 fileServiceTypeBlockV1Writer
@@ -311,12 +329,12 @@ static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
     },
 
     {
-        fileServiceTypePeers,
-        WALLET_MANAGER_PEER_VERSION_1,
+        FILE_SERVICE_TYPE_PEER,
+        FILE_SERVICE_TYPE_PEER_VERSION_1,
         1,
         {
             {
-                WALLET_MANAGER_PEER_VERSION_1,
+                FILE_SERVICE_TYPE_PEER_VERSION_1,
                 fileServiceTypePeerV1Identifier,
                 fileServiceTypePeerV1Reader,
                 fileServiceTypePeerV1Writer
@@ -325,9 +343,9 @@ static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
     }
 };
 
-const char *fileServiceTypeTransactionsBTC = fileServiceTypeTransactions;
-const char *fileServiceTypeBlocksBTC       = fileServiceTypeBlocks;
-const char *fileServiceTypePeersBTC        = fileServiceTypePeers;
+const char *fileServiceTypeTransactionsBTC = FILE_SERVICE_TYPE_TRANSACTION;
+const char *fileServiceTypeBlocksBTC       = FILE_SERVICE_TYPE_BLOCK;
+const char *fileServiceTypePeersBTC        = FILE_SERVICE_TYPE_PEER;
 
 size_t fileServiceSpecificationsCountBTC = sizeof(fileServiceSpecifications)/sizeof(BRFileServiceTypeSpecification);
 BRFileServiceTypeSpecification *fileServiceSpecificationsBTC = fileServiceSpecifications;

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
@@ -115,7 +115,6 @@ cryptoTransferDeriveStateETH (BREthereumTransactionStatus status,
 }
 
 typedef struct {
-    BRCryptoTransferState state;
     BREthereumAccount account;
     BREthereumTransferBasis basis;
     BREthereumTransaction originatingTransaction;
@@ -130,8 +129,6 @@ cryptoTransferCreateCallbackETH (BRCryptoTransferCreateContext context,
     transferETH->account = contextETH->account;
     transferETH->basis   = contextETH->basis;
     transferETH->originatingTransaction = contextETH->originatingTransaction;
-
-    cryptoTransferSetState (transfer, contextETH->state);
 }
 
 extern BRCryptoTransfer
@@ -148,7 +145,6 @@ cryptoTransferCreateAsETH (BRCryptoTransferListener listener,
                            BREthereumTransferBasis basis,
                            OwnershipGiven BREthereumTransaction originatingTransaction) {
     BRCryptoTransferCreateContextETH contextETH = {
-        transferState,
         account,
         basis,
         originatingTransaction
@@ -164,6 +160,7 @@ cryptoTransferCreateAsETH (BRCryptoTransferListener listener,
                                                             direction,
                                                             sourceAddress,
                                                             targetAddress,
+                                                            transferState,
                                                             &contextETH,
                                                             cryptoTransferCreateCallbackETH);
 

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
@@ -219,7 +219,7 @@ cryptoWalletCreateTransferETH (BRCryptoWallet  wallet,
 
     BRCryptoAddress  source   = cryptoAddressCreateAsETH  (ethSourceAddress);
 
-    BRCryptoTransferState transferState = { CRYPTO_TRANSFER_STATE_CREATED };
+    BRCryptoTransferState state = cryptoTransferStateInit(CRYPTO_TRANSFER_STATE_CREATED);
 
     // We don't/can't create TRANSFER_BASIS_EXCHANGE.
     BREthereumTransferBasis basis = (NULL == ethToken
@@ -234,13 +234,12 @@ cryptoWalletCreateTransferETH (BRCryptoWallet  wallet,
                                                            direction,
                                                            source,
                                                            target,
-                                                           transferState,
+                                                           state,
                                                            walletETH->ethAccount,
                                                            basis,
                                                            ethTransaction);
-
-    if (NULL != transfer && attributesCount > 0)
-        cryptoTransferSetAttributes (transfer, attributesCount, attributes);
+    cryptoTransferSetAttributes (transfer, attributesCount, attributes);
+    cryptoTransferStateRelease (&state);
 
     cryptoAddressGive(source);
 

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -349,7 +349,9 @@ cryptoWalletManagerCreateTokenForCurrency (BRCryptoWalletManagerETH managerETH,
 
 static BRCryptoWallet
 cryptoWalletManagerCreateWalletETH (BRCryptoWalletManager manager,
-                                    BRCryptoCurrency currency) {
+                                    BRCryptoCurrency currency,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers) {
     BRCryptoWalletManagerETH managerETH  = cryptoWalletManagerCoerceETH (manager);
 
     BREthereumToken ethToken = NULL;

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -828,6 +828,8 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH = {
     cryptoWalletManagerSignTransactionWithKeyETH,
     cryptoWalletManagerEstimateLimitETH,
     cryptoWalletManagerEstimateFeeBasisETH,
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
     cryptoWalletManagerRecoverTransfersFromTransactionBundleETH,
     cryptoWalletManagerRecoverTransferFromTransferBundleETH,
     cryptoWalletManagerRecoverFeeBasisFromFeeEstimateETH,

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -122,12 +122,12 @@ cryptoWalletManagerReleaseETH (BRCryptoWalletManager manager) {
 }
 
 static BRFileService
-crytpWalletManagerCreateFileServiceETH (BRCryptoWalletManager manager,
-                                        const char *basePath,
-                                        const char *currency,
-                                        const char *network,
-                                        BRFileServiceContext context,
-                                        BRFileServiceErrorHandler handler) {
+cryptoWalletManagerCreateFileServiceETH (BRCryptoWalletManager manager,
+                                         const char *basePath,
+                                         const char *currency,
+                                         const char *network,
+                                         BRFileServiceContext context,
+                                         BRFileServiceErrorHandler handler) {
     return fileServiceCreateFromTypeSpecfications (basePath, currency, network,
                                                    context, handler,
                                                    fileServiceSpecificationsCountETH,
@@ -818,7 +818,7 @@ const unsigned int eventTypesCountETH = (sizeof (eventTypesETH) / sizeof (BREven
 BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH = {
     cryptoWalletManagerCreateETH,
     cryptoWalletManagerReleaseETH,
-    crytpWalletManagerCreateFileServiceETH,
+    cryptoWalletManagerCreateFileServiceETH,
     cryptoWalletManagerGetEventTypesETH,
     cryptoWalletManagerCreateP2PManagerETH,
     cryptoWalletManagerCreateWalletETH,

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
@@ -9,6 +9,7 @@
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 //
 #include "BRCryptoETH.h"
+#include "crypto/BRCryptoFileService.h"
 
 #include "ethereum/blockchain/BREthereumBlock.h"
 #include "ethereum/blockchain/BREthereumTransaction.h"
@@ -449,7 +450,21 @@ initialWalletsLoadETH (BRCryptoWalletManager manager) {
 }
 #endif
 
-static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
+static BRFileServiceTypeSpecification fileServiceSpecificationsArrayETH[] = {
+    {
+        CRYPTO_FILE_SERVICE_TYPE_TRANSFER,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1,
+        1,
+        {
+            {
+                CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1,
+                cryptoFileServiceTypeTransferV1Identifier,
+                cryptoFileServiceTypeTransferV1Reader,
+                cryptoFileServiceTypeTransferV1Writer
+            }
+        }
+    },
+
     {
         fileServiceTypeTransactions,
         EWM_TRANSACTION_VERSION_1,
@@ -558,5 +573,5 @@ const char *fileServiceTypeNodesETH        = fileServiceTypeNodes;
 const char *fileServiceTypeTokensETH       = fileServiceTypeTokens;
 //const char *ewmFileServiceTypeWallets      = fileServiceTypeWallets;
 
-size_t fileServiceSpecificationsCountETH = sizeof(fileServiceSpecifications)/sizeof(BRFileServiceTypeSpecification);
-BRFileServiceTypeSpecification *fileServiceSpecificationsETH = fileServiceSpecifications;
+size_t fileServiceSpecificationsCountETH = sizeof(fileServiceSpecificationsArrayETH)/sizeof(BRFileServiceTypeSpecification);
+BRFileServiceTypeSpecification *fileServiceSpecificationsETH = fileServiceSpecificationsArrayETH;

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoFeeBasisHBAR.c
@@ -31,6 +31,12 @@ cryptoFeeBasisCreateCallbackHBAR (BRCryptoFeeBasisCreateContext context,
     feeBasisHBAR->hbarFeeBasis = contextHBAR->hbarFeeBasis;
 }
 
+private_extern BRHederaFeeBasis
+cryptoFeeBasisAsHBAR (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisHBAR feeBasisHBAR = cryptoFeeBasisCoerceHBAR (feeBasis);
+    return feeBasisHBAR->hbarFeeBasis;
+}
+
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsHBAR (BRCryptoUnit unit,
                             BRHederaFeeBasis hbarFeeBasis) {

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -61,6 +61,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsHBAR (BRCryptoTransferListener listener,
                             BRCryptoUnit unit,
                             BRCryptoUnit unitForFee,
+                            BRCryptoTransferState state,
                             BRHederaAccount hbarAccount,
                             BRHederaTransaction hbarTransaction);
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -105,6 +105,9 @@ private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsHBAR (BRCryptoUnit unit,
                             BRHederaFeeBasis hbarFeeBasis);
 
+private_extern BRHederaFeeBasis
+cryptoFeeBasisAsHBAR (BRCryptoFeeBasis feeBasis);
+
 private_extern BRCryptoFeeBasisHBAR
 cryptoFeeBasisCoerceHBAR (BRCryptoFeeBasis feeBasis);
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -41,6 +41,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsHBAR (BRCryptoTransferListener listener,
                             BRCryptoUnit unit,
                             BRCryptoUnit unitForFee,
+                            BRCryptoTransferState state,
                             OwnershipKept BRHederaAccount hbarAccount,
                             OwnershipGiven BRHederaTransaction hbarTransaction) {
     
@@ -70,6 +71,7 @@ cryptoTransferCreateAsHBAR (BRCryptoTransferListener listener,
                                                             direction,
                                                             sourceAddress,
                                                             targetAddress,
+                                                            state,
                                                             &contextHBAR,
                                                             cryptoTransferCreateCallbackHBAR);
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -70,12 +70,6 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
     return wallet;
 }
 
-//private_extern BRHederaWallet
-//cryptoWalletAsHBAR (BRCryptoWallet wallet) {
-//    BRCryptoWalletHBAR walletHBAR = cryptoWalletCoerce(wallet);
-//    return walletHBAR->wid;
-//}
-
 static void
 cryptoWalletReleaseHBAR (BRCryptoWallet wallet) {
     BRCryptoWalletHBAR walletHBAR = cryptoWalletCoerce (wallet);

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -197,21 +197,7 @@ cryptoWalletCreateTransferHBAR (BRCryptoWallet  wallet,
     hederaAddressFree (source);
     hederaAddressFree (nodeAddress);
 
-    uint64_t hbarBlockheight = hederaTransactionGetBlockheight (hbarTransaction);
-    uint64_t hbarTimestamp   = (uint64_t) hederaTransactionGetTimestamp (hbarTransaction).seconds;
-    bool     hbarSuccess     = !hederaTransactionHasError (hbarTransaction);
-
-    BRCryptoTransferState state =
-    (0 != hbarBlockheight
-     ? cryptoTransferStateIncludedInit (hbarBlockheight,
-                                        0,
-                                        hbarTimestamp,
-                                        estimatedFeeBasis,
-                                        AS_CRYPTO_BOOLEAN(hbarSuccess),
-                                        (hbarSuccess ? NULL : "unknown error"))
-     : (hbarSuccess
-        ? cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_CREATED)
-        : cryptoTransferStateErroredInit(cryptoTransferSubmitErrorUnknown())));
+    BRCryptoTransferState state = cryptoTransferStateInit(CRYPTO_TRANSFER_STATE_CREATED);
 
     BRCryptoTransfer transfer = cryptoTransferCreateAsHBAR (wallet->listenerTransfer,
                                                             unit,
@@ -219,9 +205,8 @@ cryptoWalletCreateTransferHBAR (BRCryptoWallet  wallet,
                                                             state,
                                                             walletHBAR->hbarAccount,
                                                             hbarTransaction);
-
-    // Take all the attributes, even if there aren't for HBAR.
     cryptoTransferSetAttributes (transfer, attributesCount, attributes);
+    cryptoTransferStateRelease (&state);
 
     return transfer;
 }

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -274,7 +274,9 @@ cryptoWalletManagerCreateWalletSweeperHBAR (BRCryptoWalletManager manager,
 
 static BRCryptoWallet
 cryptoWalletManagerCreateWalletHBAR (BRCryptoWalletManager manager,
-                                     BRCryptoCurrency currency) {
+                                     BRCryptoCurrency currency,
+                                     Nullable OwnershipKept BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                     Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers) {
     BRHederaAccount hbarAccount = cryptoAccountAsHBAR(manager->account);
 
     // Create the primary BRCryptoWallet

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -228,40 +228,27 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
 
     BRCryptoTransfer baseTransfer = cryptoWalletGetTransferByHash (wallet, hash);
     cryptoHashGive(hash);
-    
+
+    BRCryptoFeeBasis      feeBasis = cryptoFeeBasisCreateAsHBAR (wallet->unit, hederaTransactionGetFeeBasis(hbarTransaction));
+    BRCryptoTransferState state    = cryptoClientTransferBundleGetTransferState (bundle, feeBasis);
+
     if (NULL == baseTransfer) {
         baseTransfer = cryptoTransferCreateAsHBAR (wallet->listenerTransfer,
                                                    wallet->unit,
                                                    wallet->unitForFee,
+                                                   state,
                                                    hbarAccount,
                                                    hbarTransaction);
         hbarTransactionNeedFree = false;
 
         cryptoWalletAddTransfer (wallet, baseTransfer);
     }
-
-    bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
-                       (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status &&
-                        0 != bundle->blockNumber &&
-                        0 != bundle->blockTimestamp));
-
-    BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsHBAR (wallet->unit, hederaTransactionGetFeeBasis(hbarTransaction));
-
-    BRCryptoTransferState transferState =
-    (isIncluded
-     ? cryptoTransferStateIncludedInit (bundle->blockNumber,
-                                        bundle->blockTransactionIndex,
-                                        bundle->blockTimestamp,
-                                        feeBasis,
-                                        AS_CRYPTO_BOOLEAN(CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status),
-                                        (isIncluded ? NULL : "unknown"))
-     : (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status
-        ? cryptoTransferStateErroredInit ((BRCryptoTransferSubmitError) { CRYPTO_TRANSFER_SUBMIT_ERROR_UNKNOWN })
-        : cryptoTransferStateInit (bundle->status)));
-
-    cryptoTransferSetState (baseTransfer, transferState);
+    else {
+        cryptoTransferSetState (baseTransfer, state);
+    }
     
     cryptoFeeBasisGive (feeBasis);
+    cryptoTransferStateRelease (&state);
 
     //TODO:HBAR attributes
     //TODO:HBAR save to fileService

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -79,8 +79,8 @@ crytpWalletManagerCreateFileServiceHBAR (BRCryptoWalletManager manager,
                                          BRFileServiceErrorHandler handler) {
     return fileServiceCreateFromTypeSpecfications (basePath, currency, network,
                                                    context, handler,
-                                                   fileServiceSpecificationsCount,
-                                                   fileServiceSpecifications);
+                                                   cryptoFileServiceSpecificationsCount,
+                                                   cryptoFileServiceSpecifications);
 }
 
 static const BREventType **

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -309,6 +309,8 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersHBAR = {
     cryptoWalletManagerSignTransactionWithKeyHBAR,
     cryptoWalletManagerEstimateLimitHBAR,
     cryptoWalletManagerEstimateFeeBasisHBAR,
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
     cryptoWalletManagerRecoverTransfersFromTransactionBundleHBAR,
     cryptoWalletManagerRecoverTransferFromTransferBundleHBAR,
     NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -47,6 +47,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                            BRCryptoUnit unit,
                            BRCryptoUnit unitForFee,
+                           BRCryptoTransferState state,
                            OwnershipKept BRRippleAccount xrpAccount,
                            OwnershipGiven BRRippleTransaction xrpTransfer) {
     
@@ -65,12 +66,6 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
         xrpTransfer
     };
 
-#if EXAMPLE
-    // Set the state from `transferGeneric`.  This is where we move from 'submitted' to 'included'
-    BRCryptoTransferState oldState = cryptoTransferGetState (transfer);
-    BRCryptoTransferState newState = cryptoTransferStateCreateGEN (genTransferGetState(transferGeneric), unitForFee);
-    cryptoTransferSetState (transfer, newState);
-#endif
     BRCryptoTransfer transfer = cryptoTransferAllocAndInit (sizeof (struct BRCryptoTransferXRPRecord),
                                                             CRYPTO_NETWORK_TYPE_XRP,
                                                             listener,
@@ -81,6 +76,7 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                                                             direction,
                                                             sourceAddress,
                                                             targetAddress,
+                                                            state,
                                                             &contextXRP,
                                                             cryptoTransferCreateCallbackXRP);
     

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -224,40 +224,27 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     
     BRCryptoTransfer baseTransfer = cryptoWalletGetTransferByHash (wallet, hash);
     cryptoHashGive (hash);
-    
+
+    BRCryptoFeeBasis      feeBasis = cryptoFeeBasisCreateAsXRP (wallet->unitForFee, feeDrops);
+    BRCryptoTransferState state    = cryptoClientTransferBundleGetTransferState (bundle, feeBasis);
+
     if (NULL == baseTransfer) {
         baseTransfer = cryptoTransferCreateAsXRP (wallet->listenerTransfer,
                                                   wallet->unit,
                                                   wallet->unitForFee,
+                                                  state,
                                                   xrpAccount,
                                                   xrpTransaction);
         xrpTransactionNeedFree = false;
 
         cryptoWalletAddTransfer (wallet, baseTransfer);
     }
-    
-    BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsXRP (wallet->unitForFee, feeDrops);
-
-    bool isIncluded = (CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status ||
-                       (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status &&
-                        0 != bundle->blockNumber &&
-                        0 != bundle->blockTimestamp));
-
-    BRCryptoTransferState transferState =
-    (isIncluded
-     ? cryptoTransferStateIncludedInit (bundle->blockNumber,
-                                        bundle->blockTransactionIndex,
-                                        bundle->blockTimestamp,
-                                        feeBasis,
-                                        AS_CRYPTO_BOOLEAN(CRYPTO_TRANSFER_STATE_INCLUDED == bundle->status),
-                                        (isIncluded ? NULL : "unknown"))
-     : (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status
-        ? cryptoTransferStateErroredInit ((BRCryptoTransferSubmitError) { CRYPTO_TRANSFER_SUBMIT_ERROR_UNKNOWN })
-        : cryptoTransferStateInit (bundle->status)));
-    
-    cryptoTransferSetState (baseTransfer, transferState);
+    else {
+        cryptoTransferSetState (baseTransfer, state);
+    }
 
     cryptoFeeBasisGive (feeBasis);
+    cryptoTransferStateRelease (&state);
 
     //TODO:XRP attributes
     //TODO:XRP save to fileService

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -270,7 +270,9 @@ cryptoWalletManagerCreateWalletSweeperXRP (BRCryptoWalletManager manager,
 
 static BRCryptoWallet
 cryptoWalletManagerCreateWalletXRP (BRCryptoWalletManager manager,
-                                    BRCryptoCurrency currency) {
+                                    BRCryptoCurrency currency,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers) {
     BRRippleAccount xrpAccount = cryptoAccountAsXRP(manager->account);
 
     // Create the primary BRCryptoWallet

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -78,8 +78,8 @@ crytpWalletManagerCreateFileServiceXRP (BRCryptoWalletManager manager,
                                         BRFileServiceErrorHandler handler) {
     return fileServiceCreateFromTypeSpecfications (basePath, currency, network,
                                                    context, handler,
-                                                   fileServiceSpecificationsCount,
-                                                   fileServiceSpecifications);
+                                                   cryptoFileServiceSpecificationsCount,
+                                                   cryptoFileServiceSpecifications);
 }
 
 static const BREventType **

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -305,6 +305,8 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXRP = {
     cryptoWalletManagerSignTransactionWithKeyXRP,
     cryptoWalletManagerEstimateLimitXRP,
     cryptoWalletManagerEstimateFeeBasisXRP,
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
     cryptoWalletManagerRecoverTransfersFromTransactionBundleXRP,
     cryptoWalletManagerRecoverTransferFromTransferBundleXRP,
     NULL,//BRCryptoWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -217,21 +217,7 @@ cryptoWalletCreateTransferXRP (BRCryptoWallet  wallet,
 
     rippleAddressFree(source);
 
-    uint64_t xrpBlockheight = rippleTransactionGetBlockHeight (xrpTransaction);
-    uint64_t xrpTimestamp   = rippleTransactionGetTimestamp   (xrpTransaction);
-    bool     xrpSuccess     = rippleTransactionHasError (xrpTransaction);
-
-    BRCryptoTransferState state =
-    (0 != xrpBlockheight
-     ? cryptoTransferStateIncludedInit (xrpBlockheight,
-                                        0,
-                                        xrpTimestamp,
-                                        estimatedFeeBasis,
-                                        AS_CRYPTO_BOOLEAN(xrpSuccess),
-                                        (xrpSuccess ? NULL : "unknown error"))
-     : (xrpSuccess
-        ? cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_CREATED)
-        : cryptoTransferStateErroredInit(cryptoTransferSubmitErrorUnknown())));
+    BRCryptoTransferState state = cryptoTransferStateInit(CRYPTO_TRANSFER_STATE_CREATED);
 
     BRCryptoTransfer transfer = cryptoTransferCreateAsXRP (wallet->listenerTransfer,
                                                            unit,
@@ -239,12 +225,9 @@ cryptoWalletCreateTransferXRP (BRCryptoWallet  wallet,
                                                            state,
                                                            walletXRP->xrpAccount,
                                                            xrpTransaction);
-
-    cryptoTransferStateRelease (&state);
-    
-    // Take all the attributes, even if there aren't for XRP.
     cryptoTransferSetAttributes (transfer, attributesCount, attributes);
-    
+    cryptoTransferStateRelease (&state);
+
     return transfer;
 }
 

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -71,12 +71,6 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
     return wallet;
 }
 
-//private_extern BRRippleWallet
-//cryptoWalletAsXRP (BRCryptoWallet wallet) {
-//    BRCryptoWalletXRP walletXRP = cryptoWalletCoerce(wallet);
-//    return walletXRP->wid;
-//}
-
 static void
 cryptoWalletReleaseXRP (BRCryptoWallet wallet) {
     BRCryptoWalletXRP walletXRP = cryptoWalletCoerce (wallet);

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoXRP.h
@@ -58,6 +58,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                            BRCryptoUnit unit,
                            BRCryptoUnit unitForFee,
+                           BRCryptoTransferState state,
                            BRRippleAccount xrpAccount,
                            BRRippleTransaction xrpTransaction);
 

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoFeeBasisXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoFeeBasisXTZ.c
@@ -49,6 +49,12 @@ static void
 cryptoFeeBasisReleaseXTZ (BRCryptoFeeBasis feeBasis) {
 }
 
+private_extern BRTezosFeeBasis
+cryptoFeeBasisAsXTZ (BRCryptoFeeBasis feeBasis) {
+    BRCryptoFeeBasisXTZ feeBasisXTZ = cryptoFeeBasisCoerceXTZ(feeBasis);
+    return feeBasisXTZ->xtzFeeBasis;
+}
+
 static double
 cryptoFeeBasisGetCostFactorXTZ (BRCryptoFeeBasis feeBasis) {
     BRTezosFeeBasis xtzFeeBasis = cryptoFeeBasisCoerceXTZ (feeBasis)->xtzFeeBasis;

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
@@ -42,6 +42,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsXTZ (BRCryptoTransferListener listener,
                            BRCryptoUnit unit,
                            BRCryptoUnit unitForFee,
+                           BRCryptoTransferState state,
                            OwnershipKept BRTezosAccount xtzAccount,
                            OwnershipGiven BRTezosTransfer xtzTransfer) {
     
@@ -72,6 +73,7 @@ cryptoTransferCreateAsXTZ (BRCryptoTransferListener listener,
                                                             direction,
                                                             sourceAddress,
                                                             targetAddress,
+                                                            state,
                                                             &contextXTZ,
                                                             cryptoTransferCreateCallbackXTZ);
     

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -324,7 +324,9 @@ cryptoWalletManagerCreateWalletSweeperXTZ (BRCryptoWalletManager manager,
 
 static BRCryptoWallet
 cryptoWalletManagerCreateWalletXTZ (BRCryptoWalletManager manager,
-                                    BRCryptoCurrency currency) {
+                                    BRCryptoCurrency currency,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransactionBundle) transactions,
+                                    Nullable OwnershipKept BRArrayOf(BRCryptoClientTransferBundle) transfers) {
     BRTezosAccount xtzAccount = cryptoAccountAsXTZ(manager->account);
 
     // Create the primary BRCryptoWallet

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -79,8 +79,8 @@ crytpWalletManagerCreateFileServiceXTZ (BRCryptoWalletManager manager,
                                         BRFileServiceErrorHandler handler) {
     return fileServiceCreateFromTypeSpecfications (basePath, currency, network,
                                                    context, handler,
-                                                   fileServiceSpecificationsCount,
-                                                   fileServiceSpecifications);
+                                                   cryptoFileServiceSpecificationsCount,
+                                                   cryptoFileServiceSpecifications);
 }
 
 static const BREventType **

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -359,6 +359,8 @@ BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersXTZ = {
     cryptoWalletManagerSignTransactionWithKeyXTZ,
     cryptoWalletManagerEstimateLimitXTZ,
     cryptoWalletManagerEstimateFeeBasisXTZ,
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
+    NULL, // BRCryptoWalletManagerSaveTransactionBundleHandler
     cryptoWalletManagerRecoverTransfersFromTransactionBundleXTZ,
     cryptoWalletManagerRecoverTransferFromTransferBundleXTZ,
     cryptoWalletManagerRecoverFeeBasisFromFeeEstimateXTZ,

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -238,23 +238,6 @@ cryptoWalletCreateTransferXTZ (BRCryptoWallet  wallet,
 
     tezosAddressFree (source);
 
-#ifdef REFACTOR
-    uint64_t hbarBlockheight = hederaTransactionGetBlockheight (hbarTransaction);
-    uint64_t hbarTimestamp   = (uint64_t) hederaTransactionGetTimestamp (hbarTransaction).seconds;
-    bool     hbarSuccess     = !hederaTransactionHasError (hbarTransaction);
-
-    BRCryptoTransferState state =
-    (0 != hbarBlockheight
-     ? cryptoTransferStateIncludedInit (hbarBlockheight,
-                                        0,
-                                        hbarTimestamp,
-                                        estimatedFeeBasis,
-                                        AS_CRYPTO_BOOLEAN(hbarSuccess),
-                                        (hbarSuccess ? NULL : "unknown error"))
-     : (hbarSuccess
-        ? cryptoTransferStateInit (CRYPTO_TRANSFER_STATE_CREATED)
-        : cryptoTransferStateErroredInit(cryptoTransferSubmitErrorUnknown())));
-#endif
     BRCryptoTransferState state = cryptoTransferStateInit(CRYPTO_TRANSFER_STATE_CREATED);
 
     BRCryptoTransfer transfer = cryptoTransferCreateAsXTZ (wallet->listenerTransfer,

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
@@ -117,6 +117,8 @@ cryptoFeeBasisCreateAsXTZ (BRCryptoUnit unit,
 private_extern BRCryptoFeeBasisXTZ
 cryptoFeeBasisCoerceXTZ (BRCryptoFeeBasis feeBasis);
 
+private_extern BRTezosFeeBasis
+cryptoFeeBasisAsXTZ (BRCryptoFeeBasis feeBasis);
 
 // MARK: - Support
 

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoXTZ.h
@@ -57,6 +57,7 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsXTZ (BRCryptoTransferListener listener,
                            BRCryptoUnit unit,
                            BRCryptoUnit unitForFee,
+                           BRCryptoTransferState state,
                            BRTezosAccount xtzAccount,
                            BRTezosTransfer xtzTransfer);
 

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -347,6 +347,16 @@ extern int hederaTransactionHasError (BRHederaTransaction transaction) {
     return transaction->error;
 }
 
+extern BRHederaTimeStamp hederaTransactionGetTimestamp (BRHederaTransaction transaction) {
+    assert (transaction);
+    return transaction->timeStamp;
+}
+
+extern uint64_t hederaTransactionGetBlockheight (BRHederaTransaction transaction) {
+    assert (transaction);
+    return transaction->blockHeight;
+}
+
 extern bool hederaTransactionEqual (BRHederaTransaction t1, BRHederaTransaction t2)
 {
     assert(t1);

--- a/WalletKitCore/src/hedera/BRHederaTransaction.h
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.h
@@ -106,7 +106,10 @@ extern BRHederaUnitTinyBar hederaTransactionGetFee(BRHederaTransaction transacti
 extern BRHederaUnitTinyBar hederaTransactionGetAmount(BRHederaTransaction transaction);
 extern BRHederaAddress hederaTransactionGetSource(BRHederaTransaction transaction);
 extern BRHederaAddress hederaTransactionGetTarget(BRHederaTransaction transaction);
+
 extern int hederaTransactionHasError (BRHederaTransaction transaction);
+extern BRHederaTimeStamp hederaTransactionGetTimestamp (BRHederaTransaction transaction);
+extern uint64_t hederaTransactionGetBlockheight (BRHederaTransaction transaction);
 
 // Memo
 extern void hederaTransactionSetMemo(BRHederaTransaction transaction, const char* memo);

--- a/WalletKitCore/src/ripple/BRRippleTransaction.c
+++ b/WalletKitCore/src/ripple/BRRippleTransaction.c
@@ -744,3 +744,8 @@ extern uint64_t rippleTransactionGetBlockHeight (BRRippleTransaction transaction
     assert(transaction);
     return transaction->blockHeight;
 }
+
+extern uint64_t rippleTransactionGetTimestamp (BRRippleTransaction transaction) {
+    assert(transaction);
+    return transaction->timestamp;
+}

--- a/WalletKitCore/src/ripple/BRRippleTransaction.h
+++ b/WalletKitCore/src/ripple/BRRippleTransaction.h
@@ -143,6 +143,7 @@ extern int rippleTransactionHasError(BRRippleTransaction transaction);
 
 extern int rippleTransactionIsInBlock (BRRippleTransaction transaction);
 extern uint64_t rippleTransactionGetBlockHeight (BRRippleTransaction transaction);
+extern uint64_t rippleTransactionGetTimestamp (BRRippleTransaction transaction);
 
 extern BRSetOf(BRRippleTransaction) rippleTransactionSetCreate (size_t initialSize);
 

--- a/WalletKitCore/src/support/BRBase.h
+++ b/WalletKitCore/src/support/BRBase.h
@@ -35,6 +35,8 @@ extern "C" {
 #define OwnershipGiven
 #define OwnershipKept
 
+#define Nullable
+
 /**
  * A Block Height in a block chain.  Note: uint32_t is perhaps enough; conservatively use
  * uint64_t.

--- a/WalletKitCore/src/support/BRFileService.c
+++ b/WalletKitCore/src/support/BRFileService.c
@@ -776,7 +776,16 @@ fileServiceLoad (BRFileService fs,
 extern int
 fileServiceRemove (BRFileService fs,
                    const char *type,
-                   UInt256 identifier) {
+                   const void *entity) {
+    UInt256 identiifer = fileServiceGetIdentifier (fs, type, entity);
+
+    return !UInt256Eq (identiifer, UINT256_ZERO) && fileServiceRemoveByIdentifier (fs, type, identiifer);
+}
+
+extern int
+fileServiceRemoveByIdentifier (BRFileService fs,
+                               const char *type,
+                               UInt256 identifier) {
     BRFileServiceEntityType *entityType = fileServiceLookupType (fs, type);
     if (NULL == entityType)
         return fileServiceFailedImpl (fs, 0, NULL, NULL, "missed type");
@@ -926,6 +935,12 @@ fileServiceWipe (const char *basePath,
 #endif
 
     return result;
+}
+
+extern bool
+fileServiceHasType (BRFileService fs,
+                    const char *type) {
+    return NULL != fileServiceLookupType (fs, type);
 }
 
 extern UInt256

--- a/WalletKitCore/src/support/BRFileService.h
+++ b/WalletKitCore/src/support/BRFileService.h
@@ -27,6 +27,7 @@
 #define BRFileService_h
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include "BRSet.h"
 #include "BRInt.h"
 
@@ -133,10 +134,15 @@ fileServiceSave (BRFileService fs,
                  const char *type,  /* block, peers, transactions, logs, ... */
                  const void *entity);     /* BRMerkleBlock*, BRTransaction, BREthereumTransaction, ... */
 
-extern int
+extern int  // 1 -> success, 0 -> failure
 fileServiceRemove (BRFileService fs,
                    const char *type,
-                   UInt256 identifier);
+                   const void *entity);
+
+extern int  // 1 -> success, 0 -> failure
+fileServiceRemoveByIdentifier (BRFileService fs,
+                               const char *type,
+                               UInt256 identifier);
 
 extern int
 fileServiceReplace (BRFileService fs,
@@ -251,5 +257,9 @@ extern int
 fileServiceWipe (const char *basePath,
                  const char *currency,
                  const char *network);
+
+extern bool
+fileServiceHasType (BRFileService fs,
+                    const char *type);
 
 #endif /* BRFileService_h */


### PR DESCRIPTION
Saves the BRCryptoClient{Tranaction,Transfer} bundles to persistent storage and then recovers them on start up.  Adds a BRCryptoWalletManager handler for each of save{Transaction,Transfer} and provides a default implementation that will save an RLP encoding of the client bundles.  For BTC the default implementation is not used; instead the BRTransaction is saved which is what the P2P sync mode saved.