### PR TITLE
CORE-981: Support BCH private key sweep

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -952,6 +952,7 @@ cryptoWalletEventTypeString (BRCryptoWalletEventType t) {
 
 struct BRCryptoWalletSweeperRecord {
     BRCryptoBlockChainType type;
+    BRCryptoNetworkCanonicalType networkType;
     BRCryptoKey key;
     BRCryptoUnit unit;
     union {
@@ -1024,6 +1025,7 @@ cryptoWalletSweeperCreateAsBtc (BRCryptoNetwork network,
     assert (cryptoKeyHasSecret (key));
     BRCryptoWalletSweeper sweeper = calloc (1, sizeof(struct BRCryptoWalletSweeperRecord));
     sweeper->type = BLOCK_CHAIN_TYPE_BTC;
+    sweeper->networkType = network->canonicalType;
     sweeper->key = cryptoKeyTake (key);
     sweeper->unit = cryptoNetworkGetUnitAsBase (network, currency);
     sweeper->u.btc.sweeper = BRWalletSweeperNew(cryptoKeyGetCore (key),
@@ -1079,10 +1081,18 @@ cryptoWalletSweeperGetKey (BRCryptoWalletSweeper sweeper) {
 extern char *
 cryptoWalletSweeperGetAddress (BRCryptoWalletSweeper sweeper) {
     char * address = NULL;
-
-    switch (sweeper->type) {
-        case BLOCK_CHAIN_TYPE_BTC: {
+    
+    assert (BLOCK_CHAIN_TYPE_BTC == sweeper->type);
+    
+    switch (sweeper->networkType) {
+        case CRYPTO_NETWORK_TYPE_BTC:
             address = BRWalletSweeperGetLegacyAddress (sweeper->u.btc.sweeper);
+            break;
+            
+        case CRYPTO_NETWORK_TYPE_BCH: {
+            char * legacyAddr = BRWalletSweeperGetLegacyAddress (sweeper->u.btc.sweeper);
+            address = malloc (55);
+            BRBCashAddrEncode(address, legacyAddr);
             break;
         }
         default:

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -388,7 +388,7 @@ public final class WalletSweeper {
         }
 
         switch cryptoNetworkGetCanonicalType (wallet.manager.network.core) {
-        case CRYPTO_NETWORK_TYPE_BTC:
+        case CRYPTO_NETWORK_TYPE_BTC, CRYPTO_NETWORK_TYPE_BCH:
             // handle as BTC, creating the underlying BRCryptoWalletSweeper and initializing it
             // using the BlockchainDB
             createAsBtc(wallet: wallet,


### PR DESCRIPTION
- add network type field to `BRCryptoWalletSweeper`
- return CashAddr format address for BCH for key sweep