### PR TITLE
CORE-1129: Make BRCryptoClient 'Announce' as EventTypes

### DIFF
--- a/WalletKitCore/include/BRCryptoClient.h
+++ b/WalletKitCore/include/BRCryptoClient.h
@@ -30,11 +30,11 @@ typedef void
                                          OwnershipGiven BRCryptoClientCallbackState callbackState);
 
 extern void
-cwmAnnounceBlockNumber (OwnershipKept BRCryptoWalletManager cwm,
-                        OwnershipGiven BRCryptoClientCallbackState callbackState,
-                        BRCryptoBoolean success,
-                        BRCryptoBlockNumber blockNumber,
-                        const char *verifiedBlockHash);
+cryptoClientAnnounceBlockNumber (OwnershipKept BRCryptoWalletManager cwm,
+                               OwnershipGiven BRCryptoClientCallbackState callbackState,
+                               BRCryptoBoolean success,
+                               BRCryptoBlockNumber blockNumber,
+                               const char *verifiedBlockHash);
 
 // MARK: - Get Transactions
 
@@ -65,11 +65,11 @@ cryptoClientTransactionBundleCompare (const BRCryptoClientTransactionBundle b1,
                                       const BRCryptoClientTransactionBundle b2);
 
 extern void
-cwmAnnounceTransactions (OwnershipKept BRCryptoWalletManager cwm,
-                         OwnershipGiven BRCryptoClientCallbackState callbackState,
-                         BRCryptoBoolean success,
-                         BRCryptoClientTransactionBundle *bundles,
-                         size_t bundlesCount);
+cryptoClientAnnounceTransactions (OwnershipKept BRCryptoWalletManager cwm,
+                                  OwnershipGiven BRCryptoClientCallbackState callbackState,
+                                  BRCryptoBoolean success,
+                                  BRCryptoClientTransactionBundle *bundles,
+                                  size_t bundlesCount);
 
 // MARK: - Get Transfers
 
@@ -115,11 +115,11 @@ cryptoClientTransferBundleGetTransferState (const BRCryptoClientTransferBundle b
                                             BRCryptoFeeBasis confirmedFeeBasis);
 
 extern void
-cwmAnnounceTransfers (OwnershipKept BRCryptoWalletManager cwm,
-                      OwnershipGiven BRCryptoClientCallbackState callbackState,
-                      BRCryptoBoolean success,
-                      BRCryptoClientTransferBundle *bundles,
-                      size_t bundlesCount);
+cryptoClientAnnounceTransfers (OwnershipKept BRCryptoWalletManager cwm,
+                               OwnershipGiven BRCryptoClientCallbackState callbackState,
+                               BRCryptoBoolean success,
+                               BRCryptoClientTransferBundle *bundles,
+                               size_t bundlesCount);
 
 // MARK: - Submit Transaction
 
@@ -132,11 +132,11 @@ typedef void
                                             size_t transactionLength);
 
 extern void
-cwmAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
-                           OwnershipGiven BRCryptoClientCallbackState callbackState,
-                           OwnershipKept const char *identifier,
-                           OwnershipKept const char *hash,
-                           BRCryptoBoolean success);
+cryptoClientAnnounceSubmitTransfer (OwnershipKept BRCryptoWalletManager cwm,
+                                    OwnershipGiven BRCryptoClientCallbackState callbackState,
+                                    OwnershipKept const char *identifier,
+                                    OwnershipKept const char *hash,
+                                    BRCryptoBoolean success);
 
 // MARK: - Estimate Transaction Fee
 
@@ -149,13 +149,13 @@ typedef void
                                                  OwnershipKept const char *hashAsHex);
 
 extern void
-cwmAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
-                                   OwnershipGiven BRCryptoClientCallbackState callbackState,
-                                   BRCryptoBoolean success,
-                                   uint64_t costUnits,
-                                   size_t attributesCount,
-                                   OwnershipKept const char **attributeKeys,
-                                   OwnershipKept const char **attributeVals);
+cryptoClientAnnounceEstimateTransactionFee (OwnershipKept BRCryptoWalletManager cwm,
+                                            OwnershipGiven BRCryptoClientCallbackState callbackState,
+                                            BRCryptoBoolean success,
+                                            uint64_t costUnits,
+                                            size_t attributesCount,
+                                            OwnershipKept const char **attributeKeys,
+                                            OwnershipKept const char **attributeVals);
 
 // MARK: - Currency
 
