### PR TITLE
CORE-1084: Define `Transfer.identifier`

### DIFF
--- a/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
+++ b/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
@@ -400,8 +400,7 @@ _CWMNopSubmitTransactionCallback (BRCryptoClientContext context,
                                   OwnershipGiven BRCryptoWalletManager manager,
                                   OwnershipGiven BRCryptoClientCallbackState callbackState,
                                   OwnershipKept const uint8_t *transaction,
-                                  size_t transactionLength,
-                                  OwnershipKept const char *hashAsHex) {
+                                  size_t transactionLength) {
     cryptoWalletManagerGive (manager);
 }
 

--- a/WalletKitCore/WalletKitCoreTests/test/hedera/testHedera.c
+++ b/WalletKitCore/WalletKitCoreTests/test/hedera/testHedera.c
@@ -592,11 +592,27 @@ static void transaction_tests() {
     //create_real_transactions();
 }
 
+// From BRHederaTransaction
+/*test */ extern  int hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds);
+
 static void txIDTests() {
-    const char * txID1 = "hedera-mainnet:0.0.14222-1569828647-256912000-0";
-    BRHederaTimeStamp ts1 = hederaParseTimeStamp(txID1);
-    assert(ts1.seconds == 1569828647);
-    assert(ts1.nano == 256912000);
+    char *address;
+    BRHederaTimeStamp timestamp = (BRHederaTimeStamp) { 0, 0 };
+
+    bool success = hederaParseTransactionId("0.0.14222-1569828647-256912000",
+                                            &address,
+                                            &timestamp.seconds,
+                                            &timestamp.nano);
+    assert(success);
+    assert(0 == strcmp (address, "0.0.14222"));
+    assert(timestamp.seconds == 1569828647);
+    assert(timestamp.nano    == 256912000);
+
+    success = hederaParseTransactionId("0.0.14222@1569828647.256912000",
+                                       &address,
+                                       &timestamp.seconds,
+                                       &timestamp.nano);
+    assert(!success);
 }
 
 extern void

