### PR TITLE
CORE-1112: In WalletManager.init() don't initialize `addressScheme`.

### DIFF
--- a/WalletKitCore/WalletKitCoreTests/WalletKitCoreTests.swift
+++ b/WalletKitCore/WalletKitCoreTests/WalletKitCoreTests.swift
@@ -342,7 +342,6 @@ final class WalletKitCoreTests: XCTestCase {
 
         cryptoNetworkSetHeight (network, blockHeight)
 
-        cryptoNetworkSetCurrency (network, currency)
         cryptoNetworkAddCurrency (network, currency, satUnit, btcUnit)
 
         cryptoNetworkAddCurrencyUnit(network, currency, satUnit)
@@ -375,7 +374,6 @@ final class WalletKitCoreTests: XCTestCase {
 
         cryptoNetworkSetHeight (network, blockHeight)
 
-        cryptoNetworkSetCurrency (network, currency)
         cryptoNetworkAddCurrency (network, currency, satUnit, btcUnit)
 
         cryptoNetworkAddCurrencyUnit(network, currency, satUnit)
@@ -408,7 +406,6 @@ final class WalletKitCoreTests: XCTestCase {
 
         cryptoNetworkSetHeight (network, blockHeight)
 
-        cryptoNetworkSetCurrency (network, currency)
         cryptoNetworkAddCurrency (network, currency, satUnit, btcUnit)
 
         cryptoNetworkAddCurrencyUnit(network, currency, satUnit)
@@ -444,7 +441,6 @@ final class WalletKitCoreTests: XCTestCase {
 
         cryptoNetworkSetHeight (network, blockHeight)
 
-        cryptoNetworkSetCurrency (network, currency)
         cryptoNetworkAddCurrency (network, currency, weiUnit, etherUnit)
 
         cryptoNetworkAddCurrencyUnit(network, currency, weiUnit)

--- a/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
+++ b/WalletKitCore/WalletKitCoreTests/test/crypto/testCrypto.c
@@ -1524,9 +1524,7 @@ runCryptoTestsWithAccountAndNetwork (BRCryptoAccount account,
 
     BRCryptoAddressScheme scheme = ((isBtc || isBch) ?
                                     CRYPTO_ADDRESS_SCHEME_BTC_LEGACY :
-                                    (isEth ?
-                                     CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT :
-                                     CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT));
+                                    CRYPTO_ADDRESS_SCHEME_NATIVE);
 
     if (isBtc || isEth || isGen) {
         success = AS_CRYPTO_BOOLEAN(runCryptoWalletManagerLifecycleTest (account,

--- a/WalletKitCore/include/BRCryptoNetwork.h
+++ b/WalletKitCore/include/BRCryptoNetwork.h
@@ -116,10 +116,6 @@ extern "C" {
     cryptoNetworkGetCurrency (BRCryptoNetwork network);
 
     extern void
-    cryptoNetworkSetCurrency (BRCryptoNetwork network,
-                              BRCryptoCurrency currency);
-
-    extern void
     cryptoNetworkAddCurrency (BRCryptoNetwork network,
                               BRCryptoCurrency currency,
                               BRCryptoUnit baseUnit,

--- a/WalletKitCore/include/BRCryptoNetwork.h
+++ b/WalletKitCore/include/BRCryptoNetwork.h
@@ -43,11 +43,10 @@ extern "C" {
     typedef enum {
         CRYPTO_ADDRESS_SCHEME_BTC_LEGACY,
         CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT,
-        CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT,
-        CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT
+        CRYPTO_ADDRESS_SCHEME_NATIVE,          // Default for Currency
     } BRCryptoAddressScheme;
 
-#define NUMBER_OF_ADDRESS_SCHEMES   (1 + CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+#define NUMBER_OF_ADDRESS_SCHEMES   (1 + CRYPTO_ADDRESS_SCHEME_NATIVE)
 
 
     typedef struct BRCryptoNetworkFeeRecord *BRCryptoNetworkFee;

--- a/WalletKitCore/src/crypto/BRCryptoBaseP.h
+++ b/WalletKitCore/src/crypto/BRCryptoBaseP.h
@@ -25,5 +25,12 @@
 ///
 /// This is an implementation detail
 ///
+#define free_const(pointer)    free((void*) (pointer))
+
+#define assign_const(type, lval, rval) do { \
+  type *__ptr = (type *) &(lval);           \
+  *__ptr = (rval);                          \
+} while (0)
+
 
 #endif /* BRCryptoBaseP_h */

--- a/WalletKitCore/src/crypto/BRCryptoConfig.h
+++ b/WalletKitCore/src/crypto/BRCryptoConfig.h
@@ -124,7 +124,7 @@ DEFINE_CURRENCY ("ethereum-mainnet",     "ethereum-mainnet:__native__",   NETWOR
 DEFINE_CURRENCY ("ethereum-mainnet",    "ethereum-mainnet:0x558ec3152e2eb2174905cd19aea4e34a23de9ad6",  "BRD Token",    "brd",  "erc20",   "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6",   true)
     DEFINE_UNIT ("ethereum-mainnet:0x558ec3152e2eb2174905cd19aea4e34a23de9ad6",      "BRD Token INT",         "brdi",      0,      "BRDI")
     DEFINE_UNIT ("ethereum-mainnet:0x558ec3152e2eb2174905cd19aea4e34a23de9ad6",      "BRD Token",             "brd",       18,     "BRD")
-DEFINE_ADDRESS_SCHEMES  ("ethereum-mainnet", CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("ethereum-mainnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("ethereum-mainnet", CRYPTO_SYNC_MODE_API_ONLY, CRYPTO_SYNC_MODE_API_WITH_P2P_SEND, CRYPTO_SYNC_MODE_P2P_ONLY)
 
 #if HAS_ETH_TESTNET
@@ -137,7 +137,7 @@ DEFINE_CURRENCY ("ethereum-ropsten",     "ethereum-ropsten:__native__",   NETWOR
 DEFINE_CURRENCY ("ethereum-ropsten",    "ethereum-ropsten:0x7108ca7c4718efa810457f228305c9c71390931a",  "BRD Token Testnet",    "brd",  "erc20",   "0x7108ca7c4718efa810457f228305c9c71390931a",   true)
     DEFINE_UNIT ("ethereum-ropsten:0x7108ca7c4718efa810457f228305c9c71390931a",      "BRD Token INT",         "brdi",      0,      "BRDI")
     DEFINE_UNIT ("ethereum-ropsten:0x7108ca7c4718efa810457f228305c9c71390931a",      "BRD Token",             "brd",       18,     "BRD")
-DEFINE_ADDRESS_SCHEMES  ("ethereum-ropsten", CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("ethereum-ropsten", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("ethereum-ropsten", CRYPTO_SYNC_MODE_API_ONLY, CRYPTO_SYNC_MODE_API_WITH_P2P_SEND, CRYPTO_SYNC_MODE_P2P_ONLY)
 #endif
 #undef NETWORK_NAME
@@ -150,7 +150,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("ripple-mainnet", "10", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("ripple-mainnet",     "ripple-mainnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XRP,  "native",   NULL,   true)
     DEFINE_UNIT ("ripple-mainnet:__native__",      "Drop",       "drop",      0,      "DROP")
     DEFINE_UNIT ("ripple-mainnet:__native__",      NETWORK_NAME, "xrp",       6,      "XRP")
-DEFINE_ADDRESS_SCHEMES  ("ripple-mainnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("ripple-mainnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("ripple-mainnet", CRYPTO_SYNC_MODE_API_ONLY)
 
 #if HAS_XRP_TESTNET
@@ -159,7 +159,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("ripple-testnet", "10", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("ripple-testnet",     "ripple-testnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XRP,  "native",   NULL,   true)
     DEFINE_UNIT ("ripple-testnet:__native__",      "Drop",       "drop",      0,      "DROP")
     DEFINE_UNIT ("ripple-testnet:__native__",      NETWORK_NAME, "xrp",       6,      "XRP")
-DEFINE_ADDRESS_SCHEMES  ("ripple-testnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("ripple-testnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("ripple-testnet", CRYPTO_SYNC_MODE_API_ONLY)
 #endif
 #undef NETWORK_NAME
@@ -172,7 +172,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("hedera-mainnet", "500000", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("hedera-mainnet",     "hedera-mainnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_HBAR,  "native",   NULL,   true)
     DEFINE_UNIT ("hedera-mainnet:__native__",  "tinybar",     "thbar",  0,  "tℏ")
     DEFINE_UNIT ("hedera-mainnet:__native__",  NETWORK_NAME,  "hbar",   8,  "ℏ")
-DEFINE_ADDRESS_SCHEMES  ("hedera-mainnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("hedera-mainnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("hedera-mainnet", CRYPTO_SYNC_MODE_API_ONLY)
 
 #if HAS_HBAR_TESTNET
@@ -181,7 +181,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("hedera-testnet", "500000", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("hedera-testnet",     "hedera-testnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_HBAR,  "native",   NULL,   true)
     DEFINE_UNIT ("hedera-testnet:__native__",  "tinybar",     "thbar",  0,  "tℏ")
     DEFINE_UNIT ("hedera-testnet:__native__",  NETWORK_NAME,  "hbar",   8,  "ℏ")
-DEFINE_ADDRESS_SCHEMES  ("hedera-testnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("hedera-testnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("hedera-testnet", CRYPTO_SYNC_MODE_API_ONLY)
 #endif
 #undef NETWORK_NAME
@@ -194,7 +194,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("tezos-mainnet", "500000", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("tezos-mainnet",     "tezos-mainnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XTZ,  "native",   NULL,   true)
     DEFINE_UNIT ("tezos-mainnet:__native__",  "mutez",     "mtz",   0,  "mutez")
     DEFINE_UNIT ("tezos-mainnet:__native__",  NETWORK_NAME,  "xtz",   6,  "XTZ")
-DEFINE_ADDRESS_SCHEMES  ("tezos-mainnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("tezos-mainnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("tezos-mainnet", CRYPTO_SYNC_MODE_API_ONLY)
 
 #if HAS_XTZ_TESTNET
@@ -203,7 +203,7 @@ DEFINE_NETWORK_FEE_ESTIMATE ("tezos-testnet", "500000", "1m", 1 * 60 * 1000)
 DEFINE_CURRENCY ("tezos-testnet",     "tezos-testnet:__native__",   NETWORK_NAME,  CRYPTO_NETWORK_CURRENCY_XTZ,  "native",   NULL,   true)
     DEFINE_UNIT ("tezos-testnet:__native__",  "mutez",     "mtz",   0,  "mutez")
     DEFINE_UNIT ("tezos-testnet:__native__",  NETWORK_NAME,  "xtz",   6,  "XTZ")
-DEFINE_ADDRESS_SCHEMES  ("tezos-testnet", CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
+DEFINE_ADDRESS_SCHEMES  ("tezos-testnet", CRYPTO_ADDRESS_SCHEME_NATIVE)
 DEFINE_MODES            ("tezos-testnet", CRYPTO_SYNC_MODE_API_ONLY)
 #endif
 #undef NETWORK_NAME

--- a/WalletKitCore/src/crypto/BRCryptoNetwork.c
+++ b/WalletKitCore/src/crypto/BRCryptoNetwork.c
@@ -287,18 +287,6 @@ cryptoNetworkGetCurrencyCode (BRCryptoNetwork network) {
     return cryptoCurrencyGetCode (network->currency);
 }
 
-extern void
-cryptoNetworkSetCurrency (BRCryptoNetwork network,
-                          BRCryptoCurrency newCurrency) {
-    pthread_mutex_lock (&network->lock);
-    BRCryptoCurrency currency = network->currency;
-    network->currency = cryptoCurrencyTake(newCurrency);
-    pthread_mutex_unlock (&network->lock);
-
-    // drop reference outside of lock to avoid potential case where release function runs
-    if (NULL != currency) cryptoCurrencyGive (currency);
-}
-
 extern size_t
 cryptoNetworkGetCurrencyCount (BRCryptoNetwork network) {
     pthread_mutex_lock (&network->lock);

--- a/WalletKitCore/src/crypto/BRCryptoNetworkP.h
+++ b/WalletKitCore/src/crypto/BRCryptoNetworkP.h
@@ -57,7 +57,10 @@ typedef BRCryptoNetwork
                                  const char *name,               // Bitcoin
                                  const char *network,            // testnet
                                  bool isMainnet,                 // false
-                                 uint32_t confirmationPeriodInSeconds); // 10 * 60
+                                 uint32_t confirmationPeriodInSeconds,  // 10 * 60
+                                 BRCryptoAddressScheme defaultAddressScheme,
+                                 BRCryptoSyncMode defaultSyncMode,
+                                 BRCryptoCurrency nativeCurrency);
 
 typedef void
 (*BRCryptoNetworkReleaseHandler) (BRCryptoNetwork network);
@@ -157,6 +160,9 @@ cryptoNetworkAllocAndInit (size_t sizeInBytes,
                            const char *desc,        // "mainnet", "testnet", "rinkeby"
                            bool isMainnet,
                            uint32_t confirmationPeriodInSeconds,
+                           BRCryptoAddressScheme defaultAddressScheme,
+                           BRCryptoSyncMode defaultSyncMode,
+                           BRCryptoCurrency currencyNative,
                            BRCryptoNetworkCreateContext createContext,
                            BRCryptoNetworkCreateCallback createCallback);
 

--- a/WalletKitCore/src/crypto/BRCryptoNetworkP.h
+++ b/WalletKitCore/src/crypto/BRCryptoNetworkP.h
@@ -187,10 +187,6 @@ cryptoNetworkSetConfirmationsUntilFinal (BRCryptoNetwork network,
                                          uint32_t confirmationsUntilFinal);
 
 private_extern void
-cryptoNetworkSetCurrency (BRCryptoNetwork network,
-                          BRCryptoCurrency currency);
-
-private_extern void
 cryptoNetworkAddCurrency (BRCryptoNetwork network,
                           BRCryptoCurrency currency,
                           BRCryptoUnit baseUnit,

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoNetworkBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoNetworkBTC.c
@@ -47,44 +47,34 @@ cryptoNetworkCreateCallbackBTC (BRCryptoNetworkCreateContext context,
 }
 
 static BRCryptoNetwork
-cryptoNetworkCreateAsBTC (BRCryptoBlockChainType type,
-                          BRCryptoNetworkListener listener,
-                          const char *uids,
-                          const char *name,
-                          const char *desc,
-                          bool isMainnet,
-                          uint32_t confirmationPeriodInSeconds,
-                          const BRChainParams *params) {
+cyptoNetworkCreateBTC (BRCryptoNetworkListener listener,
+                       const char *uids,
+                       const char *name,
+                       const char *desc,
+                       bool isMainnet,
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
+
     BRCryptoNetworkCreateContextBTC contextBTC = {
-        params
+        (isMainnet ? BRMainNetParams : BRTestNetParams)
     };
 
     return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkBTCRecord),
-                                      type,
+                                      CRYPTO_NETWORK_TYPE_BTC,
                                       listener,
                                       uids,
                                       name,
                                       desc,
                                       isMainnet,
                                       confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
                                       &contextBTC,
                                       cryptoNetworkCreateCallbackBTC);
-}
-
-static BRCryptoNetwork
-cyptoNetworkCreateBTC (BRCryptoNetworkListener listener,
-                       const char *uids,
-                       const char *name,
-                       const char *desc,
-                       bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BTC, listener, uids, name, desc, true, confirmationPeriodInSeconds, BRMainNetParams);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BTC, listener,uids, name, desc, false, confirmationPeriodInSeconds, BRTestNetParams);
-    else {
-        assert (false); return NULL;
-    }
 }
 
 static BRCryptoNetwork
@@ -93,32 +83,61 @@ cyptoNetworkCreateBCH (BRCryptoNetworkListener listener,
                        const char *name,
                        const char *desc,
                        bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BCH, listener, uids, name, desc, true, confirmationPeriodInSeconds,  BRBCashParams);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BCH, listener, uids, name, desc, false, confirmationPeriodInSeconds, BRBCashTestNetParams);
-    else {
-        assert (false); return NULL;
-    }
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
+
+    BRCryptoNetworkCreateContextBTC contextBTC = {
+        (isMainnet ? BRBCashParams : BRBCashTestNetParams)
+    };
+
+    return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkBTCRecord),
+                                      CRYPTO_NETWORK_TYPE_BCH,
+                                      listener,
+                                      uids,
+                                      name,
+                                      desc,
+                                      isMainnet,
+                                      confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
+                                      &contextBTC,
+                                      cryptoNetworkCreateCallbackBTC);
 }
 
 static BRCryptoNetwork
 cyptoNetworkCreateBSV (BRCryptoNetworkListener listener,
-const char *uids,
+                       const char *uids,
                        const char *name,
                        const char *desc,
                        bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BSV, listener, uids, name, desc, true, confirmationPeriodInSeconds,  BRBSVParams);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsBTC (CRYPTO_NETWORK_TYPE_BSV, listener, uids, name, desc, false, confirmationPeriodInSeconds, BRBSVTestNetParams);
-    else {
-        assert (false); return NULL;
-    }
-}
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
 
+    BRCryptoNetworkCreateContextBTC contextBTC = {
+        (isMainnet ? BRBSVParams : BRBSVTestNetParams)
+    };
+
+    return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkBTCRecord),
+                                      CRYPTO_NETWORK_TYPE_BSV,
+                                      listener,
+                                      uids,
+                                      name,
+                                      desc,
+                                      isMainnet,
+                                      confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
+                                      &contextBTC,
+                                      cryptoNetworkCreateCallbackBTC);
+}
 
 static void
 cryptoNetworkReleaseBTC (BRCryptoNetwork network) {

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
@@ -40,15 +40,24 @@ cryptoNetworkCreateCallbackETH (BRCryptoNetworkCreateContext context,
 }
 
 static BRCryptoNetwork
-cryptoNetworkCreateAsETH (BRCryptoNetworkListener listener,
-                          const char *uids,
-                          const char *name,
-                          const char *desc,
-                          bool isMainnet,
-                          uint32_t confirmationPeriodInSeconds,
-                          BREthereumNetwork eth) {
+cyptoNetworkCreateETH (BRCryptoNetworkListener listener,
+                       const char *uids,
+                       const char *name,
+                       const char *desc,
+                       bool isMainnet,
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+
+    bool useMainnet = (0 == strcmp ("mainnet", desc));
+    bool useTestnet = (0 == strcmp ("testnet", desc));
+    bool useRinkeby = (0 == strcmp ("rinkeby", desc));
+
+    assert (isMainnet ? useMainnet : (useTestnet || useRinkeby));
+    
     BRCryptoNetworkCreateContextETH contextETH = {
-        eth
+        (useMainnet ? ethNetworkMainnet : (useTestnet ? ethNetworkTestnet : ethNetworkRinkeby))
     };
 
     return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkETHRecord),
@@ -59,26 +68,11 @@ cryptoNetworkCreateAsETH (BRCryptoNetworkListener listener,
                                       desc,
                                       isMainnet,
                                       confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
                                       &contextETH,
                                       cryptoNetworkCreateCallbackETH);
-}
-
-static BRCryptoNetwork
-cyptoNetworkCreateETH (BRCryptoNetworkListener listener,
-                       const char *uids,
-                       const char *name,
-                       const char *desc,
-                       bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsETH (listener, uids, name, desc, true, confirmationPeriodInSeconds, ethNetworkMainnet);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsETH (listener, uids, name, desc, false, confirmationPeriodInSeconds, ethNetworkTestnet);
-    else if (0 == strcmp ("rinkeby", desc))
-        return cryptoNetworkCreateAsETH (listener, uids, name, desc, false, confirmationPeriodInSeconds, ethNetworkRinkeby);
-    else {
-        assert (false); return NULL;
-    }
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletETH.c
@@ -265,7 +265,7 @@ cryptoWalletCreateTransferMultipleETH (BRCryptoWallet wallet,
 static OwnershipGiven BRSetOf(BRCryptoAddress)
 cryptoWalletGetAddressesForRecoveryETH (BRCryptoWallet wallet) {
     BRSetOf(BRCryptoAddress) addresses = cryptoAddressSetCreate (1);
-    BRSetAdd (addresses, cryptoWalletGetAddressETH (wallet, CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT));
+    BRSetAdd (addresses, cryptoWalletGetAddressETH (wallet, CRYPTO_ADDRESS_SCHEME_NATIVE));
     return addresses;
 }
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoNetworkHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoNetworkHBAR.c
@@ -19,40 +19,30 @@ cryptoNetworkCoerce (BRCryptoNetwork network) {
 }
 
 static BRCryptoNetwork
-cryptoNetworkCreateAsHBAR (BRCryptoNetworkListener listener,
-                           const char *uids,
-                           const char *name,
-                           const char *desc,
-                           bool isMainnet,
-                           uint32_t confirmationPeriodInSeconds) {
-    BRCryptoNetwork network = cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
-                                                         CRYPTO_NETWORK_TYPE_HBAR,
-                                                         listener,
-                                                         uids,
-                                                         name,
-                                                         desc,
-                                                         isMainnet,
-                                                         confirmationPeriodInSeconds,
-                                                         NULL,
-                                                         NULL);
-    
-    return network;
-}
-
-static BRCryptoNetwork
 cyptoNetworkCreateHBAR (BRCryptoNetworkListener listener,
                         const char *uids,
                         const char *name,
                         const char *desc,
                         bool isMainnet,
-                        uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsHBAR (listener, uids, name, desc, true, confirmationPeriodInSeconds);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsHBAR (listener, uids, name, desc, false, confirmationPeriodInSeconds);
-    else {
-        assert (false); return NULL;
-    }
+                        uint32_t confirmationPeriodInSeconds,
+                        BRCryptoAddressScheme defaultAddressScheme,
+                        BRCryptoSyncMode defaultSyncMode,
+                        BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
+
+    return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
+                                      CRYPTO_NETWORK_TYPE_HBAR,
+                                      listener,
+                                      uids,
+                                      name,
+                                      desc,
+                                      isMainnet,
+                                      confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
+                                      NULL,
+                                      NULL);
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletHBAR.c
@@ -84,7 +84,7 @@ cryptoWalletReleaseHBAR (BRCryptoWallet wallet) {
 static BRCryptoAddress
 cryptoWalletGetAddressHBAR (BRCryptoWallet wallet,
                             BRCryptoAddressScheme addressScheme) {
-    assert (CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT == addressScheme);
+    assert (CRYPTO_ADDRESS_SCHEME_NATIVE == addressScheme);
     BRCryptoWalletHBAR walletHBAR = cryptoWalletCoerce (wallet);
     return cryptoAddressCreateAsHBAR (hederaAccountGetAddress (walletHBAR->hbarAccount));
 }

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoNetworkXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoNetworkXRP.c
@@ -19,40 +19,30 @@ cryptoNetworkCoerce (BRCryptoNetwork network) {
 }
 
 static BRCryptoNetwork
-cryptoNetworkCreateAsXRP (BRCryptoNetworkListener listener,
-                          const char *uids,
-                          const char *name,
-                          const char *desc,
-                          bool isMainnet,
-                          uint32_t confirmationPeriodInSeconds) {
-    BRCryptoNetwork network = cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
-                                                         CRYPTO_NETWORK_TYPE_XRP,
-                                                         listener,
-                                                         uids,
-                                                         name,
-                                                         desc,
-                                                         isMainnet,
-                                                         confirmationPeriodInSeconds,
-                                                         NULL,
-                                                         NULL);
-    
-    return network;
-}
-
-static BRCryptoNetwork
 cyptoNetworkCreateXRP (BRCryptoNetworkListener listener,
                        const char *uids,
                        const char *name,
                        const char *desc,
                        bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsXRP (listener, uids, name, desc, true, confirmationPeriodInSeconds);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsXRP (listener, uids, name, desc, false, confirmationPeriodInSeconds);
-    else {
-        assert (false); return NULL;
-    }
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
+
+    return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
+                                      CRYPTO_NETWORK_TYPE_XRP,
+                                      listener,
+                                      uids,
+                                      name,
+                                      desc,
+                                      isMainnet,
+                                      confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
+                                      NULL,
+                                      NULL);
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletXRP.c
@@ -86,7 +86,7 @@ cryptoWalletReleaseXRP (BRCryptoWallet wallet) {
 static BRCryptoAddress
 cryptoWalletGetAddressXRP (BRCryptoWallet wallet,
                            BRCryptoAddressScheme addressScheme) {
-    assert (CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT == addressScheme);
+    assert (CRYPTO_ADDRESS_SCHEME_NATIVE == addressScheme);
     BRCryptoWalletXRP walletXRP = cryptoWalletCoerce (wallet);
     return cryptoAddressCreateAsXRP (rippleAccountGetAddress(walletXRP->xrpAccount));
 }

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoNetworkXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoNetworkXTZ.c
@@ -20,40 +20,30 @@ cryptoNetworkCoerce (BRCryptoNetwork network) {
 }
 
 static BRCryptoNetwork
-cryptoNetworkCreateAsXTZ (BRCryptoNetworkListener listener,
-                          const char *uids,
-                          const char *name,
-                          const char *desc,
-                          bool isMainnet,
-                          uint32_t confirmationPeriodInSeconds) {
-    BRCryptoNetwork network = cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
-                                                         CRYPTO_NETWORK_TYPE_XTZ,
-                                                         listener,
-                                                         uids,
-                                                         name,
-                                                         desc,
-                                                         isMainnet,
-                                                         confirmationPeriodInSeconds,
-                                                         NULL,
-                                                         NULL);
-    
-    return network;
-}
-
-static BRCryptoNetwork
 cyptoNetworkCreateXTZ (BRCryptoNetworkListener listener,
                        const char *uids,
                        const char *name,
                        const char *desc,
                        bool isMainnet,
-                       uint32_t confirmationPeriodInSeconds) {
-    if      (0 == strcmp ("mainnet", desc))
-        return cryptoNetworkCreateAsXTZ (listener, uids, name, desc, true, confirmationPeriodInSeconds);
-    else if (0 == strcmp ("testnet", desc))
-        return cryptoNetworkCreateAsXTZ (listener, uids, name, desc, false, confirmationPeriodInSeconds);
-    else {
-        assert (false); return NULL;
-    }
+                       uint32_t confirmationPeriodInSeconds,
+                       BRCryptoAddressScheme defaultAddressScheme,
+                       BRCryptoSyncMode defaultSyncMode,
+                       BRCryptoCurrency nativeCurrency) {
+    assert (0 == strcmp (desc, (isMainnet ? "mainnet" : "testnet")));
+    
+    return cryptoNetworkAllocAndInit (sizeof (struct BRCryptoNetworkRecord),
+                                      CRYPTO_NETWORK_TYPE_XTZ,
+                                      listener,
+                                      uids,
+                                      name,
+                                      desc,
+                                      isMainnet,
+                                      confirmationPeriodInSeconds,
+                                      defaultAddressScheme,
+                                      defaultSyncMode,
+                                      nativeCurrency,
+                                      NULL,
+                                      NULL);
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletXTZ.c
@@ -87,7 +87,7 @@ cryptoWalletReleaseXTZ (BRCryptoWallet wallet) {
 static BRCryptoAddress
 cryptoWalletGetAddressXTZ (BRCryptoWallet wallet,
                            BRCryptoAddressScheme addressScheme) {
-    assert (CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT == addressScheme);
+    assert (CRYPTO_ADDRESS_SCHEME_NATIVE == addressScheme);
     BRCryptoWalletXTZ walletXTZ = cryptoWalletCoerce (wallet);
     return cryptoAddressCreateAsXTZ (tezosAccountGetAddress(walletXTZ->xtzAccount));
 }

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
@@ -226,8 +226,7 @@ final class Utilities {
         switch (scheme) {
             case BTC_LEGACY: return BRCryptoAddressScheme.CRYPTO_ADDRESS_SCHEME_BTC_LEGACY;
             case BTC_SEGWIT: return BRCryptoAddressScheme.CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT;
-            case ETH_DEFAULT: return BRCryptoAddressScheme.CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT;
-            case GEN_DEFAULT: return BRCryptoAddressScheme.CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT;
+            case NATIVE:     return BRCryptoAddressScheme.CRYPTO_ADDRESS_SCHEME_NATIVE;
             default: throw new IllegalArgumentException("Unsupported scheme");
         }
     }
@@ -237,8 +236,7 @@ final class Utilities {
         switch (scheme) {
             case CRYPTO_ADDRESS_SCHEME_BTC_LEGACY: return AddressScheme.BTC_LEGACY;
             case CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT: return AddressScheme.BTC_SEGWIT;
-            case CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT: return AddressScheme.ETH_DEFAULT;
-            case CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT: return AddressScheme.GEN_DEFAULT;
+            case CRYPTO_ADDRESS_SCHEME_NATIVE:     return AddressScheme.NATIVE;
             default: throw new IllegalArgumentException("Unsupported scheme");
         }
     }

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -226,7 +226,6 @@ public final class CryptoLibraryDirect {
 
     // crypto/BRCryptoPrivate.h (BRCryptoNetwork)
     public static native void cryptoNetworkSetHeight(Pointer network, long height);
-    public static native void cryptoNetworkSetCurrency(Pointer network, Pointer currency);
     public static native void cryptoNetworkAddCurrency(Pointer network, Pointer currency, Pointer baseUnit, Pointer defaultUnit);
     public static native void cryptoNetworkAddCurrencyUnit(Pointer network, Pointer currency, Pointer unit);
     public static native void cryptoNetworkAddNetworkFee(Pointer network, Pointer networkFee);

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -40,13 +40,13 @@ public final class CryptoLibraryIndirect {
     }
 
     public static Pointer cryptoWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, BRCryptoTransferAttribute[] attributes) {
-        attributes = attributes.length == 0 ? null : attributes;
+        attributes = attributesCount.intValue() == 0 ? null : attributes;
         return INSTANCE.cryptoWalletCreateTransfer(wallet, target, amount, feeBasis, attributesCount, attributes);
     }
 
-    public static int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, BRCryptoTransferAttribute[] attributes, IntByReference validates) {
-        attributes = attributes.length == 0 ? null : attributes;
-        return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, countOfAttributes, attributes, validates);
+    public static int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT attributesCount, BRCryptoTransferAttribute[] attributes, IntByReference validates) {
+        attributes = attributesCount.intValue() == 0 ? null : attributes;
+        return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, attributesCount, attributes, validates);
     }
 
     public static void cwmAnnounceEstimateTransactionFee(Pointer cwm,
@@ -56,8 +56,8 @@ public final class CryptoLibraryIndirect {
                                                          SizeT attributesCount,
                                                          String[] attributeKeys,
                                                          String[] attributeVals) {
-        attributeKeys = attributeKeys.length == 0 ? null : attributeKeys;
-        attributeVals = attributeVals.length == 0 ? null : attributeVals;
+        attributeKeys = attributesCount.intValue() == 0 ? null : attributeKeys;
+        attributeVals = attributesCount.intValue() == 0 ? null : attributeVals;
 
         INSTANCE.cwmAnnounceEstimateTransactionFee(cwm, callbackState, success,
                 costUnits,
@@ -83,8 +83,8 @@ public final class CryptoLibraryIndirect {
                                                            SizeT attributesCount,
                                                            String[] attributeKeys,
                                                            String[] attributeVals) {
-        attributeKeys = attributeKeys.length == 0 ? null : attributeKeys;
-        attributeVals = attributeVals.length == 0 ? null : attributeVals;
+        attributeKeys = attributesCount.intValue() == 0 ? null : attributeKeys;
+        attributeVals = attributesCount.intValue() == 0 ? null : attributeVals;
         return INSTANCE.cryptoClientTransferBundleCreate(status,
                 uids, hash, identifier, sourceAddr, targetAddr,
                 amount, currency, fee,
@@ -94,13 +94,13 @@ public final class CryptoLibraryIndirect {
 
     public static void cwmAnnounceTransactions(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransactionBundle[] bundles, SizeT bundlesCount) {
         INSTANCE.cwmAnnounceTransactions(cwm, callbackState, success,
-                (0 == bundles.length ? null : bundles),
+                (0 == bundlesCount.intValue() ? null : bundles),
                 bundlesCount);
     }
 
     public static void cwmAnnounceTransfers(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransferBundle[] bundles, SizeT bundlesCount) {
         INSTANCE.cwmAnnounceTransfers(cwm, callbackState, success,
-                (0 == bundles.length ? null : bundles),
+                (0 == bundlesCount.intValue() ? null : bundles),
                 bundlesCount);
     }
 
@@ -121,8 +121,8 @@ public final class CryptoLibraryIndirect {
                 blockchainId,
                 address,
                 verified,
-                new SizeT(denominations.length),
-                (0 == denominations.length ? null : denominations));
+                denominationsCount,
+                (0 == denominationsCount.intValue() ? null : denominations));
     }
 
     public static void cwmAnnounceCurrencies(Pointer system, BRCryptoClientCurrencyBundle[] bundles, SizeT bundlesCount) {

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAddressScheme.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAddressScheme.java
@@ -23,31 +23,22 @@ public enum BRCryptoAddressScheme {
         }
     },
 
-    CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT {
+    CRYPTO_ADDRESS_SCHEME_NATIVE {
         @Override
         public int toCore() {
-            return CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT_VALUE;
-        }
-    },
-
-    CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT {
-        @Override
-        public int toCore() {
-            return CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT_VALUE;
+            return CRYPTO_ADDRESS_SCHEME_NATIVE_VALUE;
         }
     };
 
     private static final int CRYPTO_ADDRESS_SCHEME_BTC_LEGACY_VALUE  = 0;
     private static final int CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT_VALUE  = 1;
-    private static final int CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT_VALUE = 2;
-    private static final int CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT_VALUE = 3;
+    private static final int CRYPTO_ADDRESS_SCHEME_NATIVE_VALUE      = 2;
 
     public static BRCryptoAddressScheme fromCore(int nativeValue) {
         switch (nativeValue) {
             case CRYPTO_ADDRESS_SCHEME_BTC_LEGACY_VALUE:  return CRYPTO_ADDRESS_SCHEME_BTC_LEGACY;
             case CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT_VALUE:  return CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT;
-            case CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT_VALUE: return CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT;
-            case CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT_VALUE: return CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT;
+            case CRYPTO_ADDRESS_SCHEME_NATIVE_VALUE:      return CRYPTO_ADDRESS_SCHEME_NATIVE;
             default: throw new IllegalArgumentException("Invalid core value");
         }
     }

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetwork.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetwork.java
@@ -74,16 +74,6 @@ public class BRCryptoNetwork extends PointerType {
                 )
         );
     }
-
-    public void setCurrency(BRCryptoCurrency currency) {
-        Pointer thisPtr = this.getPointer();
-
-        CryptoLibraryDirect.cryptoNetworkSetCurrency(
-                thisPtr,
-                currency.getPointer()
-        );
-    }
-
     public boolean hasCurrency(BRCryptoCurrency currency) {
         Pointer thisPtr = this.getPointer();
 

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -358,9 +358,9 @@ public class BRCryptoWalletManager extends PointerType {
     }
 
      public void announceEstimateTransactionFee(BRCryptoClientCallbackState callbackState, boolean success, UnsignedLong costUnits, Map<String, String> meta) {
-         int metaCount = meta.size();
-         String[] metaKeys = meta.keySet().toArray(new String[metaCount]);
-         String[] metaVals = meta.values().toArray(new String[metaCount]);
+         int metaCount     = (null == meta ? 0    : meta.size());
+         String[] metaKeys = (null == meta ? null : meta.keySet().toArray(new String[metaCount]));
+         String[] metaVals = (null == meta ? null : meta.values().toArray(new String[metaCount]));
 
          CryptoLibraryIndirect.cwmAnnounceEstimateTransactionFee(
                  this.getPointer(),

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/AddressScheme.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/AddressScheme.java
@@ -17,8 +17,7 @@ package com.breadwallet.crypto;
 public enum  AddressScheme {
     BTC_LEGACY,
     BTC_SEGWIT,
-    ETH_DEFAULT,
-    GEN_DEFAULT;
+    NATIVE;
 
     @Override
     public String toString() {
@@ -27,10 +26,8 @@ public enum  AddressScheme {
                 return "BTC Legacy";
             case BTC_SEGWIT:
                 return "BTC Segwit";
-            case ETH_DEFAULT:
-                return "ETH Default";
-            case GEN_DEFAULT:
-                return "GEN Default";
+            case NATIVE:
+                return "Native";
             default:
                 return "Default";
         }

--- a/WalletKitSwift/WalletKit/BRCryptoAddress.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoAddress.swift
@@ -67,16 +67,15 @@ public final class Address: Equatable, CustomStringConvertible {
 public enum AddressScheme: Equatable, CustomStringConvertible {
     case btcLegacy
     case btcSegwit
-    case ethDefault
-    case genDefault
+    case native
+
 
     internal init (core: BRCryptoAddressScheme) {
         switch core {
         case CRYPTO_ADDRESS_SCHEME_BTC_LEGACY:  self = .btcLegacy
         case CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT:  self = .btcSegwit
-        case CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT: self = .ethDefault
-        case CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT: self = .genDefault
-        default: self = .genDefault;  preconditionFailure()
+        case CRYPTO_ADDRESS_SCHEME_NATIVE:      self = .native
+        default: self = .native;  preconditionFailure()
         }
     }
 
@@ -84,8 +83,7 @@ public enum AddressScheme: Equatable, CustomStringConvertible {
         switch self {
         case .btcLegacy:  return CRYPTO_ADDRESS_SCHEME_BTC_LEGACY
         case .btcSegwit:  return CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT
-        case .ethDefault: return CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT
-        case .genDefault: return CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT
+        case .native:     return CRYPTO_ADDRESS_SCHEME_NATIVE
         }
     }
 
@@ -93,8 +91,11 @@ public enum AddressScheme: Equatable, CustomStringConvertible {
         switch self {
         case .btcLegacy: return "BTC Legacy"
         case .btcSegwit: return "BTC Segwit"
-        case .ethDefault: return "ETH Default"
-        case .genDefault: return "GEN Default"
+        case .native:   return "Native"
         }
     }
+
+    public static let all = [AddressScheme.btcLegacy,
+                             AddressScheme.btcSegwit,
+                             AddressScheme.native]
 }

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -578,6 +578,11 @@ public enum WalletManagerMode: Equatable {
         }
     }
 
+    public static let all = [WalletManagerMode.api_only,
+                             WalletManagerMode.api_with_p2p_submit,
+                             WalletManagerMode.p2p_with_api_sync,
+                             WalletManagerMode.p2p_only]
+    
     // Equatable: [Swift-generated]
 }
 

--- a/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoWalletManager.swift
@@ -247,42 +247,7 @@ public final class WalletManager: Equatable, CustomStringConvertible {
         self.client  = system.client
 
         self.defaultNetworkFee = self.network.minimumFee
-        self.addressScheme     = AddressScheme (core: cryptoWalletManagerGetAddressScheme (core))
     }
-
-
-//    internal convenience init? (system: System,
-//                                callbackCoordinator: SystemCallbackCoordinator,
-//                                account: Account,
-//                                network: Network,
-//                                mode: WalletManagerMode,
-//                                addressScheme: AddressScheme,
-//                                currencies: Set<Currency>,
-//                                storagePath: String,
-//                                listener: BRCryptoListener,
-//                                client: BRCryptoClient) {
-//        guard let core = cryptoWalletManagerCreate (listener,
-//                                                    client,
-//                                                    account.core,
-//                                                    network.core,
-//                                                    mode.core,
-//                                                    addressScheme.core,
-//                                                    storagePath)
-//            else { return nil }
-//
-//        self.init (core: core,
-//                   system: system,
-//                   callbackCoordinator: callbackCoordinator,
-//                   take: false)
-//
-//        // Register a wallet for each currency.
-//        currencies
-//            .forEach {
-//                if network.hasCurrency ($0) {
-//                    let _ = registerWalletFor(currency: $0)
-//                }
-//        }
-//    }
 
     deinit {
         cryptoWalletManagerGive (core)

--- a/WalletKitSwift/WalletKitDemo/Source/WalletManagerViewController.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/WalletManagerViewController.swift
@@ -14,15 +14,6 @@ import WalletKit
 
 class WalletManagerViewController: UIViewController, WalletManagerListener {
     var manager: WalletManager!
-    let modes = [WalletManagerMode.api_only,
-                 WalletManagerMode.api_with_p2p_submit,
-                 WalletManagerMode.p2p_with_api_sync,
-                 WalletManagerMode.p2p_only]
-
-    let addressSchemes = [AddressScheme.btcLegacy,
-                          AddressScheme.btcSegwit,
-                          AddressScheme.ethDefault,
-                          AddressScheme.genDefault]
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,19 +28,19 @@ class WalletManagerViewController: UIViewController, WalletManagerListener {
     }
 
     func modeSegmentIsSelected (_ index: Int) -> Bool {
-        return manager.mode == modes[index]
+        return manager.mode == WalletManagerMode.all[index]
     }
 
     func modeSegmentIsEnabled (_ index: Int) -> Bool {
-        return manager.network.supportsMode(modes[index])
+        return manager.network.supportsMode(WalletManagerMode.all[index])
     }
 
     func addressSchemeIsSelected (_ index: Int) -> Bool {
-        return manager.addressScheme == addressSchemes[index]
+        return manager.addressScheme == AddressScheme.all[index]
     }
 
     func addressSchemeIsEnabled (_ index: Int) -> Bool {
-        return manager.network.supportsAddressScheme(addressSchemes[index])
+        return manager.network.supportsAddressScheme(AddressScheme.all[index])
    }
 
     func connectStateIsSelected (_ index: Int, _ state: WalletManagerState? = nil) -> Bool {
@@ -78,14 +69,14 @@ class WalletManagerViewController: UIViewController, WalletManagerListener {
             listener.add (managerListener: self)
         }
         
-        for index in 0..<modes.count {
+        for index in 0..<WalletManagerMode.all.count {
             modeSegmentedControl.setEnabled (modeSegmentIsEnabled(index), forSegmentAt: index)
             if modeSegmentIsSelected(index) {
                 modeSegmentedControl.selectedSegmentIndex = index
             }
         }
 
-        for index in 0..<addressSchemes.count {
+        for index in 0..<AddressScheme.all.count {
             addressSchemeSegmentedControl.setEnabled(addressSchemeIsEnabled(index), forSegmentAt: index)
             if addressSchemeIsSelected(index) {
                 addressSchemeSegmentedControl.selectedSegmentIndex = index
@@ -118,14 +109,14 @@ class WalletManagerViewController: UIViewController, WalletManagerListener {
     */
     @IBOutlet var modeSegmentedControl: UISegmentedControl!
     @IBAction func selectMode(_ sender: UISegmentedControl) {
-        print ("WMVC: Mode: \(modes[sender.selectedSegmentIndex].description)")
-        manager.mode = modes [sender.selectedSegmentIndex]
+        print ("WMVC: Mode: \(WalletManagerMode.all[sender.selectedSegmentIndex].description)")
+        manager.mode = WalletManagerMode.all [sender.selectedSegmentIndex]
     }
     
     @IBOutlet var addressSchemeSegmentedControl: UISegmentedControl!
     @IBAction func selectAddressScheme(_ sender: UISegmentedControl) {
-        print ("WMVC: AddressScheme: \(addressSchemes[sender.selectedSegmentIndex].description)")
-        manager.addressScheme = addressSchemes[sender.selectedSegmentIndex]
+        print ("WMVC: AddressScheme: \(AddressScheme.all[sender.selectedSegmentIndex].description)")
+        manager.addressScheme = AddressScheme.all[sender.selectedSegmentIndex]
     }
     @IBOutlet var connectStateSegmentedControl: UISegmentedControl!
     @IBAction func selectConnectState(_ sender: UISegmentedControl) {

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoAccountTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoAccountTests.swift
@@ -171,13 +171,13 @@ class BRCryptoAccountTests: XCTestCase {
     func testAddressScheme () {
         XCTAssertEqual (AddressScheme.btcLegacy,  AddressScheme(core: AddressScheme.btcLegacy.core))
         XCTAssertEqual (AddressScheme.btcSegwit,  AddressScheme(core: AddressScheme.btcSegwit.core))
-        XCTAssertEqual (AddressScheme.ethDefault, AddressScheme(core: AddressScheme.ethDefault.core))
-        XCTAssertEqual (AddressScheme.genDefault, AddressScheme(core: AddressScheme.genDefault.core))
+        XCTAssertEqual (AddressScheme.native, AddressScheme(core: AddressScheme.native.core))
+        XCTAssertEqual (AddressScheme.native, AddressScheme(core: AddressScheme.native.core))
 
         XCTAssertEqual("BTC Legacy",  AddressScheme.btcLegacy.description)
         XCTAssertEqual("BTC Segwit",  AddressScheme.btcSegwit.description)
-        XCTAssertEqual("ETH Default", AddressScheme.ethDefault.description)
-        XCTAssertEqual("GEN Default", AddressScheme.genDefault.description)
+        XCTAssertEqual("Native", AddressScheme.native.description)
+        XCTAssertEqual("Native", AddressScheme.native.description)
 
     }
 


### PR DESCRIPTION
This eliminates a race condition.  Lots of other small-ish changes.

- `CRYPTO_ADDRESS_SCHEME_NATIVE` - `Replaces CRYPTO_ADDRESS_SCHEME_{ETH,GEN,...}_DEFAULT`
- Initialize `BRCryptoNetwork` with default sync mode, default address scheme and currency - all constants.
- Slightly simplify implementation of `cryptoNetworkCreate{BTC,...,ETH,XRP,...}`
- In Java, handle the 'meta argument' count consistently; avoids a crash.
- Remove `cryptoNetworkSetCurrency()`