### PR TITLE
CORE-1050: For a RECEIVED transfer, the fee is zero for ETH, XRP, etc.

### DIFF
--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
@@ -185,10 +185,18 @@ cryptoTransferCreateWithTransactionAsETH (BRCryptoTransferListener listener,
     BREthereumEther ethAmount = transactionGetAmount(ethTransaction);
     BRCryptoAmount  amount    = cryptoAmountCreate (unit, CRYPTO_FALSE, ethEtherGetValue (ethAmount, WEI));
 
+    BREthereumFeeBasis ethFeeBasisIfReceived = { FEE_BASIS_GAS, { .gas = { ethGasCreate(0), ethGasPriceCreate(ethEtherCreateZero())}} };
+    BREthereumFeeBasis ethFeeBasisEstimated  = (CRYPTO_TRANSFER_RECEIVED == direction
+                                                ? ethFeeBasisIfReceived
+                                                : transactionGetFeeBasisEstimated (ethTransaction));
+    BREthereumFeeBasis ethFeeBasisConfirmed  = (CRYPTO_TRANSFER_RECEIVED == direction
+                                                ? ethFeeBasisIfReceived
+                                                : transactionGetFeeBasis(ethTransaction));
+
     // Get the estimated and confirmed feeBasis'.  If ethTransaction is not INCLUDDED, then the
     // confirmedFeeBasis will be the estimate.
-    BRCryptoFeeBasis estimatedFeeBasis = cryptoFeeBasisCreateAsETH (unitForFee, transactionGetFeeBasisEstimated (ethTransaction));
-    BRCryptoFeeBasis confirmedFeeBasis = cryptoFeeBasisCreateAsETH (unitForFee, transactionGetFeeBasis(ethTransaction));
+    BRCryptoFeeBasis estimatedFeeBasis = cryptoFeeBasisCreateAsETH (unitForFee, ethFeeBasisEstimated);
+    BRCryptoFeeBasis confirmedFeeBasis = cryptoFeeBasisCreateAsETH (unitForFee, ethFeeBasisConfirmed);
 
     BRCryptoAddress  source = cryptoAddressCreateAsETH (transactionGetSourceAddress (ethTransaction));
     BRCryptoAddress  target = cryptoAddressCreateAsETH (transactionGetTargetAddress (ethTransaction));

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -50,7 +50,7 @@ cryptoTransferCreateAsHBAR (BRCryptoTransferListener listener,
                                                       CRYPTO_FALSE,
                                                       hederaTransactionGetAmount (hbarTransaction));
     
-    BRHederaFeeBasis hbarFeeBasis = { hederaTransactionGetFee (hbarTransaction), 1 };
+    BRHederaFeeBasis hbarFeeBasis = { (CRYPTO_TRANSFER_RECEIVED == direction ? 0 : hederaTransactionGetFee (hbarTransaction)), 1 };
     BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsHBAR (unitForFee, hbarFeeBasis);
     
     BRCryptoAddress sourceAddress = cryptoAddressCreateAsHBAR (hederaTransactionGetSource (hbarTransaction));

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -56,7 +56,7 @@ cryptoTransferCreateAsXRP (BRCryptoTransferListener listener,
                                                      CRYPTO_FALSE,
                                                      rippleTransactionGetAmount(xrpTransfer));
 
-    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsXRP (unitForFee, rippleTransactionGetFee(xrpTransfer));
+    BRCryptoFeeBasis feeBasisEstimated = cryptoFeeBasisCreateAsXRP (unitForFee, (CRYPTO_TRANSFER_RECEIVED == direction ? 0 : rippleTransactionGetFee(xrpTransfer)));
     
     BRCryptoAddress sourceAddress = cryptoAddressCreateAsXRP (rippleTransactionGetSource(xrpTransfer));
     BRCryptoAddress targetAddress = cryptoAddressCreateAsXRP (rippleTransactionGetTarget(xrpTransfer));

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
@@ -51,7 +51,7 @@ cryptoTransferCreateAsXTZ (BRCryptoTransferListener listener,
                                                      CRYPTO_FALSE,
                                                      tezosTransferGetAmount (xtzTransfer));
     
-    BRTezosFeeBasis xtzFeeBasis = tezosFeeBasisCreateActual (tezosTransferGetFee(xtzTransfer));
+    BRTezosFeeBasis xtzFeeBasis = tezosFeeBasisCreateActual (CRYPTO_TRANSFER_RECEIVED == direction ? 0 : tezosTransferGetFee(xtzTransfer));
     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsXTZ (unitForFee,
                                                            xtzFeeBasis);
     


### PR DESCRIPTION
Needs to be zero - to be consistent with "our User's perspective".  Simplifies logic that would be required to ignore the fee.  Maintains consistency with BTC/BCH/BSV.