### PR TITLE
CORE:910: Create multiple submit serializations

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1495,6 +1495,10 @@ cryptoWalletManagerHandleTransferGENFilter (BRCryptoWalletManager cwm,
         if (NULL == genTransferGetUIDS(transferGenericOrig))
             genTransferSetUIDS (transferGenericOrig,
                                 genTransferGetUIDS (transferGeneric));
+
+        // Get the hash from the incoming transfer - and give the GEN code a chance to update if necessary
+        BRGenericHash hash = genTransferGetHash(transferGeneric);
+        genTransferUpdateHash(transferGenericOrig, hash);
     }
 
     // Fill in any attributes

--- a/WalletKitCore/src/generic/BRGeneric.c
+++ b/WalletKitCore/src/generic/BRGeneric.c
@@ -296,6 +296,11 @@ genTransferSetUIDS (BRGenericTransfer transfer,
     transfer->uids = (NULL == uids ? NULL : strdup (uids));
 }
 
+extern void
+genTransferUpdateHash (BRGenericTransfer transfer, BRGenericHash hash) {
+    transfer->handlers.updateHash(transfer->ref, hash);
+}
+
 extern BRGenericTransferState
 genTransferGetState (BRGenericTransfer transfer) {
     return transfer->state;
@@ -335,8 +340,7 @@ genTransferEqual (BRGenericTransfer t1,
     return (t1 == t2 ||
             (NULL != t1->uids && NULL != t2->uids
              ? 0 == strcmp (t1->uids, t2->uids)
-             : genericHashEqual (genTransferGetHash (t1),
-                                 genTransferGetHash (t2))));
+             : t1->handlers.isEqual(t1->ref, t2->ref)));
 }
 
 extern uint8_t *