@@ -183,9 +183,9 @@ extern void
 cryptoClientCurrencyBundleRelease (BRCryptoClientCurrencyBundle bundle);
 
 extern void
-cwmAnnounceCurrencies (BRCryptoSystem system,
-                       OwnershipGiven BRCryptoClientCurrencyBundle *bundles,
-                       size_t bundlesCount);
+cryptoClientAnnounceCurrencies (BRCryptoSystem system,
+                                OwnershipGiven BRCryptoClientCurrencyBundle *bundles,
+                                size_t bundlesCount);
 
 typedef struct {
     BRCryptoClientContext context;

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -16,6 +16,7 @@
 #include "support/BRArray.h"
 #include "support/BRSet.h"
 #include "support/rlp/BRRlp.h"
+#include "support/event/BREvent.h"
 
 #include "BRCryptoClient.h"
 #include "BRCryptoSync.h"
@@ -397,6 +398,19 @@ cryptoClientQRYManagerAsSend (BRCryptoClientQRYManager qry) {
         { .qryManager = qry }
     };
 }
+
+extern BREventType handleClientAnnounceBlockNumberEventType;
+extern BREventType handleClientAnnounceTransactionsEventType;
+extern BREventType handleClientAnnounceTransfersEventType;
+extern BREventType handleClientAnnounceSubmitEventType;
+extern BREventType handleClientAnnounceEstimateTransactionFeeEventType;
+
+#define CRYPTO_CLIENT_EVENT_TYPES             \
+  &handleClientAnnounceBlockNumberEventType,  \
+  &handleClientAnnounceTransactionsEventType, \
+  &handleClientAnnounceTransfersEventType,    \
+  &handleClientAnnounceSubmitEventType,       \
+  &handleClientAnnounceEstimateTransactionFeeEventType
 
 #ifdef __cplusplus
 }

--- a/WalletKitCore/src/crypto/BRCryptoTransferP.h
+++ b/WalletKitCore/src/crypto/BRCryptoTransferP.h
@@ -75,7 +75,7 @@ typedef void
 typedef BRCryptoHash
 (*BRCryptoTransferGetHashHandler) (BRCryptoTransfer transfer);
 
-typedef int // 1 if changed; 0 if not
+typedef bool // true if changed
 (*BRCryptoTransferSetHashHandler) (BRCryptoTransfer transfer,
                                    BRCryptoHash hash);
 
