### PR TITLE
CORE-1081: Handle `POST /transactions` HTTP JSON Response

### DIFF
--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -127,12 +127,12 @@ typedef void
                                             OwnershipGiven BRCryptoWalletManager manager,
                                             OwnershipGiven BRCryptoClientCallbackState callbackState,
                                             OwnershipKept const uint8_t *transaction,
-                                            size_t transactionLength,
-                                            OwnershipKept const char *hashAsHex);
+                                            size_t transactionLength);
 
 extern void
 cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
                            OwnershipGiven BRCryptoClientCallbackState callbackState,
+                           OwnershipKept const char *hash,
                            BRCryptoBoolean success);
 
 // MARK: - Estimate Transaction Fee
@@ -149,7 +149,6 @@ extern void
 cwmAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
                                    OwnershipGiven BRCryptoClientCallbackState callbackState,
                                    BRCryptoBoolean success,
-                                   OwnershipKept const char *hash,
                                    uint64_t costUnits,
                                    size_t attributesCount,
                                    OwnershipKept const char **attributeKeys,

--- a/WalletKitCore/include/BRCryptoTransfer.h
+++ b/WalletKitCore/include/BRCryptoTransfer.h
@@ -150,9 +150,12 @@ extern "C" {
 
     /**
      * Returns the transfer's hash.  This is the unique identifier for this transfer on the
-     * associated network's blockchain.
+     * associated network's blockchain.  This value may be NULL; notably before a Transfer is
+     * signed; and, in the case of HBAR, before it is successfully submitted (the HBAR hash depends
+     * on the HBAR node handling the Transfer).
      *
-     * @note: Uniqueness is TBD for Ethereum TOKEN transfers
+     * @note: Uniqueness is TBD for Ethereum TOKEN transfers.  One should expect all Transfers
+     * in a Wallet to have a unique hash.
      *
      * @param transfer the transfer
      *
@@ -160,6 +163,10 @@ extern "C" {
      */
     extern BRCryptoHash
     cryptoTransferGetHash (BRCryptoTransfer transfer);
+
+    extern BRCryptoBoolean
+    cryptoTransferSetHash (BRCryptoTransfer transfer,
+                           OwnershipKept BRCryptoHash hash);
 
     extern BRCryptoUnit
     cryptoTransferGetUnitForAmount (BRCryptoTransfer transfer);

--- a/WalletKitCore/include/event/BRCryptoTransfer.h
+++ b/WalletKitCore/include/event/BRCryptoTransfer.h
@@ -117,8 +117,13 @@ extern "C" {
         CRYPTO_TRANSFER_EVENT_CREATED,
 
         /// Signaled when a transfer's state change - such as when the state transitions from
-        /// SUBMITTED to INCLUDED.
+        /// SUBMITTED to INCLUDED.  Also signaled if the hash changes; which only applies to
+        /// HBAR and only when the transfer is submitted (the HBAR hash depends on what node
+        /// processes the transaction).
         CRYPTO_TRANSFER_EVENT_CHANGED,
+
+        /// For some transfers, the hash is determined when the transfer is signed and submitted.
+        /// CRYPTO_TRANSFER_EVENT_UPDATED_HASH,
 
         /// Signaled when a transfer is deleted; the transfer must not be 'dereferenced' and thus
         /// the pointer value can be used.  Surely the transfer's memory will be gone by the time

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -189,7 +189,6 @@ struct BRCryptoClientCallbackStateRecord {
         struct {
             BRCryptoWallet wallet;
             BRCryptoTransfer transfer;
-            BRCryptoHash hash;
         } submitTransaction;
 
         struct {

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -310,10 +310,15 @@ cryptoTransferGetDirection (BRCryptoTransfer transfer) {
     return transfer->direction;
 }
 
-
 extern BRCryptoHash
 cryptoTransferGetHash (BRCryptoTransfer transfer) {
     return transfer->handlers->getHash (transfer);
+}
+
+extern BRCryptoBoolean
+cryptoTransferSetHash (BRCryptoTransfer transfer,
+                       OwnershipKept BRCryptoHash hash) {
+    return AS_CRYPTO_BOOLEAN (NULL != transfer->handlers->setHash && transfer->handlers->setHash (transfer, hash));
 }
 
 extern BRCryptoFeeBasis

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -46,6 +46,10 @@ typedef void
 typedef BRCryptoHash
 (*BRCryptoTransferGetHashHandler) (BRCryptoTransfer transfer);
 
+typedef int // 1 if changed; 0 if not
+(*BRCryptoTransferSetHashHandler) (BRCryptoTransfer transfer,
+                                   BRCryptoHash hash);
+
 typedef uint8_t *
 (*BRCryptoTransferSerializeHandler) (BRCryptoTransfer transfer,
                                      BRCryptoNetwork  network,
@@ -64,6 +68,7 @@ typedef int // 1 if equal, 0 if not
 typedef struct {
     BRCryptoTransferReleaseHandler release;
     BRCryptoTransferGetHashHandler getHash;
+    BRCryptoTransferSetHashHandler setHash;
     BRCryptoTransferSerializeHandler serialize;
     BRCryptoTransferGetBytesForFeeEstimateHandler getBytesForFeeEstimate;
     BRCryptoTransferIsEqualHandler isEqual;

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
@@ -299,6 +299,7 @@ cryptoTransferDirectionFromBTC (uint64_t send, uint64_t recv, uint64_t fee) {
 BRCryptoTransferHandlers cryptoTransferHandlersBTC = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
+    NULL, // setHash
     cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC
@@ -307,6 +308,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersBTC = {
 BRCryptoTransferHandlers cryptoTransferHandlersBCH = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
+    NULL, // setHash
     cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC
@@ -315,7 +317,8 @@ BRCryptoTransferHandlers cryptoTransferHandlersBCH = {
 BRCryptoTransferHandlers cryptoTransferHandlersBSV = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
-    cryptoTransferSerializeBTC,
+    NULL, // setHash
+   cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC
 };

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
@@ -454,6 +454,7 @@ cryptoTransferEqualAsETH (BRCryptoTransfer tb1, BRCryptoTransfer tb2) {
 BRCryptoTransferHandlers cryptoTransferHandlersETH = {
     cryptoTransferReleaseETH,
     cryptoTransferGetHashETH,
+    NULL, // setHash
     cryptoTransferSerializeETH,
     cryptoTransferGetBytesForFeeEstimateETH,
     cryptoTransferEqualAsETH

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoHBAR.h
@@ -86,6 +86,9 @@ cryptoHashCreateAsHBAR (BRHederaTransactionHash hash);
 private_extern BRHederaTransactionHash
 hederaHashCreateFromString (const char *string);
 
+private_extern BRHederaTransactionHash
+cryptoHashAsHBAR (BRCryptoHash hash);
+
 // MARK: - Wallet Manager
 
 typedef struct BRCryptoWalletManagerHBARRecord {

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoSupportHBAR.c
@@ -43,6 +43,14 @@ hederaHashCreateFromString (const char *string) {
     return hash;
 }
 
+private_extern BRHederaTransactionHash
+cryptoHashAsHBAR (BRCryptoHash hash) {
+    assert (48 == hash->bytesCount);
+    BRHederaTransactionHash hbarHash;
+    memcpy (hbarHash.bytes, hash->bytes, hash->bytesCount);
+    return hbarHash;
+}
+
 // MARK: -
 
 static const char *knownMemoRequiringAddresses[] = {

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -95,6 +95,15 @@ cryptoTransferGetHashHBAR (BRCryptoTransfer transfer) {
     return cryptoHashCreateAsHBAR (hash);
 }
 
+extern int
+cryptoTransferSetHashHBAR (BRCryptoTransfer transfer,
+                           BRCryptoHash hash) {
+    BRCryptoTransferHBAR transferHBAR = cryptoTransferCoerceHBAR(transfer);
+    BRHederaTransactionHash hashHBAR  = cryptoHashAsHBAR(hash);
+
+    return hederaTransactionUpdateHash (transferHBAR->hbarTransaction, hashHBAR);
+}
+
 static uint8_t *
 cryptoTransferSerializeHBAR (BRCryptoTransfer transfer,
                              BRCryptoNetwork network,
@@ -140,6 +149,7 @@ transferGetDirectionFromHBAR (BRHederaTransaction transaction,
 BRCryptoTransferHandlers cryptoTransferHandlersHBAR = {
     cryptoTransferReleaseHBAR,
     cryptoTransferGetHashHBAR,
+    cryptoTransferSetHashHBAR,
     cryptoTransferSerializeHBAR,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualHBAR

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -102,11 +102,9 @@ cryptoWalletManagerSignTransactionWithSeedHBAR (BRCryptoWalletManager manager,
     BRHederaAccount account = cryptoAccountAsHBAR (manager->account);
     BRKey publicKey = hederaAccountGetPublicKey (account);
     BRHederaTransaction transaction = cryptoTransferCoerceHBAR(transfer)->hbarTransaction;
-#if !defined(MULTI_HEDERA_SERIALIZATION)
-    BRHederaAddress nodeAddress = hederaAccountGetNodeAddress(account);
-#else
+    // BRHederaAddress nodeAddress = hederaAccountGetNodeAddress(account);
     BRHederaAddress nodeAddress = NULL;
-#endif
+
     size_t tx_size = hederaTransactionSignTransaction (transaction, publicKey, seed, nodeAddress);
 
     if (nodeAddress) hederaAddressFree(nodeAddress);

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -153,6 +153,7 @@ transferGetDirectionFromXRP (BRRippleTransaction transaction,
 BRCryptoTransferHandlers cryptoTransferHandlersXRP = {
     cryptoTransferReleaseXRP,
     cryptoTransferGetHashXRP,
+    NULL, // setHash
     cryptoTransferSerializeXRP,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualXRP

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
@@ -146,6 +146,7 @@ transferGetDirectionFromXTZ (BRTezosTransfer transfer,
 BRCryptoTransferHandlers cryptoTransferHandlersXTZ = {
     cryptoTransferReleaseXTZ,
     cryptoTransferGetHashXTZ,
+    NULL, // setHash
     cryptoTransferSerializeXTZ,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualXTZ

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -29,7 +29,6 @@ static uint16_t numNodes = sizeof(nodes) / sizeof(uint16_t);
 // Forward declarations
 int hederaTransactionGetHashCount (BRHederaTransaction transaction);
 BRHederaTransactionHash hederaTransactionGetHashAtIndex (BRHederaTransaction transaction, int index);
-void hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash);
 
 struct BRHederaTransactionRecord {
     BRHederaAddress source;
@@ -627,7 +626,7 @@ BRHederaTransactionHash hederaTransactionGetHashAtIndex (BRHederaTransaction tra
     }
 }
 
-void hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash) {
+extern int hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash) {
     assert(transaction);
     // The hash updating ONLY happens once when we have a SENT transaction waiting to find
     // out which hash was used when submitting - so if we don't have multiple hashes then ignore
@@ -651,8 +650,9 @@ void hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTrans
                     transaction->serializedBytes = NULL;
                     transaction->serializedSize = 0;
                 }
-                return; // Found it - updated - cleaned up - DONE
+                return 1; // Found it - updated - cleaned up - DONE
             }
         }
     }
+    return 0;
 }

--- a/WalletKitCore/src/hedera/BRHederaTransaction.h
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.h
@@ -127,6 +127,9 @@ extern int hederaTransactionHasTarget (BRHederaTransaction tranaction, BRHederaA
 extern BRHederaUnitTinyBar hederaTransactionGetAmountDirected (BRHederaTransaction transfer,
                                                                BRHederaAddress address,
                                                                int *negative);
+
+extern int hederaTransactionUpdateHash (BRHederaTransaction transaction, BRHederaTransactionHash hash);
+
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -381,7 +381,7 @@ public final class CryptoLibraryDirect {
     public static native void cryptoClientCurrencyBundleRelease (Pointer currencyBundle);
 
     public static native void cwmAnnounceBlockNumber(Pointer cwm, Pointer callbackState, int success, long blockNumber, String verifiedBlockHash);
-    public static native void cwmAnnounceSubmitTransfer(Pointer cwm, Pointer callbackState, int success);
+    public static native void cwmAnnounceSubmitTransfer(Pointer cwm, Pointer callbackState, String hash, int success);
 
     //
     // Crypto Primitives

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -52,7 +52,6 @@ public final class CryptoLibraryIndirect {
     public static void cwmAnnounceEstimateTransactionFee(Pointer cwm,
                                                          Pointer callbackState,
                                                          int success,
-                                                         String hash,
                                                          long costUnits,
                                                          SizeT attributesCount,
                                                          String[] attributeKeys,
@@ -61,7 +60,6 @@ public final class CryptoLibraryIndirect {
         attributeVals = attributeVals.length == 0 ? null : attributeVals;
 
         INSTANCE.cwmAnnounceEstimateTransactionFee(cwm, callbackState, success,
-                hash,
                 costUnits,
                 attributesCount,
                 attributeKeys,
@@ -192,7 +190,6 @@ public final class CryptoLibraryIndirect {
         void cwmAnnounceEstimateTransactionFee(Pointer cwm,
                                                Pointer callbackState,
                                                int success,
-                                               String hash,
                                                long costUnits,
                                                SizeT attributesCount,
                                                String[] attributeKeys,

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClient.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClient.java
@@ -55,8 +55,7 @@ public class BRCryptoClient extends Structure {
                       Pointer manager,
                       Pointer callbackState,
                       Pointer tx,
-                      SizeT txLength,
-                      String hashAsHex);
+                      SizeT txLength);
     }
 
     public interface BRCryptoClientEstimateTransactionFeeCallback extends Callback {
@@ -64,8 +63,7 @@ public class BRCryptoClient extends Structure {
                       Pointer manager,
                       Pointer callbackState,
                       Pointer tx,
-                      SizeT txLength,
-                      String hashAsHex);
+                      SizeT txLength);
     }
 
     //
@@ -155,22 +153,19 @@ public class BRCryptoClient extends Structure {
         void handle(Cookie context,
                     BRCryptoWalletManager manager,
                     BRCryptoClientCallbackState callbackState,
-                    byte[] transaction,
-                    String hashAsHex);
+                    byte[] transaction);
 
         @Override
         default void callback(Pointer context,
                               Pointer manager,
                               Pointer callbackState,
                               Pointer tx,
-                              SizeT txLength,
-                              String hashAsHex) {
+                              SizeT txLength) {
             handle(
                     new Cookie(context),
                     new BRCryptoWalletManager(manager),
                     new BRCryptoClientCallbackState(callbackState),
-                    tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue())),
-                    hashAsHex
+                    tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue()))
             );
         }
     }
@@ -179,22 +174,19 @@ public class BRCryptoClient extends Structure {
         void handle(Cookie context,
                     BRCryptoWalletManager manager,
                     BRCryptoClientCallbackState callbackState,
-                    byte[] transaction,
-                    String hashAsHex);
+                    byte[] transaction);
 
         @Override
         default void callback(Pointer context,
                               Pointer manager,
                               Pointer callbackState,
                               Pointer tx,
-                              SizeT txLength,
-                              String hashAsHex) {
+                              SizeT txLength) {
             handle(
                     new Cookie(context),
                     new BRCryptoWalletManager(manager),
                     new BRCryptoClientCallbackState(callbackState),
-                    tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue())),
-                    hashAsHex
+                    tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue()))
             );
         }
     }

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -349,14 +349,15 @@ public class BRCryptoWalletManager extends PointerType {
                 new SizeT(bundlesCount));
     }
 
-    public void announceSubmitTransfer(BRCryptoClientCallbackState callbackState, boolean success) {
+    public void announceSubmitTransfer(BRCryptoClientCallbackState callbackState, String hash, boolean success) {
         CryptoLibraryDirect.cwmAnnounceSubmitTransfer (
                 this.getPointer(),
                 callbackState.getPointer(),
+                hash,
                 (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE));
     }
 
-     public void announceEstimateTransactionFee(BRCryptoClientCallbackState callbackState, boolean success, String hash, UnsignedLong costUnits, Map<String, String> meta) {
+     public void announceEstimateTransactionFee(BRCryptoClientCallbackState callbackState, boolean success, UnsignedLong costUnits, Map<String, String> meta) {
          int metaCount = meta.size();
          String[] metaKeys = meta.keySet().toArray(new String[metaCount]);
          String[] metaVals = meta.values().toArray(new String[metaCount]);
@@ -365,7 +366,6 @@ public class BRCryptoWalletManager extends PointerType {
                  this.getPointer(),
                  callbackState.getPointer(),
                  (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE),
-                 hash,
                  costUnits.longValue(),
                  new SizeT(metaCount),
                  metaKeys,

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -28,6 +28,7 @@ import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionCurrency;
 import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionEndpoint;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.bdb.TransactionFee;
+import com.breadwallet.crypto.blockchaindb.models.bdb.TransactionIdentifier;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transfer;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.primitives.UnsignedLong;
@@ -338,24 +339,20 @@ public class BlockchainDb {
     }
 
     public void createTransaction(String id,
-                                  String hashAsHex,
                                   byte[] tx,
-                                  CompletionHandler<Void, QueryError> handler) {
+                                  CompletionHandler<TransactionIdentifier, QueryError> handler) {
         transactionApi.createTransaction(
                 id,
-                hashAsHex,
                 tx,
                 handler
         );
     }
 
     public void estimateTransactionFee(String id,
-                                       String hashAsHex,
                                        byte[] tx,
                                        CompletionHandler<TransactionFee, QueryError> handler) {
         transactionApi.estimateTransactionFee(
                 id,
-                hashAsHex,
                 tx,
                 handler
         );

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
@@ -14,6 +14,7 @@ import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.errors.QueryJsonParseError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.bdb.TransactionFee;
+import com.breadwallet.crypto.blockchaindb.models.bdb.TransactionIdentifier;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableListMultimap;
@@ -95,19 +96,17 @@ public class TransactionApi {
     }
 
     public void createTransaction(String id,
-                                  String hashAsHex,
                                   byte[] tx,
-                                  CompletionHandler<Void, QueryError> handler) {
+                                  CompletionHandler<TransactionIdentifier, QueryError> handler) {
         Map json = ImmutableMap.of(
                 "blockchain_id", id,
-                "transaction_id", hashAsHex,
+                "transaction_id", "unknown",
                 "data", BaseEncoding.base64().encode(tx));
 
-        jsonClient.sendPost("transactions", ImmutableMultimap.of(), json, handler);
+        jsonClient.sendPost("transactions", ImmutableMultimap.of(), json, TransactionIdentifier.class, handler);
     }
 
     public void estimateTransactionFee(String id,
-                                  String hashAsHex,
                                   byte[] tx,
                                   CompletionHandler<TransactionFee, QueryError> handler) {
 
@@ -116,7 +115,7 @@ public class TransactionApi {
 
         Map json = ImmutableMap.of(
                 "blockchain_id", id,
-                "transaction_id", hashAsHex,
+                "transaction_id", "unknown",
                 "data", BaseEncoding.base64().encode(tx));
 
         jsonClient.sendPost("transactions", params, json, TransactionFee.class, handler);

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/TransactionIdentifier.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/TransactionIdentifier.java
@@ -1,0 +1,67 @@
+package com.breadwallet.crypto.blockchaindb.models.bdb;
+
+import android.support.annotation.Nullable;
+
+import com.breadwallet.crypto.blockchaindb.models.Utilities;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.google.common.primitives.UnsignedLong;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class TransactionIdentifier {
+    // creator
+
+    @JsonCreator
+    public static com.breadwallet.crypto.blockchaindb.models.bdb.TransactionIdentifier create(@JsonProperty("transaction_id") String transactionId,
+                                                                                              @JsonProperty("identifier") String identifier,
+                                                                                              @JsonProperty("hash") String hash,
+                                                                                              @JsonProperty("blockchain_id") String blockchainId) {
+        return new com.breadwallet.crypto.blockchaindb.models.bdb.TransactionIdentifier(
+                checkNotNull(transactionId),
+                checkNotNull(identifier),
+                checkNotNull(hash),
+                checkNotNull(blockchainId)
+        );
+    }
+
+    // fields
+
+    private final String transactionId;
+    private final String identifier;
+    private final String hash;
+    private final String blockchainId;
+
+    private TransactionIdentifier(String transactionId,
+                                  String identifier,
+                                  String hash,
+                                  String blockchainId) {
+        this.transactionId = transactionId;
+        this.identifier = identifier;
+        this.hash = hash;
+        this.blockchainId = blockchainId;
+    }
+    // getters
+
+    @JsonProperty("transaction_id")
+    public String getId() {
+        return transactionId;
+    }
+
+    @JsonProperty("identifier")
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @JsonProperty("hash")
+    public String getHash() {
+        return hash;
+    }
+
+    @JsonProperty("blockchain_id")
+    public String getBlockchainId() {
+        return blockchainId;
+    }
+}

--- a/WalletKitSwift/WalletKit/BRCryptoClient.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoClient.swift
@@ -129,7 +129,49 @@ public protocol SystemClient {
         acknowledgements: UInt64,
         metaData: Dictionary<String,String>?
     )
-    
+
+    typealias TransactionIdentifier = (
+        id: String,
+        blockchainId: String,
+        hash: String,
+        identifier: String
+    )
+
+    /*
+    {
+        "status":422,
+        "error":"Unprocessable Entity",
+        "path":"/transactions",
+        "timestamp":"2021-01-19T16:30:05.040+00:00",
+        "message":"Ripple submit failed",
+        "submit_status":"nonce_already_used",
+        "network_status":"tefPAST_SEQ",
+        "network_message":"This sequence number has already passed.",
+        "parameters":{
+            "transaction_resource": {
+                "transaction_id":"ABCD",
+                "blockchain_id":"ripple-mainnet",
+                "confirmations":0,
+                "index":0,
+                "status":"rejected",
+                "layers":{},
+                "links":[]}
+            }
+        }
+    }
+
+    {
+        "transaction_id":"hedera-mainnet:0.0.89650-1610738946-000879142",
+        "identifier":"0.0.89650-1610738946-000879142",
+        "hash":"a3100a93b21c3f07c803587f08ee92827b18e1448cfb73a0470bf62b55e9ff186f8f8a3c2776c6dc8836c6c9e9bba95d",
+        "blockchain_id":"hedera-mainnet",
+        "confirmations":0,
+        "index":0,
+        "status":"submitted",
+        "layers":{}
+    }
+ */
+
     func getTransactions (blockchainId: String,
                           addresses: [String],
                           begBlockNumber: UInt64?,
@@ -146,9 +188,8 @@ public protocol SystemClient {
                          completion: @escaping (Result<Transaction, SystemClientError>) -> Void)
     
     func createTransaction (blockchainId: String,
-                            hashAsHex: String,
                             transaction: Data,
-                            completion: @escaping (Result<Void, SystemClientError>) -> Void)
+                            completion: @escaping (Result<TransactionIdentifier, SystemClientError>) -> Void)
     
     
     // Transaction Fee
@@ -159,7 +200,6 @@ public protocol SystemClient {
     )
     
     func estimateTransactionFee (blockchainId: String,
-                                 hashAsHex: String,
                                  transaction: Data,
                                  completion: @escaping (Result<TransactionFee, SystemClientError>) -> Void)
     

--- a/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
@@ -93,7 +93,7 @@ public final class Transfer: Equatable {
         else { return nil }
     }
 
-    /// An optional hash
+    /// An optional hash.  This only exists if the TransferState is .included or .submitted
     public var hash: TransferHash? {
         return cryptoTransferGetHash (core)
             .map { TransferHash (core: $0, take: false) }


### PR DESCRIPTION
Note: the `POST /transactions` JSON for "transaction_id" is now uniformly passed as "unknown" rather than as "hashAsHex"; thus `hashAsHex` disappears from many interfaces.

Introduces SystemClient.TransactionIdentifier as ("transaction_id", "blockchain_id", "identifier", "hash")