--- a/WalletKitCore/src/generic/BRGeneric.h
+++ b/WalletKitCore/src/generic/BRGeneric.h
@@ -161,6 +161,9 @@ extern "C" {
     extern BRSetOf (BRGenericTransfer)
     genTransferSetCreate (size_t capacity);
 
+    extern void
+    genTransferUpdateHash (BRGenericTransfer transfer, BRGenericHash hash);
+
     // MARK: - Generic Wallet
 
     /// Create the primary wallet.  The `account` is provided because wallet's create transfers which

--- a/WalletKitCore/src/generic/BRGenericHandlers.h
+++ b/WalletKitCore/src/generic/BRGenericHandlers.h
@@ -95,6 +95,8 @@ extern "C" {
     typedef BRGenericFeeBasis (*BRGenericTransferGetFeeBasis) (BRGenericTransferRef transfer);
     typedef BRGenericHash (*BRGenericTransferGetHash) (BRGenericTransferRef transfer);
     typedef uint8_t * (*BRGenericTransferGetSerialization) (BRGenericTransferRef transfer, size_t *bytesCount);
+    typedef int (*BRGenericTransferIsEqual) (BRGenericTransferRef t1, BRGenericTransferRef t2);
+    typedef void (*BRGenericTransferUpdateHash) (BRGenericTransferRef transfer, BRGenericHash hash);
 
     typedef struct {
         BRGenericTransferCreate create;
@@ -106,6 +108,8 @@ extern "C" {
         BRGenericTransferGetFeeBasis feeBasis;
         BRGenericTransferGetHash hash;
         BRGenericTransferGetSerialization getSerialization;
+        BRGenericTransferIsEqual isEqual;
+        BRGenericTransferUpdateHash updateHash;
     } BRGenericTransferHandlers;
 
     // MARK: - Generic Wallet

--- a/WalletKitCore/src/generic/BRGenericHedera.c
+++ b/WalletKitCore/src/generic/BRGenericHedera.c
@@ -188,6 +188,24 @@ genericHederaTransferGetSerialization (BRGenericTransferRef transfer, size_t *by
     return hederaTransactionSerialize((BRHederaTransaction) transfer, bytesCount);
 }
 
+static int
+genericHederaTransferIsEqual (BRGenericTransferRef t1, BRGenericTransferRef t2)
+{
+    BRHederaTransaction tx1 = (BRHederaTransaction)t1;
+    BRHederaTransaction tx2 = (BRHederaTransaction)t2;
+    return hederaTransactionHashEqual(tx1, tx2);
+}
+
+static void
+genericHederaUpdateHash (BRGenericTransferRef genericTransfer, BRGenericHash genericHash) {
+    assert(genericTransfer);
+    assert(genericHash.bytesCount == sizeof(BRHederaTransactionHash));
+    BRHederaTransaction transaction = (BRHederaTransaction)genericTransfer;
+    BRHederaTransactionHash hash;
+    memcpy(hash.bytes, genericHash.bytes, sizeof(hash.bytes));
+    hederaTransactionUpdateHash(transaction, hash);
+}
+
 // MARK: Generic Wallet
 
 static BRGenericWalletRef
@@ -273,7 +291,6 @@ genericHederaWalletCreateTransfer (BRGenericWalletRef wallet,
                                    BRGenericTransferAttribute *attributes) {
     BRHederaAddress source = hederaWalletGetSourceAddress ((BRHederaWallet) wallet);
     BRHederaUnitTinyBar thbar  = (BRHederaUnitTinyBar) amount.u64[0];
-    BRHederaAddress nodeAddress = hederaWalletGetNodeAddress((BRHederaWallet) wallet);
     BRHederaFeeBasis feeBasis;
     feeBasis.costFactor = (uint32_t)estimatedFeeBasis.costFactor;
     int overflow = 0;
@@ -281,7 +298,7 @@ genericHederaWalletCreateTransfer (BRGenericWalletRef wallet,
     assert(overflow == 0);
 
     BRHederaTransaction transaction = hederaTransactionCreateNew (source, (BRHederaAddress) target,
-                                                           thbar, feeBasis, nodeAddress, NULL);
+                                                           thbar, feeBasis, NULL);
 
     for (size_t index = 0; index < attributesCount; index++) {
         BRGenericTransferAttribute attribute = attributes[index];
@@ -296,7 +313,6 @@ genericHederaWalletCreateTransfer (BRGenericWalletRef wallet,
     }
 
     hederaAddressFree(source);
-    hederaAddressFree(nodeAddress);
 
     return (BRGenericTransferRef) transaction;
 }
@@ -481,6 +497,8 @@ struct BRGenericHandersRecord genericHederaHandlersRecord = {
         genericHederaTransferGetFeeBasis,
         genericHederaTransferGetHash,
         genericHederaTransferGetSerialization,
+        genericHederaTransferIsEqual,
+        genericHederaUpdateHash
     },
 
     {   // Wallet

--- a/WalletKitCore/src/generic/BRGenericRipple.c
+++ b/WalletKitCore/src/generic/BRGenericRipple.c
@@ -185,6 +185,25 @@ genericRippleTransferGetSerialization (BRGenericTransferRef transfer, size_t *by
     return result;
 }
 
+static int
+genericRippleTransferIsEqual (BRGenericTransferRef t1, BRGenericTransferRef t2)
+{
+    BRRippleTransfer transfer1 = (BRRippleTransfer)t1;
+    BRRippleTransfer transfer2 = (BRRippleTransfer)t2;
+    BRRippleTransactionHash hash1 = rippleTransferGetTransactionId(transfer1);
+    BRRippleTransactionHash hash2 = rippleTransferGetTransactionId(transfer2);
+    if (memcmp(hash1.bytes, hash2.bytes, sizeof(hash1.bytes)) == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static void
+genericRippleUpdateHash (BRGenericTransferRef transfer, BRGenericHash genericHash)
+{
+    // There should be no need to update the hash for Ripple
+}
+
 // MARK: Generic Wallet
 
 static BRGenericWalletRef
@@ -488,6 +507,8 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleTransferGetFeeBasis,
         genericRippleTransferGetHash,
         genericRippleTransferGetSerialization,
+        genericRippleTransferIsEqual,
+        genericRippleUpdateHash
     },
 
     {   // Wallet

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -5,11 +5,16 @@
 #include "BRHederaCrypto.h"
 #include "BRHederaSerialize.h"
 #include "ed25519/ed25519.h"
+#include "support/BRArray.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <sys/time.h>
 #include <string.h>
+#include "ethereum/util/BRUtilHex.h"
+#include "support/BRInt.h"
+
+#define NUM_NODES 10
 
 struct BRHederaTransactionRecord {
     BRHederaAddress source;
@@ -20,19 +25,20 @@ struct BRHederaTransactionRecord {
     uint8_t * serializedBytes;
     size_t serializedSize;
     BRHederaTransactionHash hash;
+    bool hashIsSet;
     BRHederaFeeBasis feeBasis;
-    BRHederaAddress nodeAddress;
     BRHederaTimeStamp timeStamp;
     uint64_t blockHeight;
     int error;
     char * memo;
+    BRArrayOf(BRHederaTransactionHash) hashes;
 };
 
 char * createTransactionID(BRHederaAddress address, BRHederaTimeStamp timeStamp)
 {
     char buffer[128] = {0};
     const char * hederaAddress = hederaAddressAsString(address);
-    sprintf(buffer, "%s-%" PRIi64 "-%" PRIi32, hederaAddress, timeStamp.seconds, timeStamp.nano);
+    sprintf(buffer, "%s-%" PRIi64 "-%09" PRIi32, hederaAddress, timeStamp.seconds, timeStamp.nano);
     char * result = calloc(1, strlen(buffer) + 1);
     strncpy(result, buffer, strlen(buffer));
     return result;
@@ -42,7 +48,6 @@ extern BRHederaTransaction hederaTransactionCreateNew (BRHederaAddress source,
                                                        BRHederaAddress target,
                                                        BRHederaUnitTinyBar amount,
                                                        BRHederaFeeBasis feeBasis,
-                                                       BRHederaAddress nodeAddress,
                                                        BRHederaTimeStamp *timeStamp)
 {
     BRHederaTransaction transaction = calloc (1, sizeof(struct BRHederaTransactionRecord));
@@ -51,7 +56,6 @@ extern BRHederaTransaction hederaTransactionCreateNew (BRHederaAddress source,
     transaction->amount = amount;
     transaction->feeBasis = feeBasis;
     transaction->fee = hederaFeeBasisGetFee (&transaction->feeBasis);
-    transaction->nodeAddress = hederaAddressClone (nodeAddress);
     if (timeStamp != NULL) {
         transaction->timeStamp = *timeStamp;
     } else {
@@ -60,8 +64,6 @@ extern BRHederaTransaction hederaTransactionCreateNew (BRHederaAddress source,
         transaction->timeStamp = hederaGenerateTimeStamp();
     }
     transaction->transactionId = createTransactionID(source, transaction->timeStamp);
-    transaction->blockHeight = 0;
-    transaction->error = 0;
     return transaction;
 }
 
@@ -98,6 +100,7 @@ extern BRHederaTransaction hederaTransactionCreate (BRHederaAddress source,
     }
 
     transaction->hash = hash;
+    transaction->hashIsSet = true;
     transaction->blockHeight = blockHeight;
     transaction->error = error;
 
@@ -114,6 +117,7 @@ hederaTransactionClone (BRHederaTransaction transaction)
     newTransaction->amount = hederaTransactionGetAmount(transaction);
     newTransaction->fee = transaction->fee;
     newTransaction->feeBasis = transaction->feeBasis;
+    newTransaction->error = transaction->error;
 
     if (transaction->transactionId && strlen(transaction->transactionId) > 1) {
         newTransaction->transactionId = (char*) calloc(1, strlen(transaction->transactionId) + 1);
@@ -130,13 +134,17 @@ hederaTransactionClone (BRHederaTransaction transaction)
         memcpy(newTransaction->serializedBytes, transaction->serializedBytes, newTransaction->serializedSize);
     }
 
-    if (transaction->nodeAddress) {
-        newTransaction->nodeAddress = hederaAddressClone(transaction->nodeAddress);
-    }
-
     if (transaction->memo) {
         newTransaction->memo = strdup(transaction->memo);
     }
+
+    if (transaction->hashes) {
+        array_new(newTransaction->hashes, array_count(transaction->hashes));
+        array_add_array(newTransaction->hashes, transaction->hashes, array_count(transaction->hashes));
+    }
+
+    newTransaction->hashIsSet = transaction->hashIsSet;
+
     return newTransaction;
 }
 
@@ -147,8 +155,8 @@ extern void hederaTransactionFree (BRHederaTransaction transaction)
     if (transaction->transactionId) free (transaction->transactionId);
     if (transaction->source) hederaAddressFree (transaction->source);
     if (transaction->target) hederaAddressFree (transaction->target);
-    if (transaction->nodeAddress) hederaAddressFree (transaction->nodeAddress);
     if (transaction->memo) free(transaction->memo);
+    if (transaction->hashes) array_free(transaction->hashes);
     free (transaction);
 }
 
@@ -169,8 +177,117 @@ hederaTransactionGetMemo(BRHederaTransaction transaction)
     return NULL;
 }
 
+static uint8_t* hederaTransactionSignTransactionWithNode (BRHederaTransaction transaction,
+                                                          BRKey publicKey,
+                                                          const unsigned char * privateKey,
+                                                          BRHederaAddress node,
+                                                          BRHederaUnitTinyBar fee,
+                                                          size_t *bufferSize)
+{
+    // First we need to serialize the body since it is the thing we sign
+    size_t bodySize;
+    uint8_t * body = hederaTransactionBodyPack (transaction->source,
+                                                transaction->target,
+                                                node,
+                                                transaction->amount,
+                                                transaction->timeStamp,
+                                                fee,
+                                                transaction->memo,
+                                                &bodySize);
+
+    // Create signature from the body bytes
+    unsigned char signature[64];
+    memset (signature, 0x00, 64);
+    ed25519_sign(signature, body, bodySize, publicKey.pubKey, privateKey);
+
+    // Serialize the full transaction including signature and public key
+    uint8_t * serializedBytes = hederaTransactionPack (signature, 64,
+                                                       publicKey.pubKey, 32,
+                                                       body, bodySize,
+                                                       bufferSize);
+    free(body);
+    return serializedBytes;
+}
+
+static size_t
+hederaTransactionSignMultipleSerializations (BRHederaTransaction transaction, BRKey publicKey,
+                                             const unsigned char *privateKey, BRHederaUnitTinyBar fee)
+{
+    if (transaction->hashes) array_free(transaction->hashes);
+    array_new(transaction->hashes, NUM_NODES);
+    transaction->serializedSize = 0;
+    uint8_t * pSerializedBytes = NULL;
+    for (int32_t i = 0; i < NUM_NODES; i++) {
+        int32_t nodeNumber = i + 3; // Nodes 0 - 2 are not used
+        size_t size = 0;
+        BRHederaAddress node = hederaAddressCreate(0, 0, nodeNumber);
+        uint8_t * signedBytes = hederaTransactionSignTransactionWithNode(transaction, publicKey, privateKey,
+                                                                         node, fee, &size);
+
+        // Store the hash for this serialization
+        BRHederaTransactionHash hash;
+        BRSHA384(hash.bytes, signedBytes, size);
+        array_add(transaction->hashes, hash);
+
+        if (i == 0) { // First serialization
+            // We now have an idea of how much memory is needed for a single serialization
+            // - 3 bytes for the header
+            // - enough room for NUM_NODES (6 bytes for a header plus serialization)
+            // - plus some padding just in case the other serializations are larger - will truncate later
+            transaction->serializedBytes = calloc(1, 3 + ((size + 6) * NUM_NODES) + 1024);
+            pSerializedBytes = transaction->serializedBytes;
+
+            // Add the header info - version plus the number of serializations
+            *pSerializedBytes = (uint8_t)1; // Version 1 of the protocol
+            pSerializedBytes++;
+            UInt16SetBE(pSerializedBytes, NUM_NODES);
+            pSerializedBytes += 2; // Pointer to after the header
+        }
+        // Add the node number, the size of the serialization, then the
+        // serialized bytes for this node
+        UInt16SetBE(pSerializedBytes, nodeNumber);
+        UInt32SetBE(pSerializedBytes + 2, (uint32_t)size);
+        memcpy(pSerializedBytes + 6, signedBytes, size);
+        pSerializedBytes += (6 + size);
+
+        free(signedBytes);
+        hederaAddressFree(node);
+    }
+
+    // Calculate the size using pointer arithmetic
+    transaction->serializedSize = (unsigned long)(pSerializedBytes - transaction->serializedBytes);
+    // Truncate the buffer to the actual size
+    transaction->serializedBytes = realloc(transaction->serializedBytes, transaction->serializedSize);
+    return transaction->serializedSize;
+}
+
 extern size_t
 hederaTransactionSignTransaction (BRHederaTransaction transaction,
+                                  BRKey publicKey,
+                                  UInt512 seed)
+{
+    assert (transaction);
+
+    // If previously signed - delete and resign
+    if (transaction->serializedBytes) {
+        free (transaction->serializedBytes);
+        transaction->serializedSize = 0;
+    }
+
+    // Generate the private key from the seed
+    BRKey key = hederaKeyCreate (seed);
+    unsigned char privateKey[64] = {0};
+    unsigned char temp[32] = {0}; // Use the public key that is sent in instead
+    ed25519_create_keypair (temp, privateKey, key.secret.u8);
+
+    BRHederaUnitTinyBar fee = hederaFeeBasisGetFee(&transaction->feeBasis);
+
+    return hederaTransactionSignMultipleSerializations(transaction, publicKey, privateKey, fee);
+}
+
+// Keep this function for now - we might need to test the old serialization
+// code in Blockset from time to time
+size_t hederaTransactionSignTransactionV0 (BRHederaTransaction transaction,
                                   BRKey publicKey,
                                   UInt512 seed)
 {
@@ -192,9 +309,10 @@ hederaTransactionSignTransaction (BRHederaTransaction transaction,
 
     // First we need to serialize the body since it is the thing we sign
     size_t bodySize;
+    BRHederaAddress nodeAddress = hederaAddressCreate(0, 0, 5);
     uint8_t * body = hederaTransactionBodyPack (transaction->source,
                                                 transaction->target,
-                                                transaction->nodeAddress,
+                                                nodeAddress,
                                                 transaction->amount,
                                                 transaction->timeStamp,
                                                 fee,
@@ -224,7 +342,7 @@ hederaTransactionSignTransaction (BRHederaTransaction transaction,
     // The BDB server implementation requires that we add in the node account id along with
     // the serialized bytes.
     uint8_t nodeAccountId[HEDERA_ADDRESS_SERIALIZED_SIZE];
-    hederaAddressSerialize (transaction->nodeAddress, nodeAccountId, HEDERA_ADDRESS_SERIALIZED_SIZE);
+    hederaAddressSerialize (nodeAddress, nodeAccountId, HEDERA_ADDRESS_SERIALIZED_SIZE);
 
     // The buffer has to hold the nodeAccountId and the serialized bytes
     transaction->serializedBytes = calloc(1, transaction->serializedSize + HEDERA_ADDRESS_SERIALIZED_SIZE);
@@ -245,11 +363,14 @@ hederaTransactionSignTransaction (BRHederaTransaction transaction,
     return transaction->serializedSize;
 }
 
+
 extern uint8_t * hederaTransactionSerialize (BRHederaTransaction transaction, size_t *size)
 {
     if (transaction->serializedBytes) {
         *size = transaction->serializedSize;
-        return transaction->serializedBytes;
+        uint8_t * buffer = calloc(1, transaction->serializedSize);
+        memcpy(buffer, transaction->serializedBytes, transaction->serializedSize);
+        return buffer;
     } else {
         *size = 0;
         return NULL;
@@ -349,9 +470,7 @@ extern bool hederaTransactionEqual (BRHederaTransaction t1, BRHederaTransaction 
         }
     } else {
         // Transaction IDs are not available - use the hash
-        BRHederaTransactionHash hash1 = hederaTransactionGetHash(t1);
-        BRHederaTransactionHash hash2 = hederaTransactionGetHash(t2);
-        if (memcmp(hash1.bytes, hash2.bytes, sizeof(hash1.bytes)) == 0) {
+        if (hederaTransactionHashEqual(t1, t2)) {
             // Hash is the same - compare the source
             BRHederaAddress source1 = hederaTransactionGetSource(t1);
             BRHederaAddress source2 = hederaTransactionGetSource(t2);
@@ -370,6 +489,54 @@ extern bool hederaTransactionEqual (BRHederaTransaction t1, BRHederaTransaction 
         }
     }
     return result;
+}
+
+static int findHashInList (BRHederaTransactionHash *hash, BRArrayOf(BRHederaTransactionHash) hashes)
+{
+    for (int i = 0; i < array_count(hashes); i++) {
+        if (0 == memcmp(hash, &hashes[i], sizeof(BRHederaTransactionHash))) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+extern bool hederaTransactionHashEqual (BRHederaTransaction t1, BRHederaTransaction t2)
+{
+    // When we submit a transfer to Blockset for Hedera - we are forced to send
+    // multiple serializations where each one has a different hash - so we might
+    // have to check out all the hashes if applicable
+
+    // Go through the hash list and find the match
+    int hashCount1 = hederaTransactionGetHashCount(t1);
+    int hashCount2 = hederaTransactionGetHashCount(t2);
+
+    if (hashCount1 == 0 || hashCount2 == 0) {
+        return false;
+    } else if (hashCount1 == 1 && hashCount2 == 1) {
+        // Just compare the single hash
+        BRHederaTransactionHash hash1 = hederaTransactionGetHash(t1);
+        BRHederaTransactionHash hash2 = hederaTransactionGetHash(t2);
+        return (0 == memcmp(hash1.bytes, hash2.bytes, sizeof(hash1.bytes)));
+    } else if (hashCount1 == 1) {
+        BRHederaTransactionHash hash = hederaTransactionGetHash(t1);
+        return (1 == findHashInList(&hash, t2->hashes));
+    } else if (hashCount2 == 1) {
+        BRHederaTransactionHash hash = hederaTransactionGetHash(t2);
+        return (1 == findHashInList(&hash, t1->hashes));
+    } else {
+        // Both have multi hash lists - should never happen
+        for (int i = 0; i < hashCount1 - 1; i++) {
+            BRHederaTransactionHash hash1 = hederaTransactionGetHashAtIndex(t1, i);
+            for (int j = 0; j < hashCount2 - 1; j++) {
+                BRHederaTransactionHash hash2 = hederaTransactionGetHashAtIndex(t2, j);
+                if (memcmp(hash1.bytes, hash2.bytes, sizeof(hash1.bytes)) == 0) {
+                    return 1;
+                }
+            }
+        }
+    }
+    return 0;
 }
 
 extern BRHederaTimeStamp hederaGenerateTimeStamp(void)
@@ -409,4 +576,55 @@ BRHederaTimeStamp hederaParseTimeStamp(const char* transactionID)
 
     free (txID);
     return ts;
+}
+
+int hederaTransactionGetHashCount (BRHederaTransaction transaction) {
+    assert(transaction);
+    if (transaction->hashIsSet) {
+        return 1;
+    } else if (transaction->hashes) {
+        return (int)array_count(transaction->hashes);
+    } else {
+        return 0;
+    }
+}
+
+BRHederaTransactionHash hederaTransactionGetHashAtIndex (BRHederaTransaction transaction, int index) {
+    assert(transaction);
+    assert(index >= 0 && index < NUM_NODES);
+    if (transaction->hashes) {
+        return transaction->hashes[index];
+    } else {
+        return transaction->hash;
+    }
+}
+
+void hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash) {
+    assert(transaction);
+    // The hash updating ONLY happens once when we have a SENT transaction waiting to find
+    // out which hash was used when submitting - so if we don't have multiple hashes then ignore
+    if (transaction->hashes) {
+        for (int i = 0; i < array_count(transaction->hashes); i++) {
+            if (memcmp(transaction->hashes[i].bytes, hash.bytes, sizeof(hash.bytes)) == 0) {
+                // Copy the real hash into our internal hash value
+                transaction->hash = hash;
+                transaction->hashIsSet = true;
+
+                // Don't need the hashes anymore
+                array_free(transaction->hashes);
+                transaction->hashes = NULL;
+
+                // If the hash is being updated then that means the transfer was successful
+                // and the upper layers have matched up this transfer to the correct hash
+                // so we can't send this one again - since it has 10 serializtions it would be
+                // better to clean up that memory
+                if (transaction->serializedBytes != NULL) {
+                    free(transaction->serializedBytes);
+                    transaction->serializedBytes = NULL;
+                    transaction->serializedSize = 0;
+                }
+                return; // Found it - updated - cleaned up - DONE
+            }
+        }
+    }
 }

--- a/WalletKitCore/src/hedera/BRHederaTransaction.h
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.h
@@ -36,7 +36,7 @@ typedef struct BRHederaTransactionRecord *BRHederaTransaction;
 extern BRHederaTransaction /* caller owns memory and must call "hederaTransactionFree" function */
 hederaTransactionCreateNew(BRHederaAddress source, BRHederaAddress target,
                            BRHederaUnitTinyBar amount, BRHederaFeeBasis feeBasis,
-                           BRHederaAddress nodeAddress, BRHederaTimeStamp *timeStamp);
+                           BRHederaTimeStamp *timeStamp);
 
 /**
  * Create a Hedera transaction recovered from the blockset server
@@ -114,6 +114,7 @@ hederaTransactionGetMemo(BRHederaTransaction transaction);
 
 // Check equality
 extern bool hederaTransactionEqual (BRHederaTransaction t1, BRHederaTransaction t2);
+extern bool hederaTransactionHashEqual (BRHederaTransaction t1, BRHederaTransaction t2);
 
 extern BRHederaTimeStamp hederaGenerateTimeStamp(void);
 extern BRHederaTimeStamp hederaParseTimeStamp(const char* txID);
@@ -125,6 +126,11 @@ extern int hederaTransactionHasTarget (BRHederaTransaction tranaction, BRHederaA
 extern BRHederaUnitTinyBar hederaTransactionGetAmountDirected (BRHederaTransaction transfer,
                                                                BRHederaAddress address,
                                                                int *negative);
+
+int hederaTransactionGetHashCount (BRHederaTransaction transaction);
+BRHederaTransactionHash hederaTransactionGetHashAtIndex (BRHederaTransaction transaction, int index);
+void hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash);
+
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitCore/src/hedera/BRHederaWallet.c
+++ b/WalletKitCore/src/hedera/BRHederaWallet.c
@@ -20,7 +20,6 @@ struct BRHederaWalletRecord {
     BRHederaAccount account;
     BRHederaUnitTinyBar balance;
     BRHederaFeeBasis feeBasis;
-    BRArrayOf(BRHederaAddress)  nodes;
 
     BRArrayOf(BRHederaTransaction) transactions;
 
@@ -33,22 +32,6 @@ hederaWalletCreate (BRHederaAccount account)
     assert(account);
     BRHederaWallet wallet = calloc(1, sizeof(struct BRHederaWalletRecord));
     wallet->account = account;
-    // TODO - do we just hard code Hedera nodes here - we probably can for now
-    // but perhaps in the future there will be additional shards/realms
-    /*
-     {"0.0.3":"104.196.1.78:50211", "0.0.4": "35.245.250.134:50211",
-     "0.0.5":"34.68.209.35:50211", "0.0.6": "34.82.173.33:50211",
-     "0.0.7":"35.200.105.230:50211", "0.0.8": "35.203.87.206:50211",
-     "0.0.9":"35.189.221.159:50211", "0.0.10": "35.234.104.86:50211",
-     "0.0.11":"34.90.238.202:50211", "0.0.12": "35.228.11.53:50211",
-     "0.0.13":"35.234.132.107:50211", "0.0.14": "34.94.67.202:50211",
-     "0.0.15":"35.236.2.27:50211"}
-     */
-    array_new(wallet->nodes, HEDERA_NODE_COUNT);
-    // int64_t hedera_node_start = HEDERA_NODE_START;
-    for (int i = HEDERA_NODE_START; i < (HEDERA_NODE_COUNT + HEDERA_NODE_START); i++) {
-        array_add(wallet->nodes, hederaAddressCreate(0, 0, i));
-    }
 
     // Putting a '1' here avoids a 'false positive' in the Xcode leak instrument.
     array_new(wallet->transactions, 1);
@@ -64,10 +47,6 @@ extern void
 hederaWalletFree (BRHederaWallet wallet)
 {
     assert(wallet);
-    for (int i = 0; i < array_count(wallet->nodes); i++) {
-        hederaAddressFree(wallet->nodes[i]);
-    }
-    array_free(wallet->nodes);
 
     // Transactions owned elsewhere, it seems.  Therefore, free the array, not the contents.
     array_free (wallet->transactions);
@@ -137,18 +116,6 @@ hederaWalletGetBalanceLimit (BRHederaWallet wallet,
 
     *hasLimit = !asMaximum;
     return (asMaximum ? 0 : HEDERA_WALLET_MINIMUM_BALANCE_TINY_BAR);
-}
-
-extern BRHederaAddress
-hederaWalletGetNodeAddress(BRHederaWallet wallet)
-{
-    static unsigned index = 0;
-    assert(wallet);
-    if (index > HEDERA_NODE_COUNT - 1) {
-        index = 0;
-    }
-    BRHederaAddress node = wallet->nodes[index++];
-    return hederaAddressClone(node);
 }
 
 extern void

--- a/WalletKitCore/src/hedera/BRHederaWallet.h
+++ b/WalletKitCore/src/hedera/BRHederaWallet.h
@@ -20,9 +20,6 @@
 extern "C" {
 #endif
 
-#define HEDERA_NODE_COUNT 10
-#define HEDERA_NODE_START 3
-
 typedef struct BRHederaWalletRecord *BRHederaWallet;
 
 /**
@@ -103,9 +100,6 @@ extern BRHederaUnitTinyBar
 hederaWalletGetBalanceLimit (BRHederaWallet wallet,
                              int asMaximum,
                              int *hasLimit);
-
-extern BRHederaAddress /* Caller must free address using hederaAddressFree */
-hederaWalletGetNodeAddress(BRHederaWallet wallet);
 
 /**
  * Set the ripple fee basis default amount


### PR DESCRIPTION
In Core Hedera - create a serialization for 10 nodes (3-12) along
with the corresponding signature.

- Create mutlitple serializations - 1 for each Hedera node
- Save the differennt hashes in an array
- Create functions to allow finding a transaction with multiple hashes
- Create functions to allow updating the transaction with the appropriate hash
- use an empty hash (pending) until we get the real one from blockset
- clean up the code, fix any compare issues
- When returning the serialized bytes - return a copy
- remove unneeded code
- allow for the creation of both the V0 and V1 Hedera serialization