@@ -118,6 +118,8 @@ struct BRCryptoTransferRecord {
     char *identifier;
     BRCryptoAddress sourceAddress;
     BRCryptoAddress targetAddress;
+
+    /// The state (modifiable)
     BRCryptoTransferState state;
 
     /// The amount's unit.
@@ -139,6 +141,7 @@ struct BRCryptoTransferRecord {
     /// The amount (unsigned value).
     BRCryptoAmount amount;
 
+    /// The attributes (modifiable)
     BRArrayOf(BRCryptoTransferAttribute) attributes;
 };
 
@@ -168,6 +171,7 @@ private_extern void
 cryptoTransferSetState (BRCryptoTransfer transfer,
                         BRCryptoTransferState state);
 
+// TODO: Are TransferAttributes not constant?
 private_extern void
 cryptoTransferSetAttributes (BRCryptoTransfer transfer,
                              size_t attributesCount,

--- a/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManagerP.h
@@ -193,15 +193,16 @@ struct BRCryptoWalletManagerRecord {
     /// The primary wallet
     BRCryptoWallet wallet;
 
-    /// All wallets
+    /// All wallets (modifiable)
     BRArrayOf(BRCryptoWallet) wallets;
 
+    /// The state (modifiable)
     BRCryptoWalletManagerState state;
 
     BRCryptoWalletManagerListener listener;
     BRCryptoWalletListener listenerWallet;
-//    BRCryptoListener listenerTrampoline;
 
+    /// The {Transfer,Transaction}Bundle (modifiable)
     Nullable BRArrayOf(BRCryptoClientTransferBundle) bundleTransfers;
     Nullable BRArrayOf(BRCryptoClientTransactionBundle) bundleTransactions;
 };
@@ -270,19 +271,6 @@ cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (BRCryptoWallet w
                                                                 BRCryptoTransfer transfer,
                                                                 OwnershipKept BRCryptoClientTransferBundle bundle);
 
-//private_extern void
-//cryptoWalletManagerGenerateTransferEvent (BRCryptoWalletManager cwm,
-//                                          BRCryptoWallet wallet,
-//                                          BRCryptoTransfer transfer,
-//                                          BRCryptoTransferEvent event);
-//
-//private_extern void
-//cryptoWalletManagerGenerateWalletEvent (BRCryptoWalletManager cwm,
-//                                          BRCryptoWallet wallet,
-//                                          BRCryptoWalletEvent event);
-//
-
-
 private_extern BRCryptoFeeBasis
 cryptoWalletManagerRecoverFeeBasisFromFeeEstimate (BRCryptoWalletManager cwm,
                                                    BRCryptoNetworkFee networkFee,
@@ -297,7 +285,6 @@ cryptoWalletManagerGenerateEvent (BRCryptoWalletManager manager,
                                   BRCryptoWalletManagerEvent event) {
     cryptoListenerGenerateManagerEvent (&manager->listener, manager, event);
 }
-
 
 #ifdef __cplusplus
 }

--- a/WalletKitCore/src/crypto/BRCryptoWalletP.h
+++ b/WalletKitCore/src/crypto/BRCryptoWalletP.h
@@ -138,26 +138,21 @@ struct BRCryptoWalletRecord {
     pthread_mutex_t lock;
     BRCryptoWalletListener listener;
 
+    /// The state (modifiable)
     BRCryptoWalletState state;
 
     BRCryptoUnit unit;
     BRCryptoUnit unitForFee;
 
-    //
-    // Do we hold transfers here?  The BRWallet and the BREthereumWallet already hold transfers.
-    // Shouldn't we defer to those to get transfers (and then wrap them in BRCryptoTransfer)?
-    // Then we avoid caching trouble (in part).  For a newly created transaction (not yet signed),
-    // the BRWallet will not hold a BRTransaction however, BREthereumWallet will hold a new
-    // BREthereumTransaction. From BRWalet: `assert(tx != NULL && BRTransactionIsSigned(tx));`
-    //
-    // We are going to have the same
-    //
+    /// The transfers (modifiable)
     BRArrayOf (BRCryptoTransfer) transfers;
 
+    /// The balance (modifiable)
     BRCryptoAmount balance;
     BRCryptoAmount balanceMinimum;
     BRCryptoAmount balanceMaximum;
 
+    /// The defaultFeeBaiss (modifiable)
     BRCryptoFeeBasis defaultFeeBasis;
 
     BRCryptoTransferListener listenerTransfer;

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoBTC.h
@@ -251,12 +251,6 @@ extern BRArrayOf(BRTransaction*) initialTransactionsLoadBTC (BRCryptoWalletManag
 extern BRArrayOf(BRPeer)         initialPeersLoadBTC        (BRCryptoWalletManager manager);
 extern BRArrayOf(BRMerkleBlock*) initialBlocksLoadBTC       (BRCryptoWalletManager manager);
 
-// MARK: - Events
-
-extern const BREventType *eventTypesBTC[];
-extern const unsigned int eventTypesCountBTC;
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
+++ b/WalletKitCore/src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c
@@ -19,6 +19,8 @@
 
 // BRWallet Callbacks
 
+// MARK: - Foward Declarations
+
 // On: BRWalletRegisterTransaction, BRWalletRemoveTransaction
 static void cryptoWalletManagerBTCBalanceChanged (void *info, uint64_t balanceInSatoshi);
 // On: BRWalletRegisterTransaction
@@ -27,6 +29,17 @@ static void cryptoWalletManagerBTCTxAdded   (void *info, BRTransaction *tx);
 static void cryptoWalletManagerBTCTxUpdated (void *info, const UInt256 *hashes, size_t count, uint32_t blockHeight, uint32_t timestamp);
 // On: BRWalletRemoveTransaction
 static void cryptoWalletManagerBTCTxDeleted (void *info, UInt256 hash, int notifyUser, int recommendRescan);
+
+// MARK: - Events
+
+static const BREventType *eventTypesBTC[] = {
+    CRYPTO_CLIENT_EVENT_TYPES
+};
+
+static const unsigned int
+eventTypesCountBTC = (sizeof (eventTypesBTC) / sizeof (BREventType*));
+
+// MARK: - Wallet Manager
 
 extern BRCryptoWalletManagerBTC
 cryptoWalletManagerCoerceBTC (BRCryptoWalletManager manager, BRCryptoBlockChainType type) {
@@ -640,12 +653,6 @@ static void cryptoWalletManagerBTCTxDeleted (void *info, UInt256 hash, int notif
         }
     }
 }
-
-const BREventType *eventTypesBTC[] = {
-};
-
-const unsigned int
-eventTypesCountBTC = (sizeof (eventTypesBTC) / sizeof (BREventType*));
 
 BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersBTC = {
     cryptoWalletManagerCreateBTC,

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -35,6 +35,15 @@ static void
 cryptoWalletManagerCreateTokensForNetwork (BRCryptoWalletManagerETH manager,
                                            BRCryptoNetwork network);
 
+// MARK: - Event Types
+
+const BREventType *eventTypesETH[] = {
+    CRYPTO_CLIENT_EVENT_TYPES
+};
+const unsigned int eventTypesCountETH = (sizeof (eventTypesETH) / sizeof (BREventType*));
+
+// MARK: - Wallet Manager
+
 extern BRCryptoWalletManagerETH
 cryptoWalletManagerCoerceETH (BRCryptoWalletManager manager) {
     assert (CRYPTO_NETWORK_TYPE_ETH == manager->type);
@@ -936,9 +945,6 @@ cryptoWalletManagerRecoverTransferFromTransferBundleETH (BRCryptoWalletManager m
     cryptoCurrencyGive (currency);
     cryptoNetworkGive (network);
 }
-
-const BREventType *eventTypesETH[] = {};
-const unsigned int eventTypesCountETH = (sizeof (eventTypesETH) / sizeof (BREventType*));
 
 BRCryptoWalletManagerHandlers cryptoWalletManagerHandlersETH = {
     cryptoWalletManagerCreateETH,

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoTransferHBAR.c
@@ -97,13 +97,13 @@ cryptoTransferGetHashHBAR (BRCryptoTransfer transfer) {
     return cryptoHashCreateAsHBAR (hash);
 }
 
-extern int
+extern bool
 cryptoTransferSetHashHBAR (BRCryptoTransfer transfer,
                            BRCryptoHash hash) {
     BRCryptoTransferHBAR transferHBAR = cryptoTransferCoerceHBAR(transfer);
     BRHederaTransactionHash hashHBAR  = cryptoHashAsHBAR(hash);
 
-    return hederaTransactionUpdateHash (transferHBAR->hbarTransaction, hashHBAR);
+    return 1 == hederaTransactionUpdateHash (transferHBAR->hbarTransaction, hashHBAR);
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -240,6 +240,7 @@ cryptoWalletManagerRecoverTransferFromTransferBundleHBAR (BRCryptoWalletManager 
     
     cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
     
+    cryptoTransferGive(baseTransfer);
     cryptoFeeBasisGive (feeBasis);
     cryptoTransferStateGive (state);
 

--- a/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
+++ b/WalletKitCore/src/crypto/handlers/hbar/BRCryptoWalletManagerHBAR.c
@@ -24,20 +24,12 @@
 
 // MARK: - Events
 
-//TODO:HBAR make common
-const BREventType *hbarEventTypes[] = {
-    // ...
+static const BREventType *hbarEventTypes[] = {
+    CRYPTO_CLIENT_EVENT_TYPES
 };
 
-const unsigned int
+static const unsigned int
 hbarEventTypesCount = (sizeof (hbarEventTypes) / sizeof (BREventType*));
-
-
-//static BRCryptoWalletManagerHBAR
-//cryptoWalletManagerCoerce (BRCryptoWalletManager wm) {
-//    assert (CRYPTO_NETWORK_TYPE_HBAR == wm->type);
-//    return (BRCryptoWalletManagerHBAR) wm;
-//}
 
 // MARK: - Handlers
 

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -240,6 +240,7 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXRP (BRCryptoWalletManager m
     
     cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
 
+    cryptoTransferGive(baseTransfer);
     cryptoFeeBasisGive (feeBasis);
     cryptoTransferStateGive (state);
 

--- a/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
+++ b/WalletKitCore/src/crypto/handlers/xrp/BRCryptoWalletManagerXRP.c
@@ -25,11 +25,11 @@
 // MARK: - Events
 
 //TODO:XRP make common
-const BREventType *xrpEventTypes[] = {
-    // ...
+static const BREventType *xrpEventTypes[] = {
+    CRYPTO_CLIENT_EVENT_TYPES
 };
 
-const unsigned int
+static const unsigned int
 xrpEventTypesCount = (sizeof (xrpEventTypes) / sizeof (BREventType*));
 
 

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -25,20 +25,12 @@
 
 // MARK: - Events
 
-//TODO:XTZ make common
-const BREventType *xtzEventTypes[] = {
-    // ...
+static const BREventType *xtzEventTypes[] = {
+    CRYPTO_CLIENT_EVENT_TYPES
 };
 
-const unsigned int
+static const unsigned int
 xtzEventTypesCount = (sizeof (xtzEventTypes) / sizeof (BREventType*));
-
-
-//static BRCryptoWalletManagerXTZ
-//cryptoWalletManagerCoerce (BRCryptoWalletManager wm) {
-//    assert (CRYPTO_NETWORK_TYPE_XTZ == wm->type);
-//    return (BRCryptoWalletManagerXTZ) wm;
-//}
 
 // MARK: - Handlers
 

--- a/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
+++ b/WalletKitCore/src/crypto/handlers/xtz/BRCryptoWalletManagerXTZ.c
@@ -264,6 +264,7 @@ cryptoWalletManagerRecoverTransferFromTransferBundleXTZ (BRCryptoWalletManager m
     
     cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (wallet, baseTransfer, bundle);
     
+    cryptoTransferGive(baseTransfer);
     cryptoFeeBasisGive (feeBasis);
     cryptoTransferStateGive (state);
     

--- a/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/WalletKitJava/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -123,6 +123,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.breadwallet.corenative.crypto.BRCryptoTransferEventType.CRYPTO_TRANSFER_EVENT_CHANGED;
 import static com.google.common.base.Preconditions.checkState;
 
 /* package */
@@ -1620,6 +1621,10 @@ final class System implements com.breadwallet.crypto.System {
                     }
                 }
             } finally {
+                if (CRYPTO_TRANSFER_EVENT_CHANGED == event.type()) {
+                    event.u.state.oldState.give();
+                    event.u.state.newState.give();
+                }
                 coreTransfer.give();
                 coreWallet.give();
                 coreWalletManager.give();

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -390,8 +390,8 @@ public final class CryptoLibraryDirect {
     // See 'Indirect':
     public static native void cryptoClientCurrencyBundleRelease (Pointer currencyBundle);
 
-    public static native void cwmAnnounceBlockNumber(Pointer cwm, Pointer callbackState, int success, long blockNumber, String verifiedBlockHash);
-    public static native void cwmAnnounceSubmitTransfer(Pointer cwm, Pointer callbackState, String identifier, String hash, int success);
+    public static native void cryptoClientAnnounceBlockNumber(Pointer cwm, Pointer callbackState, int success, long blockNumber, String verifiedBlockHash);
+    public static native void cryptoClientAnnounceSubmitTransfer(Pointer cwm, Pointer callbackState, String identifier, String hash, int success);
 
     //
     // Crypto Primitives

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -49,17 +49,17 @@ public final class CryptoLibraryIndirect {
         return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, attributesCount, attributes, validates);
     }
 
-    public static void cwmAnnounceEstimateTransactionFee(Pointer cwm,
-                                                         Pointer callbackState,
-                                                         int success,
-                                                         long costUnits,
-                                                         SizeT attributesCount,
-                                                         String[] attributeKeys,
-                                                         String[] attributeVals) {
+    public static void cryptoClientAnnounceEstimateTransactionFee(Pointer cwm,
+                                                                  Pointer callbackState,
+                                                                  int success,
+                                                                  long costUnits,
+                                                                  SizeT attributesCount,
+                                                                  String[] attributeKeys,
+                                                                  String[] attributeVals) {
         attributeKeys = attributesCount.intValue() == 0 ? null : attributeKeys;
         attributeVals = attributesCount.intValue() == 0 ? null : attributeVals;
 
-        INSTANCE.cwmAnnounceEstimateTransactionFee(cwm, callbackState, success,
+        INSTANCE.cryptoClientAnnounceEstimateTransactionFee(cwm, callbackState, success,
                 costUnits,
                 attributesCount,
                 attributeKeys,
@@ -92,14 +92,14 @@ public final class CryptoLibraryIndirect {
                 attributesCount, attributeKeys, attributeVals);
     }
 
-    public static void cwmAnnounceTransactions(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransactionBundle[] bundles, SizeT bundlesCount) {
-        INSTANCE.cwmAnnounceTransactions(cwm, callbackState, success,
+    public static void cryptoClientAnnounceTransactions(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransactionBundle[] bundles, SizeT bundlesCount) {
+        INSTANCE.cryptoClientAnnounceTransactions(cwm, callbackState, success,
                 (0 == bundlesCount.intValue() ? null : bundles),
                 bundlesCount);
     }
 
-    public static void cwmAnnounceTransfers(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransferBundle[] bundles, SizeT bundlesCount) {
-        INSTANCE.cwmAnnounceTransfers(cwm, callbackState, success,
+    public static void cryptoClientAnnounceTransfers(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransferBundle[] bundles, SizeT bundlesCount) {
+        INSTANCE.cryptoClientAnnounceTransfers(cwm, callbackState, success,
                 (0 == bundlesCount.intValue() ? null : bundles),
                 bundlesCount);
     }
@@ -125,8 +125,8 @@ public final class CryptoLibraryIndirect {
                 (0 == denominationsCount.intValue() ? null : denominations));
     }
 
-    public static void cwmAnnounceCurrencies(Pointer system, BRCryptoClientCurrencyBundle[] bundles, SizeT bundlesCount) {
-        INSTANCE.cwmAnnounceCurrencies(system,
+    public static void cryptoClientAnnounceCurrencies(Pointer system, BRCryptoClientCurrencyBundle[] bundles, SizeT bundlesCount) {
+        INSTANCE.cryptoClientAnnounceCurrencies(system,
                 (0 == bundles.length ? null : bundles),
                 bundlesCount);
     }
@@ -194,8 +194,8 @@ public final class CryptoLibraryIndirect {
                                                  String[] attributeKeys,
                                                  String[] attributeVals);
 
-        void cwmAnnounceTransactions(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransactionBundle[] bundles, SizeT bundlesCount);
-        void cwmAnnounceTransfers(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransferBundle[] bundles, SizeT bundlesCount);
+        void cryptoClientAnnounceTransactions(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransactionBundle[] bundles, SizeT bundlesCount);
+        void cryptoClientAnnounceTransfers(Pointer cwm, Pointer callbackState, int success, BRCryptoClientTransferBundle[] bundles, SizeT bundlesCount);
 
         Pointer cryptoClientCurrencyBundleCreate(String id,
                                                  String name,
@@ -207,15 +207,15 @@ public final class CryptoLibraryIndirect {
                                                  SizeT denominationsCount,
                                                  BRCryptoClientCurrencyDenominationBundle[] denominations);
 
-        void cwmAnnounceCurrencies (Pointer system, BRCryptoClientCurrencyBundle[] bundles, SizeT bundlesCount);
+        void cryptoClientAnnounceCurrencies (Pointer system, BRCryptoClientCurrencyBundle[] bundles, SizeT bundlesCount);
 
-        void cwmAnnounceEstimateTransactionFee(Pointer cwm,
-                                               Pointer callbackState,
-                                               int success,
-                                               long costUnits,
-                                               SizeT attributesCount,
-                                               String[] attributeKeys,
-                                               String[] attributeVals);
+        void cryptoClientAnnounceEstimateTransactionFee(Pointer cwm,
+                                                        Pointer callbackState,
+                                                        int success,
+                                                        long costUnits,
+                                                        SizeT attributesCount,
+                                                        String[] attributeKeys,
+                                                        String[] attributeVals);
 
         // crypto/BRCryptoWalletManager.h
         void cryptoWalletManagerEstimateFeeBasis (Pointer cwm,

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoSystem.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoSystem.java
@@ -241,7 +241,7 @@ public class BRCryptoSystem extends PointerType {
         int bundlesCount = bundles.size();
         BRCryptoClientCurrencyBundle[] bundlesArr = bundles.toArray(new BRCryptoClientCurrencyBundle[bundlesCount]);
 
-        CryptoLibraryIndirect.cwmAnnounceCurrencies(
+        CryptoLibraryIndirect.cryptoClientAnnounceCurrencies(
                 this.getPointer(),
                 bundlesArr,
                 new SizeT(bundlesCount));

--- a/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/WalletKitJava/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -325,7 +325,7 @@ public class BRCryptoWalletManager extends PointerType {
     }
 
     public void announceGetBlockNumber(BRCryptoClientCallbackState callbackState, boolean success, UnsignedLong blockNumber, String verifiedBlockHash) {
-        CryptoLibraryDirect.cwmAnnounceBlockNumber (
+        CryptoLibraryDirect.cryptoClientAnnounceBlockNumber (
                 this.getPointer(),
                 callbackState.getPointer(),
                 (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE),
@@ -337,7 +337,7 @@ public class BRCryptoWalletManager extends PointerType {
         int bundlesCount = bundles.size();
         BRCryptoClientTransactionBundle[] bundlesArr = bundles.toArray(new BRCryptoClientTransactionBundle[bundlesCount]);
 
-        CryptoLibraryIndirect.cwmAnnounceTransactions(
+        CryptoLibraryIndirect.cryptoClientAnnounceTransactions(
                 this.getPointer(),
                 callbackState.getPointer(),
                 (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE),
@@ -349,7 +349,7 @@ public class BRCryptoWalletManager extends PointerType {
         int bundlesCount = bundles.size();
         BRCryptoClientTransferBundle[] bundlesArr = bundles.toArray(new BRCryptoClientTransferBundle[bundlesCount]);
 
-        CryptoLibraryIndirect.cwmAnnounceTransfers(
+        CryptoLibraryIndirect.cryptoClientAnnounceTransfers(
                 this.getPointer(),
                 callbackState.getPointer(),
                 (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE),
@@ -358,7 +358,7 @@ public class BRCryptoWalletManager extends PointerType {
     }
 
     public void announceSubmitTransfer(BRCryptoClientCallbackState callbackState, String identifier, String hash, boolean success) {
-        CryptoLibraryDirect.cwmAnnounceSubmitTransfer (
+        CryptoLibraryDirect.cryptoClientAnnounceSubmitTransfer (
                 this.getPointer(),
                 callbackState.getPointer(),
                 identifier,
@@ -371,7 +371,7 @@ public class BRCryptoWalletManager extends PointerType {
          String[] metaKeys = (null == meta ? null : meta.keySet().toArray(new String[metaCount]));
          String[] metaVals = (null == meta ? null : meta.values().toArray(new String[metaCount]));
 
-         CryptoLibraryIndirect.cwmAnnounceEstimateTransactionFee(
+         CryptoLibraryIndirect.cryptoClientAnnounceEstimateTransactionFee(
                  this.getPointer(),
                  callbackState.getPointer(),
                  (success ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE),

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -666,7 +666,7 @@ public final class System {
                                                                  &denominationBundles);
                     }
                     defer { bundles.forEach { cryptoClientCurrencyBundleRelease($0) }}
-                    cwmAnnounceCurrencies (self.core, &bundles, bundles.count)
+                    cryptoClientAnnounceCurrencies (self.core, &bundles, bundles.count)
                     completion? (Result.success(self.networks))
                 },
 
@@ -1521,10 +1521,13 @@ extension System {
                     (res: Result<SystemClient.Blockchain, SystemClientError>) in
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve (
-                        success: {        cwmAnnounceBlockNumber (cwm, sid, CRYPTO_TRUE,  $0.blockHeight ?? 0, $0.verifiedBlockHash) },
+                        success: {
+                            cryptoClientAnnounceBlockNumber (cwm, sid, CRYPTO_TRUE,  $0.blockHeight ?? 0, $0.verifiedBlockHash)
+                        },
                         failure: { (e) in
                             print ("SYS: GetBlockNumber: Error: \(e)")
-                            cwmAnnounceBlockNumber (cwm, sid, CRYPTO_FALSE, 0, nil) })
+                            cryptoClientAnnounceBlockNumber (cwm, sid, CRYPTO_FALSE, 0, nil)
+                        })
                 }},
 
             funcGetTransactions: { (context, cwm, sid, addresses, addressesCount, begBlockNumber, endBlockNumber) in
@@ -1547,10 +1550,10 @@ extension System {
                     res.resolve(
                         success: {
                             var bundles: [BRCryptoClientTransactionBundle?] = System.canonicalizeTransactions ($0).map { System.makeTransactionBundle ($0) }
-                            cwmAnnounceTransactions (cwm, sid, CRYPTO_TRUE,  &bundles, bundles.count) },
+                            cryptoClientAnnounceTransactions (cwm, sid, CRYPTO_TRUE,  &bundles, bundles.count) },
                         failure: { (e) in
                             print ("SYS: GetTransactions: Error: \(e)")
-                            cwmAnnounceTransactions (cwm, sid, CRYPTO_FALSE, nil, 0) })
+                            cryptoClientAnnounceTransactions (cwm, sid, CRYPTO_FALSE, nil, 0) })
                 }},
 
             funcGetTransfers: { (context, cwm, sid, addresses, addressesCount, begBlockNumber, endBlockNumber) in
@@ -1573,10 +1576,10 @@ extension System {
                     res.resolve(
                         success: {
                             var bundles: [BRCryptoClientTransferBundle?]  = $0.flatMap { System.makeTransferBundles ($0, addresses: addresses) }
-                            cwmAnnounceTransfers (cwm, sid, CRYPTO_TRUE,  &bundles, bundles.count) },
+                            cryptoClientAnnounceTransfers (cwm, sid, CRYPTO_TRUE,  &bundles, bundles.count) },
                         failure: { (e) in
                             print ("SYS: GetTransfers: Error: \(e)")
-                            cwmAnnounceTransfers (cwm, sid, CRYPTO_FALSE, nil,     0) })
+                            cryptoClientAnnounceTransfers (cwm, sid, CRYPTO_FALSE, nil,     0) })
                 }},
 
             funcSubmitTransaction: { (context, cwm, sid, identifier, transactionBytes, transactionBytesLength) in
@@ -1595,10 +1598,10 @@ extension System {
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve(
                         success: { (ti) in
-                            cwmAnnounceSubmitTransfer (cwm, sid, ti.identifier, ti.hash, CRYPTO_TRUE) },
+                            cryptoClientAnnounceSubmitTransfer (cwm, sid, ti.identifier, ti.hash, CRYPTO_TRUE) },
                         failure: { (e) in
                             print ("SYS: SubmitTransaction: Error: \(e)")
-                            cwmAnnounceSubmitTransfer (cwm, sid, nil, nil, CRYPTO_FALSE) })
+                            cryptoClientAnnounceSubmitTransfer (cwm, sid, nil, nil, CRYPTO_FALSE) })
                 }},
 
             funcEstimateTransactionFee: { (context, cwm, sid, transactionBytes, transactionBytesLength, hashAsHex) in
@@ -1624,7 +1627,7 @@ extension System {
                                 .map { UnsafePointer<Int8>(strdup($0)) }
                             defer { metaValsPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
                             
-                            cwmAnnounceEstimateTransactionFee (cwm,
+                            cryptoClientAnnounceEstimateTransactionFee (cwm,
                                                                sid,
                                                                CRYPTO_TRUE,
                                                                $0.costUnits,
@@ -1635,7 +1638,7 @@ extension System {
                         },
                         failure: { (e) in
                             print ("SYS: EstimateTransactionFee: Error: \(e)")
-                            cwmAnnounceEstimateTransactionFee (cwm, sid, CRYPTO_FALSE, 0, 0, nil, nil) })
+                            cryptoClientAnnounceEstimateTransactionFee (cwm, sid, CRYPTO_FALSE, 0, 0, nil, nil) })
                 }}
         )
     }

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1311,12 +1311,13 @@ extension System {
                     transferEvent = TransferEvent.created
 
                 case CRYPTO_TRANSFER_EVENT_CHANGED:
-                    print ("SYS: Event: Transfer (\(wallet.name)): \(event.type): {\(TransferState (core: event.u.state.old)) -> \(TransferState (core: event.u.state.new))}")
+                    defer { cryptoTransferStateGive (event.u.state.old); cryptoTransferStateGive (event.u.state.new) }
 
-                    // The event.u.state.{old,new} references to BRCryptoTransferState are 'passed'
-                    // to the TransferState initializer.
-                    transferEvent = TransferEvent.changed (old: TransferState (core: event.u.state.old),
-                                                           new: TransferState (core: event.u.state.new))
+                    let oldState = TransferState (core: event.u.state.old)
+                    let newState = TransferState (core: event.u.state.new)
+
+                    print ("SYS: Event: Transfer (\(wallet.name)): \(event.type): {\(oldState) -> \(newState)}")
+                    transferEvent = TransferEvent.changed (old: oldState, new: newState)
 
                 case CRYPTO_TRANSFER_EVENT_DELETED:
                     transferEvent = TransferEvent.deleted

--- a/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitSwift/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -130,8 +130,8 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
             "bsv" : .api_only,
             "eth" : .api_only,
             "xrp" : .api_only,
-            "hbar" : .api_only,
-            "xtz": .api_only
+            "hbar": .api_only,
+            "xtz" : .api_only
             ]
 
         registerCurrencyCodes = (mainnet


### PR DESCRIPTION
Changes `cwmAnnounce{BlockNumber,Transactions,...}` BRCryptoClient functions to signal events, thereby 
1. not blocking the HTTP response thread
2. ensuring that updating the BRCryptoClient and BRCryptoWalletManger state occurs in the wallet manager's thread (thus with the wallet manager's lock taken)

All BRCryptoWalletMangers will get their (default) event types from `CRYPTO_CLIENT_EVENT_TYPES`

Also: renames `cwmAnnounce...` to `cryptoClientAnnounce...` and fixes some memory issues.