### PR TITLE
CORE-1120: Make 'hash' optional in TransferIdentifier

### DIFF
--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -2079,7 +2079,7 @@ final class System implements com.breadwallet.crypto.System {
                                     @Override
                                     public void handleData(TransactionIdentifier data) {
                                         Log.log(Level.FINE, "BRCryptoCWMBtcSubmitTransactionCallback: succeeded");
-                                        walletManager.getCoreBRCryptoWalletManager().announceSubmitTransferSuccess(callbackState, data.getHash());
+                                        walletManager.getCoreBRCryptoWalletManager().announceSubmitTransferSuccess(callbackState, data.getHash().orNull());
                                     }
 
                                     @Override

--- a/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/TransactionIdentifier.java
+++ b/WalletKitJava/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/TransactionIdentifier.java
@@ -1,7 +1,10 @@
 package com.breadwallet.crypto.blockchaindb.models.bdb;
 
+import android.support.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -11,12 +14,12 @@ public class TransactionIdentifier {
     @JsonCreator
     public static TransactionIdentifier create(@JsonProperty("transaction_id") String transactionId,
                                                @JsonProperty("identifier") String identifier,
-                                               @JsonProperty("hash") String hash,
+                                               @JsonProperty("hash")  @Nullable String hash,
                                                @JsonProperty("blockchain_id") String blockchainId) {
         return new TransactionIdentifier(
                 checkNotNull(transactionId),
                 checkNotNull(identifier),
-                checkNotNull(hash),
+                hash,
                 checkNotNull(blockchainId)
         );
     }
@@ -25,12 +28,12 @@ public class TransactionIdentifier {
 
     private final String transactionId;
     private final String identifier;
-    private final String hash;
+    private final @Nullable String hash;
     private final String blockchainId;
 
     private TransactionIdentifier(String transactionId,
                                   String identifier,
-                                  String hash,
+                                  @Nullable String hash,
                                   String blockchainId) {
         this.transactionId = transactionId;
         this.identifier = identifier;
@@ -50,8 +53,8 @@ public class TransactionIdentifier {
     }
 
     @JsonProperty("hash")
-    public String getHash() {
-        return hash;
+    public Optional<String> getHash() {
+        return Optional.fromNullable(hash);
     }
 
     @JsonProperty("blockchain_id")

--- a/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
+++ b/WalletKitSwift/WalletKit/common/BRBlockChainDB.swift
@@ -450,16 +450,17 @@ public class BlockChainDB {
         public typealias TransactionIdentifier = (
             id: String,
             blockchainId: String,
-            hash: String,
+            hash: String?,
             identifier: String
         )
 
         static internal func asTransactionIdentifier (json: JSON) -> TransactionIdentifier? {
             guard let id         = json.asString(name: "transaction_id"),
                   let bid        = json.asString (name: "blockchain_id"),
-                  let hash       = json.asString (name: "hash"),
                   let identifier = json.asString (name: "identifier")
             else { return nil }
+
+            let hash = json.asString (name: "hash")
 
             return (id: id, blockchainId: bid, hash: hash, identifier: identifier)
         }


### PR DESCRIPTION
But, required for Hedera.