### PR TITLE
CORE-1059: Generate SYNC events in API mode

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -768,7 +768,7 @@ cryptoWalletManagerConnect (BRCryptoWalletManager cwm,
         case CRYPTO_WALLET_MANAGER_STATE_CREATED:
         case CRYPTO_WALLET_MANAGER_STATE_DISCONNECTED: {
 
-            cryptoClientQRYManagerConnect (cwm->qryManager);
+            // Go to the connected state.
             if (CRYPTO_CLIENT_P2P_MANAGER_TYPE == cwm->canSend.type ||
                 CRYPTO_CLIENT_P2P_MANAGER_TYPE == cwm->canSync.type)
                 cryptoClientP2PManagerConnect (cwm->p2pManager, peer);
@@ -776,6 +776,8 @@ cryptoWalletManagerConnect (BRCryptoWalletManager cwm,
                 // TODO: CORE-1059 - Do we require cryptoClientP2PManagerConnect to set BRCryptoWalletManager state?
                 cryptoWalletManagerSetState (cwm, cryptoWalletManagerStateInit (CRYPTO_WALLET_MANAGER_STATE_CONNECTED));
 
+            // Start the QRY Manager
+            cryptoClientQRYManagerConnect (cwm->qryManager);
             break;
         }
             

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerP2PBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerP2PBTC.c
@@ -103,9 +103,9 @@ cryptoClientP2PManagerConnectBTC (BRCryptoClientP2PManager baseManager,
         BRPeerManagerSetFixedPeer (manager->btcPeerManager, address, port);
     }
 
-//    if (!syncInProgress)
-        // Change state here; before connecting to the `btcPeerManager` produces start/stop/updates.
-        cryptoWalletManagerSetState (&manager->manager->base, cryptoWalletManagerStateInit (CRYPTO_WALLET_MANAGER_STATE_SYNCING));
+    //    if (!syncInProgress)
+    // Change state here; before connecting to the `btcPeerManager` produces start/stop/updates.
+    cryptoWalletManagerSetState (&manager->manager->base, cryptoWalletManagerStateInit (CRYPTO_WALLET_MANAGER_STATE_SYNCING));
 
     // Start periodic updates, sync if required.
     BRPeerManagerConnect(manager->btcPeerManager);


### PR DESCRIPTION
In JIRA CORE-1059 it is noted the `Wallet Manger <currency>` tests fail because the event sequence produced is different from what the test expects.  Those tests are not fixed.  In reviewing the events, I'm not sure if the expected events are actually correct.  Going to leave the event sequences until consideration of 'callbacks vs events'.

This change does bring the API vs P2P events into (near) agreement.