### PR TITLE
CORE-1083: During fee estimation, ensure the `unit` reference count.

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoAmount.c
+++ b/WalletKitCore/src/crypto/BRCryptoAmount.c
@@ -29,7 +29,7 @@ struct BRCryptoAmountRecord {
 
 IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoAmount, cryptoAmount);
 
-private_extern BRCryptoAmount
+static BRCryptoAmount
 cryptoAmountCreateInternal (BRCryptoUnit unit,
                             BRCryptoBoolean isNegative,
                             UInt256 value,

--- a/WalletKitCore/src/crypto/BRCryptoAmountP.h
+++ b/WalletKitCore/src/crypto/BRCryptoAmountP.h
@@ -23,12 +23,6 @@ cryptoAmountCreate (BRCryptoUnit unit,
                     BRCryptoBoolean isNegative,
                     UInt256 value);
 
-private_extern BRCryptoAmount
-cryptoAmountCreateInternal (BRCryptoUnit unit,
-                            BRCryptoBoolean isNegative,
-                            UInt256 value,
-                            int takeCurrency);
-
 private_extern UInt256
 cryptoAmountGetValue (BRCryptoAmount amount);
 

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletBTC.c
@@ -44,6 +44,8 @@ cryptoWalletCreateAsBTC (BRCryptoBlockChainType type,
                          BRCryptoUnit unit,
                          BRCryptoUnit unitForFee,
                          BRWallet *wid) {
+    BRCryptoAmount minBalance = cryptoAmountCreateInteger(0, unit);
+
     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsBTC (unitForFee,
                                                            CRYPTO_FEE_BASIS_BTC_FEE_UNKNOWN,
                                                            BRWalletFeePerKb(wid),
@@ -58,11 +60,13 @@ cryptoWalletCreateAsBTC (BRCryptoBlockChainType type,
                                                       listener,
                                                       unit,
                                                       unitForFee,
-                                                      cryptoAmountCreateInteger(0, unit),
+                                                      minBalance,
                                                       NULL,
                                                       feeBasis,
                                                       &contextBTC,
                                                       cryptoWalletCreateCallbackBTC);
+
+    cryptoAmountGive (minBalance);
     cryptoFeeBasisGive (feeBasis);
 
     return wallet;

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletSweeperBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletSweeperBTC.c
@@ -62,7 +62,7 @@ private_extern BRCryptoAmount
 cryptoWalletSweeperGetBalanceBTC (BRCryptoWalletSweeper sweeper) {
     BRCryptoWalletSweeperBTC sweeperBTC = cryptoWalletSweeperCoerce (sweeper);
     UInt256 value = uint256Create (BRWalletSweeperGetBalance (sweeperBTC));
-    return cryptoAmountCreateInternal(sweeper->unit, CRYPTO_FALSE, value, 0);
+    return cryptoAmountCreate (sweeper->unit, CRYPTO_FALSE, value);
 }
 
 private_extern BRCryptoWalletSweeperStatus

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoFeeBasisETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoFeeBasisETH.c
@@ -82,10 +82,7 @@ cryptoFeeBasisGetFeeETH (BRCryptoFeeBasis feeBasis) {
     
     return (overflow
             ? NULL
-            : cryptoAmountCreateInternal (feeBasis->unit,
-                                          CRYPTO_FALSE,
-                                          value,
-                                          1));
+            : cryptoAmountCreate (feeBasis->unit, CRYPTO_FALSE, value));
 }
 
 static BRCryptoBoolean

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -44,8 +44,11 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
                           BRHederaAccount hbarAccount) {
     int hasMinBalance;
     int hasMaxBalance;
-    BRHederaUnitTinyBar minBalance = hederaAccountGetBalanceLimit (hbarAccount, 0, &hasMinBalance);
-    BRHederaUnitTinyBar maxBalance = hederaAccountGetBalanceLimit (hbarAccount, 1, &hasMaxBalance);
+    BRHederaUnitTinyBar minBalanceHBAR = hederaAccountGetBalanceLimit (hbarAccount, 0, &hasMinBalance);
+    BRHederaUnitTinyBar maxBalanceHBAR = hederaAccountGetBalanceLimit (hbarAccount, 1, &hasMaxBalance);
+
+    BRCryptoAmount minBalance = hasMinBalance ? cryptoAmountCreateAsHBAR(unit, CRYPTO_FALSE, minBalanceHBAR) : NULL;
+    BRCryptoAmount maxBalance = hasMaxBalance ? cryptoAmountCreateAsHBAR(unit, CRYPTO_FALSE, maxBalanceHBAR) : NULL;
 
     BRHederaFeeBasis feeBasisHBAR = hederaAccountGetDefaultFeeBasis (hbarAccount);
     BRCryptoFeeBasis feeBasis     = cryptoFeeBasisCreateAsHBAR (unitForFee, feeBasisHBAR);
@@ -59,13 +62,16 @@ cryptoWalletCreateAsHBAR (BRCryptoWalletListener listener,
                                                       listener,
                                                       unit,
                                                       unitForFee,
-                                                      hasMinBalance ? cryptoAmountCreateAsHBAR(unit, CRYPTO_FALSE, minBalance) : NULL,
-                                                      hasMaxBalance ? cryptoAmountCreateAsHBAR(unit, CRYPTO_FALSE, maxBalance) : NULL,
+                                                      minBalance,
+                                                      maxBalance,
                                                       feeBasis,
                                                       &contextHBAR,
                                                       cryptoWalletCreateCallbackHBAR);
+
     cryptoFeeBasisGive(feeBasis);
-    
+    cryptoAmountGive (maxBalance);
+    cryptoAmountGive (minBalance);
+
     return wallet;
 }
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -157,10 +157,7 @@ cryptoWalletManagerEstimateLimitHBAR (BRCryptoWalletManager manager,
         cryptoAmountGive (newBalance);
     }
     
-    return cryptoAmountCreateInternal (unit,
-                                       CRYPTO_FALSE,
-                                       amount,
-                                       0);
+    return cryptoAmountCreate (unit, CRYPTO_FALSE, amount);
 }
 
 static BRCryptoFeeBasis

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -153,11 +153,8 @@ cryptoWalletManagerEstimateLimitXRP (BRCryptoWalletManager manager,
         cryptoAmountGive (fee);
         cryptoAmountGive (newBalance);
     }
