### PR TITLE
CORE-1094: Encode BRCryptoHash in the native Blockchain format (no '0x' prefix for BTC)

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoHash.c
+++ b/WalletKitCore/src/crypto/BRCryptoHash.c
@@ -64,12 +64,12 @@ _cryptoHashAddPrefix (char *hash, int freeHash) {
 }
 
 private_extern OwnershipGiven char *
-cryptoHashStringAsHex (BRCryptoHash hash) {
+cryptoHashStringAsHex (BRCryptoHash hash, bool includePrefix) {
     size_t stringLength = 2 * hash->bytesCount + 1;
     char string [stringLength];
 
     hexEncode (string, stringLength, hash->bytes, hash->bytesCount);
-    return _cryptoHashAddPrefix (string, 0);
+    return (includePrefix ? _cryptoHashAddPrefix (string, 0) : strdup (string));
 }
 
 extern int

--- a/WalletKitCore/src/crypto/BRCryptoHashP.h
+++ b/WalletKitCore/src/crypto/BRCryptoHashP.h
@@ -40,8 +40,7 @@ cryptoHashCreateInternal (uint32_t setValue,
                           BRCryptoBlockChainType type);
 
 private_extern OwnershipGiven char *
-cryptoHashStringAsHex (BRCryptoHash hash);
-
+cryptoHashStringAsHex (BRCryptoHash hash, bool includePrefix);
 
 #ifdef __cplusplus
 }

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoNetworkBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoNetworkBTC.c
@@ -199,7 +199,7 @@ cryptoNetworkCreateHashFromStringBTC (BRCryptoNetwork network,
 
 static char *
 cryptoNetworkEncodeHashBTC (BRCryptoHash hash) {
-    return cryptoHashStringAsHex (hash);
+    return cryptoHashStringAsHex (hash, false);
 }
 
 // MARK: - Network Fee

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
@@ -156,7 +156,7 @@ cryptoNetworkCreateHashFromStringETH (BRCryptoNetwork network,
 
 static char *
 cryptoNetworkEncodeHashETH (BRCryptoHash hash) {
-    return cryptoHashStringAsHex (hash);
+    return cryptoHashStringAsHex (hash, true);
 }
 
 // MARK: -

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoNetworkHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoNetworkHBAR.c
@@ -135,7 +135,7 @@ cryptoNetworkCreateHashFromStringHBAR (BRCryptoNetwork network,
 
 static char *
 cryptoNetworkEncodeHashHBAR (BRCryptoHash hash) {
-    return cryptoHashStringAsHex (hash);
+    return cryptoHashStringAsHex (hash, false);
 }
 
 // MARK: -

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoNetworkXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoNetworkXRP.c
@@ -123,7 +123,7 @@ cryptoNetworkCreateHashFromStringXRP (BRCryptoNetwork network,
 
 static char *
 cryptoNetworkEncodeHashXRP (BRCryptoHash hash) {
-    return cryptoHashStringAsHex (hash);
+    return cryptoHashStringAsHex (hash, false);
 }
 
 // MARK: - Handlers

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoNetworkXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoNetworkXTZ.c
@@ -127,6 +127,8 @@ cryptoNetworkCreateHashFromStringXTZ (BRCryptoNetwork network,
 static char *
 cryptoNetworkEncodeHashXTZ (BRCryptoHash hash) {
     size_t len = BRBase58CheckEncode (NULL, 0, hash->bytes, TEZOS_HASH_BYTES);
+    if (0 == len) return NULL;
+
     char * string = calloc (1, len);
     BRBase58CheckEncode (string, len, hash->bytes, TEZOS_HASH_BYTES);
     return string;


### PR DESCRIPTION
'finally' some would say.