### PR TITLE
CORE-1116: Revert the `genTransferEqual()` comparison of UIDS.

### DIFF
--- a/WalletKitCore/src/generic/BRGeneric.c
+++ b/WalletKitCore/src/generic/BRGeneric.c
@@ -359,8 +359,9 @@ genTransferEqual (BRGenericTransfer t1,
                   BRGenericTransfer t2) {
     return (t1 == t2 ||
             (NULL != t1->handlers.equal && NULL != t2->handlers.equal && t1->handlers.equal (t1->ref, t2->ref)) ||
-            (NULL != t1->uids           && NULL != t2->uids           && 0 == strcmp (t1->uids, t2->uids))      ||
-            genericHashEqual (genTransferGetHash (t1), genTransferGetHash (t2)));
+            (NULL != t1->uids           && NULL != t2->uids
+             ? 0 == strcmp (t1->uids, t2->uids)
+             : genericHashEqual (genTransferGetHash (t1), genTransferGetHash (t2))));
 }
 
 extern uint8_t *


### PR DESCRIPTION
If two transfers have UIDS, compare based on those.  Do not defer to`genericHashEqual()`.  This returns to prior logic that got messed up when adding `handlers->equal` (to do HBAR multi-serialization comparison).