-    
-    return cryptoAmountCreateInternal (unit,
-                                       CRYPTO_FALSE,
-                                       amount,
-                                       0);
+
+    return cryptoAmountCreate (unit, CRYPTO_FALSE, amount);
 }
 
 static BRCryptoFeeBasis

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -49,6 +49,9 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
     BRRippleUnitDrops minBalanceDrops = rippleAccountGetBalanceLimit (xrpAccount, 0, &hasMinBalance);
     BRRippleUnitDrops maxBalanceDrops = rippleAccountGetBalanceLimit (xrpAccount, 1, &hasMaxBalance);
 
+    BRCryptoAmount minBalance = hasMinBalance ? cryptoAmountCreateAsXRP(unit, CRYPTO_FALSE, minBalanceDrops) : NULL;
+    BRCryptoAmount maxBalance = hasMaxBalance ? cryptoAmountCreateAsXRP(unit, CRYPTO_FALSE, maxBalanceDrops) : NULL;
+
     BRRippleFeeBasis feeBasisXRP = rippleAccountGetDefaultFeeBasis (xrpAccount);
     BRCryptoFeeBasis feeBasis    = cryptoFeeBasisCreateAsXRP (unitForFee, feeBasisXRP.pricePerCostFactor);
 
@@ -61,12 +64,15 @@ cryptoWalletCreateAsXRP (BRCryptoWalletListener listener,
                                                       listener,
                                                       unit,
                                                       unitForFee,
-                                                      hasMinBalance ? cryptoAmountCreateAsXRP(unit, CRYPTO_FALSE, minBalanceDrops) : NULL,
-                                                      hasMaxBalance ? cryptoAmountCreateAsXRP(unit, CRYPTO_FALSE, maxBalanceDrops) : NULL,
+                                                      minBalance,
+                                                      maxBalance,
                                                       feeBasis,
                                                       &contextXRP,
                                                       cryptoWalletCreateCallbackXRP);
