### PR TITLE
CORE-1074: Add BRCryptoExportablePaperWallet and Swift/Java interfaces

### DIFF
--- a/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
+++ b/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
@@ -1643,6 +1643,17 @@ int BRKeyTests()
     
     if (pkLen5 != pkLen || memcmp(pubKey, pubKey5, pkLen) != 0)
         r = 0, fprintf(stderr, "***FAILED*** %s: BRPubKeyRecover() test 3\n", __func__);
+    
+    // paper wallet key pair
+    BRKeyGenerateRandom (&key, 1);
+    
+    BRKeyPrivKey(&key, privKey1, sizeof(privKey1), BRMainNetParams->addrParams);
+    printf("privKey:%s\n", privKey1);
+    // compressed private key
+    if (! BRPrivKeyIsValid(BRMainNetParams->addrParams, privKey1))
+        r = 0, fprintf(stderr, "***FAILED*** %s: BRPrivKeyIsValid() test 8\n", __func__);
+    BRKeyLegacyAddr(&key, addr.s, sizeof(addr), BRMainNetParams->addrParams);
+    printf("privKey:%s = %s\n", privKey1, addr.s);
 
     printf("                                    ");
     return r;

--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -25,6 +25,7 @@ extern "C" {
     /// MARK: Forward Declarations
 
     typedef struct BRCryptoWalletSweeperRecord *BRCryptoWalletSweeper;
+    typedef struct BRCryptoExportablePaperWalletRecord *BRCryptoExportablePaperWallet;
 
     /// MARK: Wallet Event
 
@@ -298,6 +299,36 @@ extern "C" {
 
     extern BRCryptoWalletSweeperStatus
     cryptoWalletSweeperValidate (BRCryptoWalletSweeper sweeper);
+
+    /// MARK: Exportable Paper Wallet
+
+    typedef enum {
+        CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS,
+        CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY,
+        CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS,
+        
+        // calling a sweeper function for the wrong type
+        CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION,
+    } BRCryptoExportablePaperWalletStatus;
+
+    extern BRCryptoExportablePaperWalletStatus
+    cryptoExportablePaperWalletValidateSupported (BRCryptoNetwork network,
+                                                  BRCryptoCurrency currency,
+                                                  BRCryptoWallet wallet);
+
+    extern BRCryptoExportablePaperWallet
+    cryptoExportablePaperWalletCreateAsBTC (BRCryptoNetwork network,
+                                            BRCryptoCurrency currency);
+
+    extern void
+    cryptoExportablePaperWalletRelease (BRCryptoExportablePaperWallet paperWallet);
+
+    extern BRCryptoKey
+    cryptoExportablePaperWalletGetKey (BRCryptoExportablePaperWallet paperWallet);
+
+    extern BRCryptoAddress
+    cryptoExportablePaperWalletGetAddress (BRCryptoExportablePaperWallet paperWallet);
+
 
 #ifdef __cplusplus
 }

--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -313,8 +313,7 @@ extern "C" {
 
     extern BRCryptoExportablePaperWalletStatus
     cryptoExportablePaperWalletValidateSupported (BRCryptoNetwork network,
-                                                  BRCryptoCurrency currency,
-                                                  BRCryptoWallet wallet);
+                                                  BRCryptoCurrency currency);
 
     extern BRCryptoExportablePaperWallet
     cryptoExportablePaperWalletCreateAsBTC (BRCryptoNetwork network,

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -1156,24 +1156,12 @@ struct BRCryptoExportablePaperWalletRecord {
 
 extern BRCryptoExportablePaperWalletStatus
 cryptoExportablePaperWalletValidateSupported (BRCryptoNetwork network,
-                                              BRCryptoCurrency currency,
-                                              BRCryptoWallet wallet) {
+                                              BRCryptoCurrency currency) {
     if (CRYPTO_FALSE == cryptoNetworkHasCurrency (network, currency)) {
         return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
     }
 
-    if (cryptoNetworkGetType (network) != cryptoWalletGetType (wallet)) {
-        return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
-    }
-
-    BRCryptoCurrency walletCurrency = cryptoWalletGetCurrency (wallet);
-    if (CRYPTO_FALSE == cryptoCurrencyIsIdentical (currency, walletCurrency)) {
-        cryptoCurrencyGive (walletCurrency);
-        return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
-    }
-    cryptoCurrencyGive (walletCurrency);
-
-    switch (cryptoWalletGetType (wallet)) {
+    switch (cryptoNetworkGetType (network)) {
         case BLOCK_CHAIN_TYPE_BTC:
             return CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS;
         default:

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -1145,3 +1145,99 @@ cryptoWalletSweeperAsBTC (BRCryptoWalletSweeper sweeper) {
     assert (BLOCK_CHAIN_TYPE_BTC == sweeper->type);
     return sweeper->u.btc.sweeper;
 }
+
+/// MARK: Exportable Paper Wallet
+
+struct BRCryptoExportablePaperWalletRecord {
+    BRCryptoBlockChainType type;
+    BRCryptoNetwork network;
+    BRCryptoKey key;
+};
+
+extern BRCryptoExportablePaperWalletStatus
+cryptoExportablePaperWalletValidateSupported (BRCryptoNetwork network,
+                                              BRCryptoCurrency currency,
+                                              BRCryptoWallet wallet) {
+    if (CRYPTO_FALSE == cryptoNetworkHasCurrency (network, currency)) {
+        return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
+    }
+
+    if (cryptoNetworkGetType (network) != cryptoWalletGetType (wallet)) {
+        return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
+    }
+
+    BRCryptoCurrency walletCurrency = cryptoWalletGetCurrency (wallet);
+    if (CRYPTO_FALSE == cryptoCurrencyIsIdentical (currency, walletCurrency)) {
+        cryptoCurrencyGive (walletCurrency);
+        return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
+    }
+    cryptoCurrencyGive (walletCurrency);
+
+    switch (cryptoWalletGetType (wallet)) {
+        case BLOCK_CHAIN_TYPE_BTC:
+            return CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS;
+        default:
+            break;
+    }
+
+    return CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY;
+}
+
+extern BRCryptoExportablePaperWallet
+cryptoExportablePaperWalletCreateAsBTC (BRCryptoNetwork network,
+                                        BRCryptoCurrency currency) {
+    BRCryptoExportablePaperWallet paperWallet = calloc (1, sizeof(struct BRCryptoExportablePaperWalletRecord));
+    paperWallet->type = BLOCK_CHAIN_TYPE_BTC;
+    paperWallet->network = cryptoNetworkTake (network);
+    
+    BRKey key;
+    int compressed = 1;
+    if (1 == BRKeyGenerateRandom (&key, compressed)) {
+        paperWallet->key = cryptoKeyCreateFromKey (&key); // cleans key
+        return paperWallet;
+    } else {
+        cryptoExportablePaperWalletRelease (paperWallet);
+        return NULL;
+    }
+}
+
+extern void
+cryptoExportablePaperWalletRelease (BRCryptoExportablePaperWallet paperWallet) {
+    cryptoNetworkGive (paperWallet->network);
+    cryptoKeyGive (paperWallet->key);
+
+    memset (paperWallet, 0, sizeof(struct BRCryptoWalletSweeperRecord));
+    free (paperWallet);
+}
+
+extern BRCryptoKey
+cryptoExportablePaperWalletGetKey (BRCryptoExportablePaperWallet paperWallet) {
+    return cryptoKeyTake (paperWallet->key);
+}
+
+extern BRCryptoAddress
+cryptoExportablePaperWalletGetAddress (BRCryptoExportablePaperWallet paperWallet) {
+    BRCryptoAddress address = NULL;
+    
+    assert (BLOCK_CHAIN_TYPE_BTC == paperWallet->type);
+    
+    switch (paperWallet->network->canonicalType) {
+        case CRYPTO_NETWORK_TYPE_BTC: {
+            BRAddressParams addrParams = cryptoNetworkAsBTC (paperWallet->network)->addrParams;
+            BRKey *key = cryptoKeyGetCore (paperWallet->key);
+            //TODO: segwit?
+            // encode using legacy format (only supported method for BTC)
+            size_t addrLength = BRKeyLegacyAddr (key, NULL, 0, addrParams);
+            char *addr = malloc (addrLength + 1);
+            BRKeyLegacyAddr (key, addr, addrLength, addrParams);
+            addr[addrLength] = '\0';
+            address = cryptoAddressCreateFromString (paperWallet->network, addr);
+            break;
+        }
+        default:
+            assert (0);
+            break;
+    }
+
+    return address;
+}

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -1203,8 +1203,8 @@ cryptoExportablePaperWalletCreateAsBTC (BRCryptoNetwork network,
 
 extern void
 cryptoExportablePaperWalletRelease (BRCryptoExportablePaperWallet paperWallet) {
-    cryptoNetworkGive (paperWallet->network);
-    cryptoKeyGive (paperWallet->key);
+    if (NULL != paperWallet->network) cryptoNetworkGive (paperWallet->network);
+    if (NULL != (paperWallet->key)) cryptoKeyGive (paperWallet->key);
 
     memset (paperWallet, 0, sizeof(struct BRCryptoWalletSweeperRecord));
     free (paperWallet);
@@ -1225,13 +1225,13 @@ cryptoExportablePaperWalletGetAddress (BRCryptoExportablePaperWallet paperWallet
         case CRYPTO_NETWORK_TYPE_BTC: {
             BRAddressParams addrParams = cryptoNetworkAsBTC (paperWallet->network)->addrParams;
             BRKey *key = cryptoKeyGetCore (paperWallet->key);
-            //TODO: segwit?
             // encode using legacy format (only supported method for BTC)
             size_t addrLength = BRKeyLegacyAddr (key, NULL, 0, addrParams);
             char *addr = malloc (addrLength + 1);
             BRKeyLegacyAddr (key, addr, addrLength, addrParams);
             addr[addrLength] = '\0';
             address = cryptoAddressCreateFromString (paperWallet->network, addr);
+            free (addr);
             break;
         }
         default:

--- a/WalletKitCore/src/support/BRKey.c
+++ b/WalletKitCore/src/support/BRKey.c
@@ -591,3 +591,11 @@ int BRKeySetCompressed (BRKey *key, int compressed) {
     }
     else return 0;
 }
+
+int BRKeyGenerateRandom (BRKey *key, int compressed) {
+    assert (NULL != key);
+    UInt256 secret;
+    arc4random_buf_brd (secret.u64, sizeof (secret));
+
+    return BRKeySetSecret(key, &secret, compressed);
+}

--- a/WalletKitCore/src/support/BRKey.h
+++ b/WalletKitCore/src/support/BRKey.h
@@ -143,6 +143,8 @@ int BRKeyRecoverPubKeyEthereum(BRKey *key, UInt256 md, const void *compactSig, s
 // Returns true (1) if the compress flag changed; false (0) otherwise
 int BRKeySetCompressed (BRKey *key, int compressed);
 
+int BRKeyGenerateRandom (BRKey *key, int compressed);
+
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -294,7 +294,7 @@ public final class CryptoLibraryDirect {
     public static native int cryptoWalletValidateTransferAttribute(Pointer wallet, Pointer attribute, IntByReference validates);
     // INDIRECT: public static native int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, Pointer arrayOfAttributes, IntByReference validates);
 
-    public static native int cryptoExportablePaperWalletValidateSupported(Pointer network, Pointer currency, Pointer wallet);
+    public static native int cryptoExportablePaperWalletValidateSupported(Pointer network, Pointer currency);
     public static native Pointer cryptoExportablePaperWalletCreateAsBTC(Pointer network, Pointer currency);
     public static native void cryptoExportablePaperWalletRelease(Pointer paperWallet);
     public static native Pointer cryptoExportablePaperWalletGetKey(Pointer paperWallet);

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -294,6 +294,11 @@ public final class CryptoLibraryDirect {
     public static native int cryptoWalletValidateTransferAttribute(Pointer wallet, Pointer attribute, IntByReference validates);
     // INDIRECT: public static native int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, Pointer arrayOfAttributes, IntByReference validates);
 
+    public static native int cryptoExportablePaperWalletValidateSupported(Pointer network, Pointer currency, Pointer wallet);
+    public static native Pointer cryptoExportablePaperWalletCreateAsBTC(Pointer network, Pointer currency);
+    public static native void cryptoExportablePaperWalletRelease(Pointer paperWallet);
+    public static native Pointer cryptoExportablePaperWalletGetKey(Pointer paperWallet);
+    public static native Pointer cryptoExportablePaperWalletGetAddress (Pointer paperWallet);
 
     public static native Pointer cryptoWalletTake(Pointer wallet);
     public static native void cryptoWalletGive(Pointer obj);

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWallet.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWallet.java
@@ -1,0 +1,66 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.corenative.crypto;
+
+import com.breadwallet.corenative.CryptoLibraryDirect;
+import com.google.common.base.Optional;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+
+public class BRCryptoExportablePaperWallet extends PointerType {
+    public BRCryptoExportablePaperWallet() { super(); }
+
+    public BRCryptoExportablePaperWallet(Pointer address) {
+        super(address);
+    }
+
+    public static BRCryptoExportablePaperWalletStatus validateSupported(BRCryptoNetwork network,
+                                                                        BRCryptoCurrency currency,
+                                                                        BRCryptoWallet wallet) {
+        return BRCryptoExportablePaperWalletStatus.fromCore(
+                CryptoLibraryDirect.cryptoExportablePaperWalletValidateSupported(
+                        network.getPointer(),
+                        currency.getPointer(),
+                        wallet.getPointer()
+                )
+        );
+    }
+
+    public static BRCryptoExportablePaperWallet createAsBTC(BRCryptoNetwork network,
+                                                            BRCryptoCurrency currency) {
+        return new BRCryptoExportablePaperWallet(
+                CryptoLibraryDirect.cryptoExportablePaperWalletCreateAsBTC(
+                        network.getPointer(),
+                        currency.getPointer()
+                )
+        );
+    }
+
+    public Optional<BRCryptoKey> getKey() {
+        Pointer thisPtr = this.getPointer();
+
+        return Optional.fromNullable(
+                CryptoLibraryDirect.cryptoExportablePaperWalletGetKey(thisPtr)
+        ).transform(BRCryptoKey::new);
+    }
+
+    public Optional<BRCryptoAddress> getAddress() {
+        Pointer thisPtr = this.getPointer();
+
+        return Optional.fromNullable(
+                CryptoLibraryDirect.cryptoExportablePaperWalletGetAddress(thisPtr)
+        ).transform(BRCryptoAddress::new);
+    }
+
+    public void give() {
+        Pointer thisPtr = this.getPointer();
+
+        CryptoLibraryDirect.cryptoExportablePaperWalletRelease(thisPtr);
+    }
+}

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWallet.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWallet.java
@@ -21,13 +21,11 @@ public class BRCryptoExportablePaperWallet extends PointerType {
     }
 
     public static BRCryptoExportablePaperWalletStatus validateSupported(BRCryptoNetwork network,
-                                                                        BRCryptoCurrency currency,
-                                                                        BRCryptoWallet wallet) {
+                                                                        BRCryptoCurrency currency) {
         return BRCryptoExportablePaperWalletStatus.fromCore(
                 CryptoLibraryDirect.cryptoExportablePaperWalletValidateSupported(
                         network.getPointer(),
-                        currency.getPointer(),
-                        wallet.getPointer()
+                        currency.getPointer()
                 )
         );
     }

--- a/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWalletStatus.java
+++ b/WalletKitJava/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoExportablePaperWalletStatus.java
@@ -1,0 +1,56 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.corenative.crypto;
+
+public enum BRCryptoExportablePaperWalletStatus {
+
+    CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS {
+        @Override
+        public int toCore() {
+            return CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS_VALUE;
+        }
+    },
+
+    CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY {
+        @Override
+        public int toCore() {
+            return CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY_VALUE;
+        }
+    },
+
+    CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS {
+        @Override
+        public int toCore() {
+            return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS_VALUE;
+        }
+    },
+
+    CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION  {
+        @Override
+        public int toCore() {
+            return CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION_VALUE;
+        }
+    };
+
+    private static final int CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS_VALUE                = 0;
+    private static final int CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY_VALUE   = 1;
+    private static final int CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS_VALUE      = 2;
+    private static final int CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION_VALUE      = 3;
+
+    public static BRCryptoExportablePaperWalletStatus fromCore(int nativeValue) {
+        switch (nativeValue) {
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS_VALUE:               return CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS;
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY_VALUE:  return CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY;
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS_VALUE:     return CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS;
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION_VALUE:     return CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION;
+            default: throw new IllegalArgumentException("Invalid core value");
+        }
+    }
+
+    public abstract int toCore();
+}

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/ExportablePaperWallet.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/ExportablePaperWallet.java
@@ -1,0 +1,96 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.corecrypto;
+
+import com.breadwallet.corenative.cleaner.ReferenceCleaner;
+import com.breadwallet.corenative.crypto.BRCryptoCurrency;
+import com.breadwallet.corenative.crypto.BRCryptoExportablePaperWallet;
+import com.breadwallet.corenative.crypto.BRCryptoExportablePaperWalletStatus;
+import com.breadwallet.corenative.crypto.BRCryptoNetwork;
+import com.breadwallet.corenative.crypto.BRCryptoWallet;
+import com.breadwallet.crypto.blockchaindb.BlockchainDb;
+import com.breadwallet.crypto.errors.ExportablePaperWalletError;
+import com.breadwallet.crypto.errors.ExportablePaperWalletUnexpectedError;
+import com.breadwallet.crypto.errors.ExportablePaperWalletUnsupportedCurrencyError;
+import com.breadwallet.crypto.utility.CompletionHandler;
+import com.google.common.base.Optional;
+
+
+final class ExportablePaperWallet implements com.breadwallet.crypto.ExportablePaperWallet {
+    /* package */
+    static void create(WalletManager manager,
+                                        Wallet wallet,
+                                        BlockchainDb bdb,
+                                        CompletionHandler<ExportablePaperWallet, ExportablePaperWalletError> completion) {
+        // check that the requested operation is supported
+        ExportablePaperWalletError e = ExportablePaperWallet.validateSupported(manager, wallet);
+        if (null != e) {
+            completion.handleError(e);
+            return;
+        }
+
+        ExportablePaperWallet paperWallet = ExportablePaperWallet.createAsBTC(manager, wallet);
+        completion.handleData(paperWallet);
+    }
+
+    private static ExportablePaperWalletError statusToError(BRCryptoExportablePaperWalletStatus status) {
+        switch (status) {
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS: return null;
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY: return new ExportablePaperWalletUnsupportedCurrencyError();
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS: return new ExportablePaperWalletUnexpectedError("Invalid argument");
+            case CRYPTO_EXPORTABLE_PAPER_WALLET_ILLEGAL_OPERATION: return new ExportablePaperWalletUnexpectedError("Illegal operation");
+        }
+        return null;
+    }
+
+    private static ExportablePaperWalletError validateSupported(WalletManager manager,
+                                                                Wallet wallet) {
+        Network network = manager.getNetwork();
+        Currency currency = wallet.getCurrency();
+
+        BRCryptoWallet coreWallet = wallet.getCoreBRCryptoWallet();
+        BRCryptoNetwork coreNetwork = network.getCoreBRCryptoNetwork();
+        BRCryptoCurrency coreCurrency = currency.getCoreBRCryptoCurrency();
+
+        return ExportablePaperWallet.statusToError(BRCryptoExportablePaperWallet.validateSupported(coreNetwork, coreCurrency, coreWallet));
+    }
+
+    private static ExportablePaperWallet createAsBTC(WalletManager manager,
+                                                     Wallet wallet) {
+        Network network = manager.getNetwork();
+        Currency currency = wallet.getCurrency();
+
+        BRCryptoNetwork coreNetwork = network.getCoreBRCryptoNetwork();
+        BRCryptoCurrency coreCurrency = currency.getCoreBRCryptoCurrency();
+
+        BRCryptoExportablePaperWallet core = BRCryptoExportablePaperWallet.createAsBTC(coreNetwork, coreCurrency);
+        return ExportablePaperWallet.create(core, manager, wallet);
+    }
+
+    private static ExportablePaperWallet create(BRCryptoExportablePaperWallet core, WalletManager manager, Wallet wallet) {
+        ExportablePaperWallet paperWallet = new ExportablePaperWallet(core);
+        ReferenceCleaner.register(paperWallet, core::give);
+        return paperWallet;
+    }
+
+    private final BRCryptoExportablePaperWallet core;
+
+    private ExportablePaperWallet(BRCryptoExportablePaperWallet core) {
+        this.core = core;
+    }
+
+    @Override
+    public Optional<Key> getKey() {
+        return core.getKey().transform(Key::create);
+    }
+
+    @Override
+    public Optional<Address> getAddress() {
+        return core.getAddress().transform(Address::create);
+    }
+}

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/ExportablePaperWallet.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/ExportablePaperWallet.java
@@ -24,17 +24,15 @@ import com.google.common.base.Optional;
 final class ExportablePaperWallet implements com.breadwallet.crypto.ExportablePaperWallet {
     /* package */
     static void create(WalletManager manager,
-                                        Wallet wallet,
-                                        BlockchainDb bdb,
-                                        CompletionHandler<ExportablePaperWallet, ExportablePaperWalletError> completion) {
+                       CompletionHandler<com.breadwallet.crypto.ExportablePaperWallet, ExportablePaperWalletError> completion) {
         // check that the requested operation is supported
-        ExportablePaperWalletError e = ExportablePaperWallet.validateSupported(manager, wallet);
+        ExportablePaperWalletError e = ExportablePaperWallet.validateSupported(manager);
         if (null != e) {
             completion.handleError(e);
             return;
         }
 
-        ExportablePaperWallet paperWallet = ExportablePaperWallet.createAsBTC(manager, wallet);
+        ExportablePaperWallet paperWallet = ExportablePaperWallet.createAsBTC(manager);
         completion.handleData(paperWallet);
     }
 
@@ -48,31 +46,28 @@ final class ExportablePaperWallet implements com.breadwallet.crypto.ExportablePa
         return null;
     }
 
-    private static ExportablePaperWalletError validateSupported(WalletManager manager,
-                                                                Wallet wallet) {
+    private static ExportablePaperWalletError validateSupported(WalletManager manager) {
         Network network = manager.getNetwork();
-        Currency currency = wallet.getCurrency();
+        Currency currency = manager.getCurrency();
 
-        BRCryptoWallet coreWallet = wallet.getCoreBRCryptoWallet();
         BRCryptoNetwork coreNetwork = network.getCoreBRCryptoNetwork();
         BRCryptoCurrency coreCurrency = currency.getCoreBRCryptoCurrency();
 
-        return ExportablePaperWallet.statusToError(BRCryptoExportablePaperWallet.validateSupported(coreNetwork, coreCurrency, coreWallet));
+        return ExportablePaperWallet.statusToError(BRCryptoExportablePaperWallet.validateSupported(coreNetwork, coreCurrency));
     }
 
-    private static ExportablePaperWallet createAsBTC(WalletManager manager,
-                                                     Wallet wallet) {
+    private static ExportablePaperWallet createAsBTC(WalletManager manager) {
         Network network = manager.getNetwork();
-        Currency currency = wallet.getCurrency();
+        Currency currency = manager.getCurrency();
 
         BRCryptoNetwork coreNetwork = network.getCoreBRCryptoNetwork();
         BRCryptoCurrency coreCurrency = currency.getCoreBRCryptoCurrency();
 
         BRCryptoExportablePaperWallet core = BRCryptoExportablePaperWallet.createAsBTC(coreNetwork, coreCurrency);
-        return ExportablePaperWallet.create(core, manager, wallet);
+        return ExportablePaperWallet.create(core);
     }
 
-    private static ExportablePaperWallet create(BRCryptoExportablePaperWallet core, WalletManager manager, Wallet wallet) {
+    private static ExportablePaperWallet create(BRCryptoExportablePaperWallet core) {
         ExportablePaperWallet paperWallet = new ExportablePaperWallet(core);
         ReferenceCleaner.register(paperWallet, core::give);
         return paperWallet;

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -18,6 +18,7 @@ import com.breadwallet.crypto.AddressScheme;
 import com.breadwallet.crypto.WalletManagerMode;
 import com.breadwallet.crypto.WalletManagerState;
 import com.breadwallet.crypto.WalletManagerSyncDepth;
+import com.breadwallet.crypto.errors.ExportablePaperWalletError;
 import com.breadwallet.crypto.errors.WalletSweeperError;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.base.Optional;
@@ -113,6 +114,11 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
                               com.breadwallet.crypto.Key key,
                               CompletionHandler<com.breadwallet.crypto.WalletSweeper, WalletSweeperError> completion) {
         WalletSweeper.create(this, Wallet.from(wallet), Key.from(key), system.getBlockchainDb(), completion);
+    }
+
+    @Override
+    public void createExportablePaperWallet(CompletionHandler<com.breadwallet.crypto.ExportablePaperWallet, ExportablePaperWalletError> completion) {
+        ExportablePaperWallet.create(this, completion);
     }
 
     @Override

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/ExportablePaperWallet.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/ExportablePaperWallet.java
@@ -1,0 +1,16 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto;
+
+import com.google.common.base.Optional;
+
+public interface ExportablePaperWallet {
+
+    Optional<? extends Key> getKey();
+    Optional<? extends Address> getAddress();
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -11,6 +11,7 @@ package com.breadwallet.crypto;
 
 import android.support.annotation.Nullable;
 
+import com.breadwallet.crypto.errors.ExportablePaperWalletError;
 import com.breadwallet.crypto.errors.WalletSweeperError;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.base.Optional;
@@ -20,6 +21,8 @@ import java.util.List;
 public interface WalletManager {
 
     void createSweeper(Wallet wallet, Key key, CompletionHandler<WalletSweeper, WalletSweeperError> completion);
+
+    void createExportablePaperWallet(CompletionHandler<ExportablePaperWallet, ExportablePaperWalletError> completion);
 
     void connect(@Nullable NetworkPeer peer);
 

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletError.java
@@ -1,0 +1,25 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.errors;
+
+public abstract class ExportablePaperWalletError extends Exception {
+    /* package */
+    ExportablePaperWalletError() {
+        super();
+    }
+
+    /* package */
+    ExportablePaperWalletError(String message) {
+        super(message);
+    }
+
+    /* package */
+    ExportablePaperWalletError(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletUnexpectedError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletUnexpectedError.java
@@ -1,0 +1,14 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.errors;
+
+public final class ExportablePaperWalletUnexpectedError extends ExportablePaperWalletError {
+    public ExportablePaperWalletUnexpectedError(String message) {
+        super(message);
+    }
+}

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletUnsupportedCurrencyError.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/errors/ExportablePaperWalletUnsupportedCurrencyError.java
@@ -1,0 +1,11 @@
+/*
+ * Created by Ehsan Rezaie <ehsan@brd.com> on 11/23/20.
+ * Copyright (c) 2020 Breadwinner AG.  All right reserved.
+ *
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.errors;
+
+public final class ExportablePaperWalletUnsupportedCurrencyError extends ExportablePaperWalletError {
+}

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -231,8 +231,8 @@ public final class WalletManager: Equatable, CustomStringConvertible {
         WalletSweeper.create(wallet: wallet, key: key, bdb: query, completion: completion)
     }
     
-    public func createExportablePaperWallet (wallet: Wallet) -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
-        return ExportablePaperWallet.create(wallet: wallet)
+    public func createExportablePaperWallet () -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
+        return ExportablePaperWallet.create(manager: self)
     }
 
     internal init (core: BRCryptoWalletManager,
@@ -512,17 +512,16 @@ public enum ExportablePaperWalletError: Error {
 }
 
 public final class ExportablePaperWallet {
-    internal static func create(wallet: Wallet) -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
+    internal static func create(manager: WalletManager) -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
         // check that requested wallet supports generating exportable paper wallets
-        if let e = ExportablePaperWalletError(cryptoExportablePaperWalletValidateSupported(wallet.manager.network.core,
-                                                                                           wallet.currency.core,
-                                                                                           wallet.core)) {
+        if let e = ExportablePaperWalletError(cryptoExportablePaperWalletValidateSupported(manager.network.core,
+                                                                                           manager.currency.core)) {
             return Result.failure(e)
         }
 
-        switch cryptoNetworkGetCanonicalType (wallet.manager.network.core) {
+        switch cryptoNetworkGetCanonicalType (manager.network.core) {
         case CRYPTO_NETWORK_TYPE_BTC:
-            let paperWallet: ExportablePaperWallet = createAsBTC(wallet: wallet)
+            let paperWallet: ExportablePaperWallet = createAsBTC(manager: manager)
             return Result.success(paperWallet)
         default:
             assertionFailure()
@@ -531,9 +530,9 @@ public final class ExportablePaperWallet {
         return Result.failure(.unexpectedError)
     }
 
-    private static func createAsBTC(wallet: Wallet) -> ExportablePaperWallet {
-        return ExportablePaperWallet(core: cryptoExportablePaperWalletCreateAsBTC(wallet.manager.network.core,
-                                                                                  wallet.currency.core))
+    private static func createAsBTC(manager: WalletManager) -> ExportablePaperWallet {
+        return ExportablePaperWallet(core: cryptoExportablePaperWalletCreateAsBTC(manager.network.core,
+                                                                                  manager.currency.core))
     }
     
     internal let core: BRCryptoWalletSweeper

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -533,19 +533,13 @@ public final class ExportablePaperWallet {
 
     private static func createAsBTC(wallet: Wallet) -> ExportablePaperWallet {
         return ExportablePaperWallet(core: cryptoExportablePaperWalletCreateAsBTC(wallet.manager.network.core,
-                                                                                  wallet.currency.core),
-                                     wallet: wallet)
+                                                                                  wallet.currency.core))
     }
     
     internal let core: BRCryptoWalletSweeper
-    private let manager: WalletManager
-    private let wallet: Wallet
 
-    private init (core: BRCryptoWalletSweeper,
-                  wallet: Wallet) {
+    private init (core: BRCryptoWalletSweeper) {
         self.core = core
-        self.manager = wallet.manager
-        self.wallet = wallet
     }
 
     public var privateKey: Key? {

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -454,7 +454,7 @@ public final class WalletSweeper {
         bdb.getTransactions(blockchainId: network.uids,
                             addresses: [address],
                             begBlockNumber: 0,
-                            endBlockNumber: network.height,
+                            endBlockNumber: nil,
                             includeRaw: true,
                             includeTransfers: false) {
                             (res: Result<[BlockChainDB.Model.Transaction], BlockChainDB.QueryError>) in

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -230,6 +230,10 @@ public final class WalletManager: Equatable, CustomStringConvertible {
                                completion: @escaping (Result<WalletSweeper, WalletSweeperError>) -> Void) {
         WalletSweeper.create(wallet: wallet, key: key, bdb: query, completion: completion)
     }
+    
+    public func createExportablePaperWallet (wallet: Wallet) -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
+        return ExportablePaperWallet.create(wallet: wallet)
+    }
 
     internal init (core: BRCryptoWalletManager,
                    system: System,
@@ -486,6 +490,76 @@ public final class WalletSweeper {
 
     deinit {
         cryptoWalletSweeperRelease(core)
+    }
+}
+
+///
+/// Exportable Paper Wallet
+///
+
+public enum ExportablePaperWalletError: Error {
+    case unsupportedCurrency
+    case unexpectedError
+
+    internal init? (_ core: BRCryptoExportablePaperWalletStatus) {
+        switch core {
+        case CRYPTO_EXPORTABLE_PAPER_WALLET_SUCCESS:                 return nil
+        case CRYPTO_EXPORTABLE_PAPER_WALLET_UNSUPPORTED_CURRENCY:    self = .unsupportedCurrency
+        case CRYPTO_EXPORTABLE_PAPER_WALLET_INVALID_ARGUMENTS:       self = .unexpectedError
+        default: self = .unexpectedError; preconditionFailure()
+        }
+    }
+}
+
+public final class ExportablePaperWallet {
+    internal static func create(wallet: Wallet) -> Result<ExportablePaperWallet, ExportablePaperWalletError> {
+        // check that requested wallet supports generating exportable paper wallets
+        if let e = ExportablePaperWalletError(cryptoExportablePaperWalletValidateSupported(wallet.manager.network.core,
+                                                                                           wallet.currency.core,
+                                                                                           wallet.core)) {
+            return Result.failure(e)
+        }
+
+        switch cryptoNetworkGetCanonicalType (wallet.manager.network.core) {
+        case CRYPTO_NETWORK_TYPE_BTC:
+            let paperWallet: ExportablePaperWallet = createAsBTC(wallet: wallet)
+            return Result.success(paperWallet)
+        default:
+            assertionFailure()
+        }
+        
+        return Result.failure(.unexpectedError)
+    }
+
+    private static func createAsBTC(wallet: Wallet) -> ExportablePaperWallet {
+        return ExportablePaperWallet(core: cryptoExportablePaperWalletCreateAsBTC(wallet.manager.network.core,
+                                                                                  wallet.currency.core),
+                                     wallet: wallet)
+    }
+    
+    internal let core: BRCryptoWalletSweeper
+    private let manager: WalletManager
+    private let wallet: Wallet
+
+    private init (core: BRCryptoWalletSweeper,
+                  wallet: Wallet) {
+        self.core = core
+        self.manager = wallet.manager
+        self.wallet = wallet
+    }
+
+    public var privateKey: Key? {
+        return cryptoExportablePaperWalletGetKey (self.core)
+            .map { Key (core: $0) }
+    }
+
+    public var address: Address? {
+        return cryptoExportablePaperWalletGetAddress (self.core)
+            .map { Address (core: $0, take: false) }
+    }
+
+    deinit {
+        cryptoExportablePaperWalletRelease(core)
     }
 }
 

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoWalletTests.swift
@@ -136,7 +136,8 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         var feeEstimateResult: Result<TransferFeeBasis, Wallet.FeeEstimationError>!
         wallet.estimateFee (target: transferTargetAddress,
                             amount: transferAmount,
-                            fee: network.minimumFee) { (res: Result<TransferFeeBasis, Wallet.FeeEstimationError>) in
+                            fee: network.minimumFee,
+                            attributes: nil) { (res: Result<TransferFeeBasis, Wallet.FeeEstimationError>) in
                                 feeEstimateResult = res
                                 feeEstimateExpectation.fulfill()
         }


### PR DESCRIPTION
Add `BRCryptoExportablePaperWallet` for generating a random single-key BTC "paper" wallet and exposing its private key and address.