--- a/WalletKitCore/WalletKitCoreTests/test/tezos/testTezos.c
+++ b/WalletKitCore/WalletKitCoreTests/test/tezos/testTezos.c
@@ -371,8 +371,8 @@ testTransactionSerialize() {
     BRCryptoData unsignedBytes = tezosSerializeOperationList(opList, opCount, lastBlockHash);
     //printByteString(0, unsignedBytes.bytes, unsignedBytes.size);
     bin2HexString(unsignedBytes.bytes, unsignedBytes.size, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86c004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc87000", serializedHex));
-    
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86c004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc87000", serializedHex));
+
     tezosTransferFree(transfer);
     cryptoDataFree(unsignedBytes);
     
@@ -386,7 +386,7 @@ testTransactionSerialize() {
     //printByteString(0, unsignedBytes.bytes, unsignedBytes.size);
     
     bin2HexString(unsignedBytes.bytes, unsignedBytes.size, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86b004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0000efc82a1445744a87fec55fce35e1b7ec80f9bbed9df2a03bcdde1a346f3d4294", serializedHex));
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86b004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0000efc82a1445744a87fec55fce35e1b7ec80f9bbed9df2a03bcdde1a346f3d4294", serializedHex));
     
     cryptoDataFree(unsignedBytes);
     tezosTransactionFree(tx);
@@ -404,7 +404,8 @@ testTransactionSerialize() {
     //printByteString(0, unsignedBytes.bytes, unsignedBytes.size);
     
     bin2HexString(unsignedBytes.bytes, unsignedBytes.size, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86e004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f00ff003e47f837f0467b4acde406ed5842f35e2414b1a8", serializedHex));
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86e004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f00ff003e47f837f0467b4acde406ed5842f35e2414b1a8", serializedHex));
+    //                                                                                                                                   ******
     
     tezosTransferFree(transfer);
     cryptoDataFree(unsignedBytes);
@@ -412,7 +413,7 @@ testTransactionSerialize() {
     // delegation off
     tezosAddressFree(targetAddress);
     targetAddress = NULL;
-    transfer = tezosTransferCreateNew(sourceAddress, targetAddress, 0, feeBasis, counter, 1);
+    transfer = tezosTransferCreateNew(sourceAddress, sourceAddress, 0, feeBasis, counter, 1);
     tx = tezosTransferGetTransaction(transfer);
     
     opList[0] = tx;
@@ -421,7 +422,7 @@ testTransactionSerialize() {
     //printByteString(0, unsignedBytes.bytes, unsignedBytes.size);
     
     bin2HexString(unsignedBytes.bytes, unsignedBytes.size, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86e004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0000", serializedHex));
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86e004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0000", serializedHex));
     
     tezosTransferFree(transfer);
     cryptoDataFree(unsignedBytes);
@@ -473,8 +474,8 @@ testBatchOperationSerialize() {
     BRCryptoData unsignedBytes = tezosSerializeOperationList(opList, opCount, lastBlockHash);
 //    //printByteString(0, unsignedBytes.bytes, unsignedBytes.size);
     bin2HexString(unsignedBytes.bytes, unsignedBytes.size, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86b004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0000efc82a1445744a87fec55fce35e1b7ec80f9bbed9df2a03bcdde1a346f3d42946c004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc87000", serializedHex));
-    
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86b004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0000efc82a1445744a87fec55fce35e1b7ec80f9bbed9df2a03bcdde1a346f3d42946c004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc87000", serializedHex));
+
     tezosTransferFree(transfer);
     tezosTransactionFree(reveal);
     cryptoDataFree(unsignedBytes);
@@ -523,12 +524,12 @@ testTransactionSign() {
     //printByteString(0, signedBytes, signedSize);
 
     bin2HexString(signedBytes, signedSize, serializedHex);
-    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86c004cdee21a9180f80956ab8d27fb6abdbd8993405288cd0c03d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc870002688209fbb4dcc0a1e81b4d66c74dae4432f72ff6eadf7bfc7e84817d54c3e7038a320d4438e9cd622f8ceac9e54e712f66bfb439ed055e4fecd178e769f7f03", serializedHex));
-    
+    assert (0 == strcasecmp("f3b761a633b2b0cc9d2edbb09cda4800818f893b3d6567b09a818f1a5f685fb86c004cdee21a9180f80956ab8d27fb6abdbd89934052949a0303d84f0080c2d72f0000d2e495a7ab40156d0a7c35b73d2530a3470fc87000d7af41ce947d6daf7d22994bc1241c6db15549eb2c256bedfc52cdcb42c13a8821e13251c365fcaff50e28797bf7cc09d130a910c0d95559fd544bc684422d0d", serializedHex));
+
     BRTezosHash hash = tezosTransactionGetHash(tx);
     char hashString[64] = {0};
     BRBase58CheckEncode(hashString, sizeof(hashString), hash.bytes, sizeof(hash.bytes));
-    assert (0 == strcmp ("onj92gjTtCUTPzQ4zbst3tndYyYGdRTtv7FxwBfBh5w95o5YLwa", hashString));
+    assert (0 == strcmp ("ooRC21UA17amABZekMapQJkn1cZEiqcffGNtZXtBeUW5rMiJBGR", hashString));
     
     tezosAddressFree(targetAddress);
     tezosAddressFree(sourceAddress);
@@ -577,12 +578,12 @@ testTransactionSignWithReveal() {
     //printByteString(0, signedBytes, signedSize);
 
     bin2HexString(signedBytes, signedSize, serializedHex);
-    assert (0 == strcasecmp("77aa56c6022b22922cc1e5760ff22768437341b41f6f084b14a8d2487c80b7a86b0029e55328366cf257b64de39e784c9b6682c2f2b589840183fa8003e05d000064b6cfc1ed37bc26ab4c68ec93d4769f98e83f1e07afd36fb4cb42d01203339e6c0029e55328366cf257b64de39e784c9b6682c2f2b589840184fa8003e05d00a08d0600008dcd911b4896ac05a3649d4cd1c462cef4e7f6450028740967468373f7a2c11c4a1564c26751d69542e9a5baa89809586b32e26bce645d7a98f994a350a381c6f8790c67aa036f5324945f93e63957f23615b4d504", serializedHex));
-    
+    assert (0 == strcasecmp("77aa56c6022b22922cc1e5760ff22768437341b41f6f084b14a8d2487c80b7a86b0029e55328366cf257b64de39e784c9b6682c2f2b5822983fa8003e05d000064b6cfc1ed37bc26ab4c68ec93d4769f98e83f1e07afd36fb4cb42d01203339e6c0029e55328366cf257b64de39e784c9b6682c2f2b5822984fa8003e05d00a08d0600008dcd911b4896ac05a3649d4cd1c462cef4e7f645009d764e037b9b823deda8c89f9fe5d8c435e1065d185f0622086d6d8acc2414971bf639fabfaa61e37861c4974005bde56900678d07d9772258ec388689c50906", serializedHex));
+
     BRTezosHash hash = tezosTransactionGetHash(tx);
     char hashString[64] = {0};
     BRBase58CheckEncode(hashString, sizeof(hashString), hash.bytes, sizeof(hash.bytes));
-    assert (0 == strcmp ("opEuThdvgqJpuXmi4HsjMQNFUWDvCp9UiifUuZuQxSc2zUpph43", hashString));
+    assert (0 == strcmp ("ooARsejugnjqVwFScyEDfjDAa8GWzspTSBeUSh5SS8MrpoqSVy6", hashString));
     
     tezosAddressFree(targetAddress);
     tezosAddressFree(sourceAddress);

--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -86,8 +86,9 @@ typedef struct BRCryptoClientTransferBundleRecord *BRCryptoClientTransferBundle;
 
 extern BRCryptoClientTransferBundle
 cryptoClientTransferBundleCreate (BRCryptoTransferStateType status,
-                                  OwnershipKept const char *hash,
                                   OwnershipKept const char *uids,
+                                  OwnershipKept const char *hash,
+                                  OwnershipKept const char *identifier,
                                   OwnershipKept const char *from,
                                   OwnershipKept const char *to,
                                   OwnershipKept const char *amount,

--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -132,6 +132,7 @@ typedef void
 extern void
 cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
                            OwnershipGiven BRCryptoClientCallbackState callbackState,
+                           OwnershipKept const char *identifier,
                            OwnershipKept const char *hash,
                            BRCryptoBoolean success);
 

--- a/WalletKitCore/include/BRCryptoTransfer.h
+++ b/WalletKitCore/include/BRCryptoTransfer.h
@@ -149,13 +149,34 @@ extern "C" {
     cryptoTransferGetDirection (BRCryptoTransfer transfer);
 
     /**
-     * Returns the transfer's hash.  This is the unique identifier for this transfer on the
-     * associated network's blockchain.  This value may be NULL; notably before a Transfer is
-     * signed; and, in the case of HBAR, before it is successfully submitted (the HBAR hash depends
-     * on the HBAR node handling the Transfer).
+     * Returns the unique identifier for a transaction.  The identifer is unique within the
+     * scope of the Transfer's wallet.  In WalletKit it is possible for two Transfers to have
+     * the same identifier if and only if the Transfers are in a different wallet.  This will
+     * happen, for example, with send ERC-20 wallets whereby both the asset transfer and the fee
+     * will have the same identifer.
      *
-     * @note: Uniqueness is TBD for Ethereum TOKEN transfers.  One should expect all Transfers
-     * in a Wallet to have a unique hash.
+     * @Note In general, the identifier will not exist until the Transfer has been successfully
+     * submitted to its Blockchain; before then the return value is `NULL`.  However, the actual
+     * time of existence is blockchain specific.
+     *
+     * @param transfer the transfer
+     * @return the identifier as a string.
+     */
+    extern const char *
+    cryptoTransferGetIdentifier (BRCryptoTransfer transfer);
+
+    /**
+     * Returns the transfer's hash.  The hash is determined by applying a blockchain-specific hash
+     * function to a blockchain-specific byte-serialized representation of a Transfer.  A hash is
+     * generally a unique identifier of Transfers in a wallet and also, but not always, on a
+     * blockchain.
+     *
+     * This value may be NULL; notably before a Transfer is signed; and, in the case of HBAR,
+     * before it is successfully submitted (the HBAR hash depends on the HBAR node handling the
+     * Transfer).
+     *
+     * @note: One should expect all Transfers in a Wallet to have a unique hash.  However, in
+     * WalletKit, a hash might be shared by two Transfers if and only if in different wallets.
      *
      * @param transfer the transfer
      *
@@ -164,6 +185,14 @@ extern "C" {
     extern BRCryptoHash
     cryptoTransferGetHash (BRCryptoTransfer transfer);
 
+    /**
+     * Generally a Transfer's hash is derived by applying a Blockchain-specific hash function to a
+     * Blockchain-specific byte representation of a Transfer.
+     *
+     * @Note: Some Blockchains, notablely Hedera, produce a hash the depends on the Hedera Node the
+     * processes the Transfer.  Hence, we don't
+     * know the hash until after
+     */
     extern BRCryptoBoolean
     cryptoTransferSetHash (BRCryptoTransfer transfer,
                            OwnershipKept BRCryptoHash hash);

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -727,6 +727,7 @@ cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry,
 extern void
 cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
                            OwnershipGiven BRCryptoClientCallbackState callbackState,
+                           OwnershipKept const char *identifierStr,
                            OwnershipKept const char *hashStr,
                            BRCryptoBoolean success) {
     assert (CLIENT_CALLBACK_SUBMIT_TRANSACTION == callbackState->type);
@@ -862,6 +863,12 @@ cryptoClientTransferBundleCreate (BRCryptoTransferStateType status,
                                   OwnershipKept const char **attributeKeys,
                                   OwnershipKept const char **attributeVals) {
     BRCryptoClientTransferBundle bundle = calloc (1, sizeof (struct BRCryptoClientTransferBundleRecord));
+
+    // In the case of an error, as indicated by `status`,  we've got no additional information
+    // as to the error type.  The transfer/transaction is in the blockchain, presumably it has
+    // resulted in a fee paid but no transfer of the desired asset.  A User would be expected to
+    // recover in some blockchain specific way - and hopefully can recognize the cause of the error
+    // so as to avoid simply creating a transaction to cause it again.
 
     bundle->status   = status;
     bundle->hash     = strdup (hash);

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -74,8 +74,9 @@ cryptoClientTransactionBundleSetRelease (BRSetOf(BRCryptoClientTransactionBundle
 
 struct BRCryptoClientTransferBundleRecord {
     BRCryptoTransferStateType status;
-    char *hash;
     char *uids;
+    char *hash;
+    char *identifier;
     char *from;
     char *to;
     char *amount;

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -43,6 +43,9 @@ typedef struct {
 typedef void
 (*BRCryptoTransferReleaseHandler) (BRCryptoTransfer transfer);
 
+typedef void
+(*BRCryptoTransferUpdateIdentifierHandler) (BRCryptoTransfer transfer);
+
 typedef BRCryptoHash
 (*BRCryptoTransferGetHashHandler) (BRCryptoTransfer transfer);
 
@@ -69,6 +72,7 @@ typedef struct {
     BRCryptoTransferReleaseHandler release;
     BRCryptoTransferGetHashHandler getHash;
     BRCryptoTransferSetHashHandler setHash;
+    BRCryptoTransferUpdateIdentifierHandler updateIdentifier;
     BRCryptoTransferSerializeHandler serialize;
     BRCryptoTransferGetBytesForFeeEstimateHandler getBytesForFeeEstimate;
     BRCryptoTransferIsEqualHandler isEqual;
@@ -85,6 +89,7 @@ struct BRCryptoTransferRecord {
     pthread_mutex_t lock;
     BRCryptoTransferListener listener;
 
+    char *identifier;
     BRCryptoAddress sourceAddress;
     BRCryptoAddress targetAddress;
     BRCryptoTransferState state;

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoTransferBTC.c
@@ -300,6 +300,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersBTC = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
     NULL, // setHash
+    NULL, // updateIdentifier
     cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC
@@ -309,6 +310,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersBCH = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
     NULL, // setHash
+    NULL, // updateIdentifier
     cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC
@@ -318,6 +320,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersBSV = {
     cryptoTransferReleaseBTC,
     cryptoTransferGetHashBTC,
     NULL, // setHash
+    NULL, // updateIdentifier
    cryptoTransferSerializeBTC,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualBTC

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoTransferETH.c
@@ -455,6 +455,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersETH = {
     cryptoTransferReleaseETH,
     cryptoTransferGetHashETH,
     NULL, // setHash
+    NULL, // updateIdentifier
     cryptoTransferSerializeETH,
     cryptoTransferGetBytesForFeeEstimateETH,
     cryptoTransferEqualAsETH

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -104,6 +104,14 @@ cryptoTransferSetHashHBAR (BRCryptoTransfer transfer,
     return hederaTransactionUpdateHash (transferHBAR->hbarTransaction, hashHBAR);
 }
 
+static void
+crptoTransferUpdateIdentifierHBAR (BRCryptoTransfer transfer) {
+    if (NULL != transfer->identifier) return;
+
+    BRCryptoTransferHBAR transferHBAR = cryptoTransferCoerceHBAR(transfer);
+    transfer->identifier = hederaTransactionGetTransactionId (transferHBAR->hbarTransaction);
+}
+
 static uint8_t *
 cryptoTransferSerializeHBAR (BRCryptoTransfer transfer,
                              BRCryptoNetwork network,
@@ -150,6 +158,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersHBAR = {
     cryptoTransferReleaseHBAR,
     cryptoTransferGetHashHBAR,
     cryptoTransferSetHashHBAR,
+    crptoTransferUpdateIdentifierHBAR,
     cryptoTransferSerializeHBAR,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualHBAR

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -91,6 +91,8 @@ cryptoTransferReleaseHBAR (BRCryptoTransfer transfer) {
 static BRCryptoHash
 cryptoTransferGetHashHBAR (BRCryptoTransfer transfer) {
     BRCryptoTransferHBAR transferHBAR = cryptoTransferCoerceHBAR(transfer);
+    if (! hederaTransactionHashExists(transferHBAR->hbarTransaction)) return NULL;
+
     BRHederaTransactionHash hash = hederaTransactionGetHash (transferHBAR->hbarTransaction);
     return cryptoHashCreateAsHBAR (hash);
 }

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -206,7 +206,7 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
         assert(96 == strlen(bundle->hash));
         hexDecode(txHash.bytes, sizeof(txHash.bytes), bundle->hash, strlen(bundle->hash));
     }
-    
+
     int error = (CRYPTO_TRANSFER_STATE_ERRORED == bundle->status);
 
     bool hbarTransactionNeedFree = true;
@@ -214,7 +214,7 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
                                                                   toAddress,
                                                                   amountHbar,
                                                                   feeHbar,
-                                                                  NULL,
+                                                                  bundle->identifier,
                                                                   txHash,
                                                                   bundle->blockTimestamp,
                                                                   bundle->blockNumber,

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoTransferXRP.c
@@ -154,6 +154,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersXRP = {
     cryptoTransferReleaseXRP,
     cryptoTransferGetHashXRP,
     NULL, // setHash
+    NULL,
     cryptoTransferSerializeXRP,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualXRP

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoTransferXTZ.c
@@ -147,6 +147,7 @@ BRCryptoTransferHandlers cryptoTransferHandlersXTZ = {
     cryptoTransferReleaseXTZ,
     cryptoTransferGetHashXTZ,
     NULL, // setHash
+    NULL, // updateIdentifier
     cryptoTransferSerializeXTZ,
     NULL, // getBytesForFeeEstimate
     cryptoTransferIsEqualXTZ

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -104,8 +104,7 @@ extern BRHederaTransaction hederaTransactionCreate (BRHederaAddress source,
 
     // Parse the transactionID
     if (txID && strlen(txID) > 1) {
-        transaction->transactionId = (char*) calloc(1, strlen(txID) + 1);
-        strcpy(transaction->transactionId, txID);
+        transaction->transactionId = strdup (txID);
         // Get the timestamp from the transaction id
         transaction->timeStamp = hederaParseTimeStamp(txID);
     } else {
@@ -134,8 +133,7 @@ hederaTransactionClone (BRHederaTransaction transaction)
     newTransaction->feeBasis = transaction->feeBasis;
 
     if (transaction->transactionId && strlen(transaction->transactionId) > 1) {
-        newTransaction->transactionId = (char*) calloc(1, strlen(transaction->transactionId) + 1);
-        strcpy(newTransaction->transactionId, transaction->transactionId);
+        newTransaction->transactionId = strdup (transaction->transactionId);
     }
 
     newTransaction->hash = transaction->hash;

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -20,6 +20,11 @@
 #include <string.h>
 #include "support/BRInt.h"
 
+// Forward Declarations
+
+static char * hederaCreateTransactionId(BRHederaAddress address, BRHederaTimeStamp timeStamp);
+static int hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds);
+
 // Here is the list of Hedera nodes used in production
 static uint16_t nodes[10] = {
     3, 4, 5, 6, 7, 8, 9, 10, 11, 12
@@ -48,16 +53,6 @@ struct BRHederaTransactionRecord {
     BRArrayOf(BRHederaTransactionHash) hashes;
 };
 
-char * createTransactionID(BRHederaAddress address, BRHederaTimeStamp timeStamp)
-{
-    char buffer[128] = {0};
-    const char * hederaAddress = hederaAddressAsString(address);
-    sprintf(buffer, "%s-%" PRIi64 "-%" PRIi32, hederaAddress, timeStamp.seconds, timeStamp.nano);
-    char * result = calloc(1, strlen(buffer) + 1);
-    strncpy(result, buffer, strlen(buffer));
-    return result;
-}
-
 extern BRHederaTransaction hederaTransactionCreateNew (BRHederaAddress source,
                                                        BRHederaAddress target,
                                                        BRHederaUnitTinyBar amount,
@@ -77,7 +72,7 @@ extern BRHederaTransaction hederaTransactionCreateNew (BRHederaAddress source,
         // and includes seconds and nano-seconds
         transaction->timeStamp = hederaGenerateTimeStamp();
     }
-    transaction->transactionId = createTransactionID(source, transaction->timeStamp);
+    transaction->transactionId = hederaCreateTransactionId(source, transaction->timeStamp);
     transaction->blockHeight = 0;
     transaction->error = 0;
     return transaction;
@@ -87,7 +82,7 @@ extern BRHederaTransaction hederaTransactionCreate (BRHederaAddress source,
                                                     BRHederaAddress target,
                                                     BRHederaUnitTinyBar amount,
                                                     BRHederaUnitTinyBar fee,
-                                                    const char * txID,
+                                                    const char * transactionId,
                                                     BRHederaTransactionHash hash,
                                                     uint64_t timestamp, uint64_t blockHeight,
                                                     int error)
@@ -103,10 +98,16 @@ extern BRHederaTransaction hederaTransactionCreate (BRHederaAddress source,
     transaction->fee = hederaFeeBasisGetFee(&transaction->feeBasis);
 
     // Parse the transactionID
-    if (txID && strlen(txID) > 1) {
-        transaction->transactionId = strdup (txID);
+    if (transactionId && strlen(transactionId) > 1) {
+        transaction->transactionId = NULL;
+        transaction->timeStamp     = (BRHederaTimeStamp) { 0, 0 };
+
         // Get the timestamp from the transaction id
-        transaction->timeStamp = hederaParseTimeStamp(txID);
+        int success = hederaParseTransactionId (transactionId, NULL,
+                                                &transaction->timeStamp.seconds,
+                                                &transaction->timeStamp.nano);
+
+        if (success) transaction->transactionId = strdup (transactionId);
     } else {
         // It would great to be able to get the timestamp from the txID - but I guess
         // we just have to use whatever came from blockset
@@ -332,7 +333,7 @@ hederaTransactionSignTransactionV0 (BRHederaTransaction transaction,
     free (serializedBytes);
 
     // Create the transaction id
-    transaction->transactionId = createTransactionID(transaction->source, transaction->timeStamp);
+    transaction->transactionId = hederaCreateTransactionId(transaction->source, transaction->timeStamp);
 
     transaction->serializedSize += HEDERA_ADDRESS_SERIALIZED_SIZE; // This will be our new size of serialized bytes
     return transaction->serializedSize;
@@ -381,6 +382,11 @@ extern uint8_t * hederaTransactionSerialize (BRHederaTransaction transaction, si
         *size = 0;
         return NULL;
     }
+}
+
+extern int hederaTransactionHashExists (BRHederaTransaction transaction) {
+    BRHederaTransactionHash empty = { 0 };
+    return 0 != memcmp (transaction->hash.bytes, empty.bytes, sizeof (empty.bytes));
 }
 
 extern BRHederaTransactionHash hederaTransactionGetHash(BRHederaTransaction transaction)
@@ -574,33 +580,38 @@ extern BRHederaTimeStamp hederaGenerateTimeStamp(void)
     return ts;
 }
 
-BRHederaTimeStamp hederaParseTimeStamp(const char* transactionID)
+static char *
+hederaCreateTransactionId(BRHederaAddress address, BRHederaTimeStamp timeStamp)
 {
-    BRHederaTimeStamp ts;
+    char buffer[128] = {0};
+    const char * hederaAddress = hederaAddressAsString(address);
+    sprintf(buffer, "%s-%10" PRIi64 "-%09" PRIi32, hederaAddress, timeStamp.seconds, timeStamp.nano);
+    char * result = calloc(1, strlen(buffer) + 1);
+    strncpy(result, buffer, strlen(buffer));
+    return result;
+}
 
-    // The transaction ID looks like this:
-    // block-chain:shard.realm.account-seconds-nanos-index
 
-    // Copy the transactionID and then use strtok to parse
-    char * txID = strdup(transactionID);
-    const char * searchTokens = ":.";
-    strtok(txID, searchTokens); // blockchain-id
-    strtok(NULL, searchTokens); // shard
-    strtok(NULL, searchTokens); // realm
-    char * accountAndTS = strtok(NULL, searchTokens); // account plus rest of the string
+static int
+hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds)
+{
+    assert (strlen (transactionId) <= 128);
+    char tid[129];
+    strcpy (tid, transactionId);
 
-    // Now start over and search for the "-" the string now looks like this:
-    // account-seconds-nanos-index-whatever
-    strtok(accountAndTS, "-"); // Account number
-    char * secondsStr = strtok(NULL, "-"); // Seconds
-    char * nanosStr = strtok(NULL, "-"); // Nanos
+    char *addressParse     = strtok (tid,  "-");
+    char *secondsParse     = strtok (NULL, "-");
+    char *nanosecondsParse = strtok (NULL, "-");
 
-    //sscanf(transactionID, "%s:%lld.%lld.%lld-%lld-%d-", blockchain, &shard, &realm, &account, &seconds, &nanos);
-    sscanf(secondsStr, "%" PRIi64, &ts.seconds);
-    sscanf(nanosStr, "%" PRIi32, &ts.nano);
+    bool success = (NULL != addressParse && NULL != secondsParse && NULL != nanosecondsParse);
 
-    free (txID);
-    return ts;
+    if (success) {
+        if (NULL != address)     *address     = strdup (addressParse);
+        if (NULL != seconds)     *seconds     = (int64_t) strtoll (secondsParse,     NULL, 10);
+        if (NULL != nanoseconds) *nanoseconds = (int32_t) strtoll (nanosecondsParse, NULL, 10);
+    }
+
+    return success;
 }
 
 int hederaTransactionGetHashCount (BRHederaTransaction transaction) {

--- a/WalletKitCore/src/hedera/BRHederaTransaction.c
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.c
@@ -23,7 +23,7 @@
 // Forward Declarations
 
 static char * hederaCreateTransactionId(BRHederaAddress address, BRHederaTimeStamp timeStamp);
-static int hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds);
+/*test */ extern  int hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds);
 
 // Here is the list of Hedera nodes used in production
 static uint16_t nodes[10] = {
@@ -592,7 +592,7 @@ hederaCreateTransactionId(BRHederaAddress address, BRHederaTimeStamp timeStamp)
 }
 
 
-static int
+/*test */ extern int
 hederaParseTransactionId (const char *transactionId, char **address, int64_t *seconds, int32_t *nanoseconds)
 {
     assert (strlen (transactionId) <= 128);

--- a/WalletKitCore/src/hedera/BRHederaTransaction.h
+++ b/WalletKitCore/src/hedera/BRHederaTransaction.h
@@ -51,9 +51,14 @@ hederaTransactionCreateNew(BRHederaAddress source, BRHederaAddress target,
  * @return transaction
  */
 extern BRHederaTransaction /* caller must free - hederaTransactionFree */
-hederaTransactionCreate(BRHederaAddress source, BRHederaAddress target,
-                        BRHederaUnitTinyBar amount, BRHederaUnitTinyBar fee, const char *txID,
-                        BRHederaTransactionHash hash, uint64_t timestamp, uint64_t blockHeight,
+hederaTransactionCreate(BRHederaAddress source,
+                        BRHederaAddress target,
+                        BRHederaUnitTinyBar amount,
+                        BRHederaUnitTinyBar fee,
+                        const char * transactionId,
+                        BRHederaTransactionHash hash,
+                        uint64_t timestamp,
+                        uint64_t blockHeight,
                         int error);
 
 extern BRHederaTransaction /* caller must free - hederaTrasactionFree */
@@ -96,6 +101,7 @@ extern uint8_t * /* caller owns and must free using normal "free" function */
 hederaTransactionSerialize (BRHederaTransaction transaction, size_t *size);
 
 // Getters for the various transaction fields
+extern int hederaTransactionHashExists (BRHederaTransaction transaction);
 extern BRHederaTransactionHash hederaTransactionGetHash(BRHederaTransaction transaction);
 extern char * // Caller owns memory and must free calling "free"
 hederaTransactionGetTransactionId(BRHederaTransaction transaction);

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -1932,8 +1932,9 @@ final class System implements com.breadwallet.crypto.System {
 
             result.add (BRCryptoClientTransferBundle.create(
                     status,
-                    transaction.getHash(),
                     o.o1.getId(),
+                    transaction.getHash(),
+                    transaction.getIdentifier(),
                     o.o1.getFromAddress().orNull(),
                     o.o1.getToAddress().orNull(),
                     o.o1.getAmount().getAmount(),

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Transfer.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Transfer.java
@@ -138,6 +138,11 @@ final class Transfer implements com.breadwallet.crypto.Transfer {
     }
 
     @Override
+    public Optional<String> getIdentifier() {
+        return core.getIdentifier();
+    }
+
+    @Override
     public Optional<TransferHash> getHash() {
         return core.getHash().transform(TransferHash::create);
     }

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -242,6 +242,7 @@ public final class CryptoLibraryDirect {
     public static native Pointer cryptoTransferGetAmountDirected(Pointer transfer);
     public static native int cryptoTransferGetDirection(Pointer transfer);
     public static native BRCryptoTransferState.ByValue cryptoTransferGetState(Pointer transfer);
+    public static native Pointer cryptoTransferGetIdentifier(Pointer transfer);
     public static native Pointer cryptoTransferGetHash(Pointer transfer);
     public static native Pointer cryptoTransferGetUnitForAmount (Pointer transfer);
     public static native Pointer cryptoTransferGetUnitForFee (Pointer transfer);

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -67,8 +67,9 @@ public final class CryptoLibraryIndirect {
     }
 
     public static Pointer cryptoClientTransferBundleCreate(int status,
-                                                           String hash,
                                                            String uids,
+                                                           String hash,
+                                                           String identifier,
                                                            String sourceAddr,
                                                            String targetAddr,
                                                            String amount,
@@ -85,7 +86,7 @@ public final class CryptoLibraryIndirect {
         attributeKeys = attributeKeys.length == 0 ? null : attributeKeys;
         attributeVals = attributeVals.length == 0 ? null : attributeVals;
         return INSTANCE.cryptoClientTransferBundleCreate(status,
-                hash, uids, sourceAddr, targetAddr,
+                uids, hash, identifier, sourceAddr, targetAddr,
                 amount, currency, fee,
                 blockTimestamp, blockHeight, blockConfirmations, blockTransactionIndex, blockHash,
                 attributesCount, attributeKeys, attributeVals);
@@ -156,8 +157,9 @@ public final class CryptoLibraryIndirect {
         int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, BRCryptoTransferAttribute[] attributes, IntByReference validates);
 
         Pointer cryptoClientTransferBundleCreate(int status,
-                                                 String hash,
                                                  String uids,
+                                                 String hash,
+                                                 String identifier,
                                                  String sourceAddr,
                                                  String targetAddr,
                                                  String amount,

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClientTransferBundle.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClientTransferBundle.java
@@ -11,8 +11,9 @@ import java.util.Map;
 public class BRCryptoClientTransferBundle extends PointerType {
     public static BRCryptoClientTransferBundle create(
             BRCryptoTransferStateType status,
-            String hash,
             String uids,
+            String hash,
+            String identifier,
             String from,
             String to,
             String amount,
@@ -32,8 +33,9 @@ public class BRCryptoClientTransferBundle extends PointerType {
 
         Pointer pointer = CryptoLibraryIndirect.cryptoClientTransferBundleCreate(
                 status.toCore(),
-                hash,
                 uids,
+                hash,
+                identifier,
                 from,
                 to,
                 amount,

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransfer.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransfer.java
@@ -56,6 +56,14 @@ public class BRCryptoTransfer extends PointerType {
         return new BRCryptoAmount(CryptoLibraryDirect.cryptoTransferGetAmountDirected(thisPtr));
     }
 
+    public Optional<String> getIdentifier() {
+        return Optional.fromNullable(
+                CryptoLibraryDirect.cryptoTransferGetIdentifier (
+                        this.getPointer()
+                )
+        ).transform((s) -> s.getString(0, "UTF-8"));
+    }
+
     public Optional<BRCryptoHash> getHash() {
         Pointer thisPtr = this.getPointer();
 

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Transfer.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/Transfer.java
@@ -36,6 +36,8 @@ public interface Transfer {
 
     TransferDirection getDirection();
 
+    Optional<String> getIdentifier();
+
     Optional<? extends TransferHash> getHash();
 
     Unit getUnit();

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -151,7 +151,8 @@ public class CoreCryptoApplication extends Application {
                     "eth",
                     "xrp",
                     "hbar",
-                    "xtz"
+                    "xtz",
+                    "ignore - end-of-array, w/o comma"
             );
             systemListener = new DispatchingSystemListener();
             systemListener.addSystemListener(new CoreSystemListener(mode, isMainnet, currencyCodesNeeded));

--- a/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
+++ b/WalletKitJava/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
@@ -258,7 +258,7 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
             this.feeText = transfer.getFee().toString();
             this.senderText = transfer.getSource().transform(Address::toString).or("<unknown>");
             this.receiverText = transfer.getTarget().transform(Address::toString).or("<unknown>");
-            this.identifierText = transfer.getHash().transform(TransferHash::toString).or("<pending>");
+            this.identifierText = transfer.getIdentifier().or("<pending>");
             this.confirmationText = conf.transform((c) -> "Yes @ " + c.getBlockNumber()).or("No");
             this.confirmationCountText = transfer.getConfirmations().transform(String::valueOf).or("");
             this.dateText = conf.transform((c) -> DATE_FORMAT.get().format(c.getConfirmationTime())).or("<pending>");

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1470,8 +1470,9 @@ extension System {
                 defer { metaValsPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
 
                 return cryptoClientTransferBundleCreate (status,
-                                                         transaction.hash,
                                                          transfer.id,
+                                                         transaction.hash,
+                                                         transaction.identifier,
                                                          transfer.source,
                                                          transfer.target,
                                                          transfer.amount.value,

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1575,10 +1575,10 @@ extension System {
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve(
                         success: { (ti) in
-                            cwmAnnounceSubmitTransfer (cwm, sid, ti.hash, CRYPTO_TRUE) },
+                            cwmAnnounceSubmitTransfer (cwm, sid, ti.identifier, ti.hash, CRYPTO_TRUE) },
                         failure: { (e) in
                             print ("SYS: SubmitTransaction: Error: \(e)")
-                            cwmAnnounceSubmitTransfer (cwm, sid, nil, CRYPTO_FALSE) })
+                            cwmAnnounceSubmitTransfer (cwm, sid, nil, nil, CRYPTO_FALSE) })
                 }},
 
             funcEstimateTransactionFee: { (context, cwm, sid, transactionBytes, transactionBytesLength, hashAsHex) in

--- a/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
@@ -93,6 +93,10 @@ public final class Transfer: Equatable {
         else { return nil }
     }
 
+    public var identifier: String? {
+        return cryptoTransferGetIdentifier(core)
+            .map { asUTF8String($0) }
+    }
     /// An optional hash.  This only exists if the TransferState is .included or .submitted
     public var hash: TransferHash? {
         return cryptoTransferGetHash (core)

--- a/WalletKitSwift/WalletKitDemo/Source/TransferViewController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/TransferViewController.swift
@@ -70,7 +70,6 @@ class TransferViewController: UIViewController, TransferListener, WalletManagerL
 //        let address = UIApplication.sharedClient.node.address
         let date: Date? = (nil == transfer.confirmation ? nil
             : Date (timeIntervalSince1970: TimeInterval(transfer.confirmation!.timestamp)))
-        let hash = transfer.hash
 
         amountLabel.text = transfer.amountDirected.description
         feeLabel.text  =  transfer.fee.description
@@ -78,7 +77,7 @@ class TransferViewController: UIViewController, TransferListener, WalletManagerL
         sendButton.setTitle(transfer.source?.description ?? "<unknown>", for: .normal)
         recvButton.setTitle(transfer.target?.description ?? "<unknown>", for: .normal)
 
-        identifierButton.setTitle(hash.map { $0.description } ?? "<pending>", for: .normal)
+        identifierButton.setTitle(transfer.identifier ?? "<pending>", for: .normal)
 
         confLabel.text = transfer.confirmation.map { "Yes @ \($0.blockNumber)" } ?? "No"
         confCountLabel.text = transfer.confirmations?.description ?? ""


### PR DESCRIPTION
Pending Java changes.

Only HBAR has an 'identifier' that differs from the 'hash'.  For BTC segwit, we use `txHash` (see BRTransaction.{hc}), not `wtxHash`, as the 'identifier'