### PR TITLE
CORE-1119: On SubmitTransfer provide a quasi-realistic 'identifier'

### DIFF
--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -127,6 +127,7 @@ typedef void
 (*BRCryptoClientSubmitTransactionCallback) (BRCryptoClientContext context,
                                             OwnershipGiven BRCryptoWalletManager manager,
                                             OwnershipGiven BRCryptoClientCallbackState callbackState,
+                                            OwnershipKept const char    *identifier,
                                             OwnershipKept const uint8_t *transaction,
                                             size_t transactionLength);
 

--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -718,6 +718,7 @@ cryptoClientQRYSubmitTransfer (BRCryptoClientQRYManager qry,
     qry->client.funcSubmitTransaction (qry->client.context,
                                        cwm,
                                        callbackState,
+                                       cryptoTransferGetIdentifier(transfer),
                                        serialization,
                                        serializationCount);
 

--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -338,7 +338,7 @@ cryptoTransferGetIdentifier (BRCryptoTransfer transfer) {
                     // and `identifer` are both the string representation of the `txHash`.  See
                     // BRTransaction.{hc}
                     //
-                   BRCryptoHash hash = cryptoTransferGetHash (transfer);
+                    BRCryptoHash hash = cryptoTransferGetHash (transfer);
                     transfer->identifier = cryptoHashEncodeString(hash);
                     cryptoHashGive(hash);
                     break;

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -2019,6 +2019,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     private static void submitTransaction(Cookie context, BRCryptoWalletManager coreWalletManager, BRCryptoClientCallbackState callbackState,
+                                          String identifier,
                                           byte[] transaction) {
         EXECUTOR_CLIENT.execute(() -> {
             try {
@@ -2032,7 +2033,7 @@ final class System implements com.breadwallet.crypto.System {
                     if (optWalletManager.isPresent()) {
                         WalletManager walletManager = optWalletManager.get();
 
-                        system.query.createTransaction(walletManager.getNetwork().getUids(), transaction,
+                        system.query.createTransaction(walletManager.getNetwork().getUids(), transaction, identifier,
                                 new CompletionHandler<TransactionIdentifier, QueryError>() {
                                     @Override
                                     public void handleData(TransactionIdentifier tid) {

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClient.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoClient.java
@@ -54,6 +54,7 @@ public class BRCryptoClient extends Structure {
         void callback(Pointer context,
                       Pointer manager,
                       Pointer callbackState,
+                      String  identifier,
                       Pointer tx,
                       SizeT txLength);
     }
@@ -153,18 +154,21 @@ public class BRCryptoClient extends Structure {
         void handle(Cookie context,
                     BRCryptoWalletManager manager,
                     BRCryptoClientCallbackState callbackState,
+                    String identifier,
                     byte[] transaction);
 
         @Override
         default void callback(Pointer context,
                               Pointer manager,
                               Pointer callbackState,
+                              String identifier,
                               Pointer tx,
                               SizeT txLength) {
             handle(
                     new Cookie(context),
                     new BRCryptoWalletManager(manager),
                     new BRCryptoClientCallbackState(callbackState),
+                    identifier,
                     tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue()))
             );
         }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -340,10 +340,12 @@ public class BlockchainDb {
 
     public void createTransaction(String id,
                                   byte[] tx,
+                                  String identifier,
                                   CompletionHandler<TransactionIdentifier, QueryError> handler) {
         transactionApi.createTransaction(
                 id,
                 tx,
+                identifier,
                 handler
         );
     }

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/TransactionApi.java
@@ -97,10 +97,11 @@ public class TransactionApi {
 
     public void createTransaction(String id,
                                   byte[] tx,
+                                  String identifier,
                                   CompletionHandler<TransactionIdentifier, QueryError> handler) {
         Map json = ImmutableMap.of(
                 "blockchain_id", id,
-                "transaction_id", "unknown",
+                "transaction_id", (null == identifier ? "unknown" : (id + ":" + identifier)),
                 "data", BaseEncoding.base64().encode(tx));
 
         jsonClient.sendPost("transactions", ImmutableMultimap.of(), json, TransactionIdentifier.class, handler);

--- a/WalletKitSwift/WalletKit/BRCryptoClient.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoClient.swift
@@ -137,41 +137,6 @@ public protocol SystemClient {
         identifier: String
     )
 
-    /*
-    {
-        "status":422,
-        "error":"Unprocessable Entity",
-        "path":"/transactions",
-        "timestamp":"2021-01-19T16:30:05.040+00:00",
-        "message":"Ripple submit failed",
-        "submit_status":"nonce_already_used",
-        "network_status":"tefPAST_SEQ",
-        "network_message":"This sequence number has already passed.",
-        "parameters":{
-            "transaction_resource": {
-                "transaction_id":"ABCD",
-                "blockchain_id":"ripple-mainnet",
-                "confirmations":0,
-                "index":0,
-                "status":"rejected",
-                "layers":{},
-                "links":[]}
-            }
-        }
-    }
-
-    {
-        "transaction_id":"hedera-mainnet:0.0.89650-1610738946-000879142",
-        "identifier":"0.0.89650-1610738946-000879142",
-        "hash":"a3100a93b21c3f07c803587f08ee92827b18e1448cfb73a0470bf62b55e9ff186f8f8a3c2776c6dc8836c6c9e9bba95d",
-        "blockchain_id":"hedera-mainnet",
-        "confirmations":0,
-        "index":0,
-        "status":"submitted",
-        "layers":{}
-    }
- */
-
     func getTransactions (blockchainId: String,
                           addresses: [String],
                           begBlockNumber: UInt64?,
@@ -189,9 +154,9 @@ public protocol SystemClient {
     
     func createTransaction (blockchainId: String,
                             transaction: Data,
+                            identifier: String?,
                             completion: @escaping (Result<TransactionIdentifier, SystemClientError>) -> Void)
-    
-    
+
     // Transaction Fee
     
     typealias TransactionFee = (

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1563,7 +1563,7 @@ extension System {
                             cwmAnnounceTransfers (cwm, sid, CRYPTO_FALSE, nil,     0) })
                 }},
 
-            funcSubmitTransaction: { (context, cwm, sid, transactionBytes, transactionBytesLength) in
+            funcSubmitTransaction: { (context, cwm, sid, identifier, transactionBytes, transactionBytesLength) in
                 precondition (nil != context  && nil != cwm)
 
                 guard let (_, manager) = System.systemExtract (context, cwm)
@@ -1572,7 +1572,9 @@ extension System {
 
                 let data = Data (bytes: transactionBytes!, count: transactionBytesLength)
 
-                manager.client.createTransaction (blockchainId: manager.network.uids, transaction: data) {
+                manager.client.createTransaction (blockchainId: manager.network.uids,
+                                                  transaction: data,
+                                                  identifier: identifier.map { asUTF8String($0) }) {
                     (res: Result<SystemClient.TransactionIdentifier, SystemClientError>) in
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve(

--- a/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
@@ -97,6 +97,7 @@ public final class Transfer: Equatable {
         return cryptoTransferGetIdentifier(core)
             .map { asUTF8String($0) }
     }
+    
     /// An optional hash.  This only exists if the TransferState is .included or .submitted
     public var hash: TransferHash? {
         return cryptoTransferGetHash (core)

--- a/WalletKitSwift/WalletKit/common/BRCryptoBlockset.swift
+++ b/WalletKitSwift/WalletKit/common/BRCryptoBlockset.swift
@@ -962,10 +962,11 @@ public class BlocksetSystemClient: SystemClient {
 
     public func createTransaction (blockchainId: String,
                                    transaction: Data,
+                                   identifier: String?,
                                    completion: @escaping (Result<TransactionIdentifier, SystemClientError>) -> Void) {
         let json: JSON.Dict = [
             "blockchain_id"  : blockchainId,
-            "transaction_id" : "unknown",
+            "transaction_id" : identifier.map { "\(blockchainId):\($0)" } ?? "unknown",
             "data"           : transaction.base64EncodedString()
         ]
 


### PR DESCRIPTION
Add 'identifier' in the C callback to Swift/Java for 'SubmitTransfer' and provide as `cryptoTransferGetIdentifier()`.  In Blockset call, provide the "transaction_id" (name is TBD) as `blockchain_id + ":" + identifier`.