### PR TITLE
CORE-968: In Ethereum, handle Blockset transaction error state for included txns

### DIFF
--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
@@ -42,7 +42,7 @@ cryptoTransferDeriveStateETH (BREthereumTransactionStatus status,
                                                     status.u.included.transactionIndex,
                                                     status.u.included.blockTimestamp,
                                                     cryptoFeeBasisTake (feeBasis),
-                                                    CRYPTO_TRUE,
+                                                    AS_CRYPTO_BOOLEAN (status.u.included.success),
                                                     NULL);
             break;
 

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerP2PETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerP2PETH.c
@@ -196,6 +196,9 @@ ewmHandleTransactionOriginatingLog (BRCryptoWalletManagerETH manager,
         for (size_t tid = 0; tid < array_count(wallet->transfers); tid++) {
 
             BRCryptoTransferETH thatTransferETH = cryptoTransferCoerceETH (wallet->transfers[tid]);
+            
+            // submitted transfers have the originating transaction assigned on construction
+            if (NULL != thatTransferETH->originatingTransaction) continue;
 
             BREthereumHash thatHash;
             switch (thatTransferETH->basis.type) {

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
@@ -20,7 +20,8 @@
 #define fileServiceTypeTransactions "transactions"
 
 enum {
-    EWM_TRANSACTION_VERSION_1
+    EWM_TRANSACTION_VERSION_1,
+    EWM_TRANSACTION_VERSION_2
 };
 
 static UInt256
@@ -467,11 +468,11 @@ static BRFileServiceTypeSpecification fileServiceSpecificationsArrayETH[] = {
 
     {
         fileServiceTypeTransactions,
-        EWM_TRANSACTION_VERSION_1,
+        EWM_TRANSACTION_VERSION_2,
         1,
         {
             {
-                EWM_TRANSACTION_VERSION_1,
+                EWM_TRANSACTION_VERSION_2,
                 fileServiceTypeTransactionV1Identifier,
                 fileServiceTypeTransactionV1Reader,
                 fileServiceTypeTransactionV1Writer

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerPersistETH.c
@@ -20,8 +20,7 @@
 #define fileServiceTypeTransactions "transactions"
 
 enum {
-    EWM_TRANSACTION_VERSION_1,
-    EWM_TRANSACTION_VERSION_2
+    EWM_TRANSACTION_VERSION_1
 };
 
 static UInt256
@@ -468,11 +467,11 @@ static BRFileServiceTypeSpecification fileServiceSpecificationsArrayETH[] = {
 
     {
         fileServiceTypeTransactions,
-        EWM_TRANSACTION_VERSION_2,
+        EWM_TRANSACTION_VERSION_1,
         1,
         {
             {
-                EWM_TRANSACTION_VERSION_2,
+                EWM_TRANSACTION_VERSION_1,
                 fileServiceTypeTransactionV1Identifier,
                 fileServiceTypeTransactionV1Reader,
                 fileServiceTypeTransactionV1Writer

--- a/WalletKitCore/src/ethereum/bcs/BREthereumBCS.c
+++ b/WalletKitCore/src/ethereum/bcs/BREthereumBCS.c
@@ -1551,7 +1551,8 @@ bcsHandleBlockBody (BREthereumBCS bcs,
                                                                       blockGetNumber(block),
                                                                       i,
                                                                       blockGetTimestamp(block),
-                                                                      transactionGetGasLimit(tx)));
+                                                                      transactionGetGasLimit(tx),
+                                                                      1));
 
             if (NULL == neededTransactions) array_new (neededTransactions, 3);
             array_add(neededTransactions, tx);
@@ -1770,7 +1771,8 @@ bcsHandleTransactionReceipts (BREthereumBCS bcs,
                                                                         blockGetNumber(block),
                                                                         ti,
                                                                         blockGetTimestamp(block),
-                                                                        ethGasCreate(0)));
+                                                                        ethGasCreate(0),
+                                                                        1));
                     
                     if (NULL == neededLogs) array_new(neededLogs, 3);
                     array_add(neededLogs, log);

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
@@ -186,9 +186,12 @@ transactionStatusRLPDecode (BRRlpItem item,
             size_t othersCount;
             const BRRlpItem *others = rlpDecodeList(coder, items[1], &othersCount);
 
-            // The 'encode' function produces '5' others; however, for consistency with delivered
-            // code with an existing archival value, we keep '3' around.
-            assert (6 == othersCount || 3 == othersCount);
+            // The 'encode' function provides '6' others.  However, the value of others has
+            // varied over time:
+            //   3: baseline
+            //   5: Add - included timestamp and included gasUsed
+            //   6: Add - included success
+            assert (6 == othersCount || 5 == othersCount || 3 == othersCount);
 
             return transactionStatusCreateIncluded (ethHashRlpDecode(others[0], coder),
                                                     rlpDecodeUInt64(coder, others[1], 0),
@@ -199,7 +202,9 @@ transactionStatusRLPDecode (BRRlpItem item,
                                                     (3 == othersCount
                                                      ? ethGasCreate(0)
                                                      : ethGasRlpDecode(others[4], coder)),
-                                                    rlpDecodeUInt64(coder, others[5], 0));
+                                                    (3 == othersCount || 5 == othersCount
+                                                     ? 1
+                                                     : rlpDecodeUInt64(coder, others[5], 0)));
         }
         
         case TRANSACTION_STATUS_ERRORED: {

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.c
@@ -55,14 +55,16 @@ transactionStatusCreateIncluded (BREthereumHash blockHash,
                                  uint64_t blockNumber,
                                  uint64_t transactionIndex,
                                  uint64_t blockTimestamp,
-                                 BREthereumGas gasUsed) {
+                                 BREthereumGas gasUsed,
+                                 uint64_t success) {
     return (BREthereumTransactionStatus) {
         TRANSACTION_STATUS_INCLUDED,
         blockHash,
         blockNumber,
         transactionIndex,
         blockTimestamp,
-        gasUsed
+        gasUsed,
+        success
     };
 }
 
@@ -186,7 +188,7 @@ transactionStatusRLPDecode (BRRlpItem item,
 
             // The 'encode' function produces '5' others; however, for consistency with delivered
             // code with an existing archival value, we keep '3' around.
-            assert (5 == othersCount || 3 == othersCount);
+            assert (6 == othersCount || 3 == othersCount);
 
             return transactionStatusCreateIncluded (ethHashRlpDecode(others[0], coder),
                                                     rlpDecodeUInt64(coder, others[1], 0),
@@ -196,7 +198,8 @@ transactionStatusRLPDecode (BRRlpItem item,
                                                      : rlpDecodeUInt64(coder, others[3], 0)),
                                                     (3 == othersCount
                                                      ? ethGasCreate(0)
-                                                     : ethGasRlpDecode(others[4], coder)));
+                                                     : ethGasRlpDecode(others[4], coder)),
+                                                    rlpDecodeUInt64(coder, others[5], 0));
         }
         
         case TRANSACTION_STATUS_ERRORED: {
@@ -225,12 +228,13 @@ transactionStatusRLPEncode (BREthereumTransactionStatus status,
             break;
 
         case TRANSACTION_STATUS_INCLUDED:
-            items[1] = rlpEncodeList (coder, 5,
+            items[1] = rlpEncodeList (coder, 6,
                                       ethHashRlpEncode(status.u.included.blockHash, coder),
                                       rlpEncodeUInt64(coder, status.u.included.blockNumber, 0),
                                       rlpEncodeUInt64(coder, status.u.included.transactionIndex, 0),
                                       rlpEncodeUInt64(coder, status.u.included.blockTimestamp, 0),
-                                      ethGasRlpEncode(status.u.included.gasUsed, coder));
+                                      ethGasRlpEncode(status.u.included.gasUsed, coder),
+                                      rlpEncodeUInt64(coder, status.u.included.success, 0));
             items[2] = rlpEncodeString(coder, "");
 
             break;

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.h
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransactionStatus.h
@@ -92,6 +92,7 @@ typedef struct BREthereumTransactionStatusLESRecord {
             uint64_t transactionIndex;
             uint64_t blockTimestamp;
             BREthereumGas gasUsed;      // Internal
+            uint64_t success; // 1 = success, 0 = included w/ error
         } included;
 
         struct {
@@ -111,7 +112,8 @@ transactionStatusCreateIncluded (BREthereumHash blockHash,
                                  uint64_t blockNumber,
                                  uint64_t transactionIndex,
                                  uint64_t blockTimestamp,
-                                 BREthereumGas gasUsed);
+                                 BREthereumGas gasUsed,
+                                 uint64_t success);
 
 extern BREthereumTransactionStatus
 transactionStatusCreateErrored (BREthereumTransactionErrorType type,

--- a/WalletKitCore/src/ethereum/les/BREthereumProvision.c
+++ b/WalletKitCore/src/ethereum/les/BREthereumProvision.c
@@ -940,7 +940,8 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                                                      outputs[index].u.transactionIndex.blockNumber,
                                                      outputs[index].u.transactionIndex.transactionIndex,
                                                      TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN,
-                                                     ethGasCreate(0));
+                                                     ethGasCreate(0),
+                                                     1);
 
                 }
             }
@@ -966,7 +967,8 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                                                      outputs[0].u.transactionIndex.blockNumber,
                                                      outputs[0].u.transactionIndex.transactionIndex,
                                                      TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN,
-                                                     ethGasCreate (0));
+                                                     ethGasCreate (0),
+                                                     1);
                     break;
 
                 default:


### PR DESCRIPTION
Added success state to `BREthereumTransactionStatus`, modifies persistent storage encoding.