+
     cryptoFeeBasisGive(feeBasis);
+    cryptoAmountGive (maxBalance);
+    cryptoAmountGive (minBalance);
 
     return wallet;
 }

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -47,8 +47,11 @@ cryptoWalletCreateAsXTZ (BRCryptoWalletListener listener,
                          BRTezosAccount xtzAccount) {
     int hasMinBalance;
     int hasMaxBalance;
-    BRTezosUnitMutez minBalance = tezosAccountGetBalanceLimit (xtzAccount, 0, &hasMinBalance);
-    BRTezosUnitMutez maxBalance = tezosAccountGetBalanceLimit (xtzAccount, 1, &hasMaxBalance);
+    BRTezosUnitMutez minBalanceXTZ = tezosAccountGetBalanceLimit (xtzAccount, 0, &hasMinBalance);
+    BRTezosUnitMutez maxBalanceXTZ = tezosAccountGetBalanceLimit (xtzAccount, 1, &hasMaxBalance);
+
+    BRCryptoAmount minBalance = hasMinBalance ? cryptoAmountCreateAsXTZ(unit, CRYPTO_FALSE, minBalanceXTZ) : NULL;
+    BRCryptoAmount maxBalance = hasMaxBalance ? cryptoAmountCreateAsXTZ(unit, CRYPTO_FALSE, maxBalanceXTZ) : NULL;
 
     BRTezosFeeBasis feeBasisXTZ = tezosDefaultFeeBasis (TEZOS_DEFAULT_MUTEZ_PER_BYTE);
     BRCryptoFeeBasis feeBasis   = cryptoFeeBasisCreateAsXTZ (unitForFee, feeBasisXTZ);
@@ -62,12 +65,15 @@ cryptoWalletCreateAsXTZ (BRCryptoWalletListener listener,
                                                       listener,
                                                       unit,
                                                       unitForFee,
-                                                      hasMinBalance ? cryptoAmountCreateAsXTZ(unit, CRYPTO_FALSE, minBalance) : NULL,
-                                                      hasMaxBalance ? cryptoAmountCreateAsXTZ(unit, CRYPTO_FALSE, maxBalance) : NULL,
+                                                      minBalance,
+                                                      maxBalance,
                                                       feeBasis,
                                                       &contextXTZ,
                                                       cryptoWalletCreateCallbackXTZ);
+
     cryptoFeeBasisGive(feeBasis);
+    cryptoAmountGive (maxBalance);
+    cryptoAmountGive (minBalance);
 
     return wallet;
 }

--- a/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferCreateSendController.swift
@@ -132,7 +132,7 @@ UITextViewDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
 
             let unit = self.wallet.unit
             let amount = Amount.create (double: Double(value), unit: unit)
-            print ("APP: TVV: Submit \(self.isBitCurrency ? "BTC/BCH" : "ETH") Amount: \(amount)");
+            print ("APP: TVV: Submit Amount: \(amount)");
 
             guard let transferFeeBasis = self.feeBasis
                 else { self.submitTransferFailed ("no fee basis"); return }


### PR DESCRIPTION
This fixes a `cryptoUnitGive()` crash. But not the one observed in a 'Java Stress Test'

 In feeEstimation code, a 'take' was missed.  Essentially calls like:
`cryptoAmountCreateInternal(sweeper->unit, CRYPTO_FALSE, value, 0)` needed the last argument to be `1`.  Since all uses of `cryptoAmountCreateInternal()` would then use `1`, I replaced those calls with `cryptoAmountCreate()`.

Also found some missed gives in code for `cryptoWalletCreateAs<CURRENCY>`