### PR TITLE
Update android-gradle-plugin to 4.1.3

### DIFF
--- a/WalletKitJava/build.gradle
+++ b/WalletKitJava/build.gradle
@@ -41,7 +41,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'digital.wup:android-maven-publish:3.6.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }


### PR DESCRIPTION
This version must match brd-android exactly to be included as a [composite build](https://docs.gradle.org/current/userguide/composite_builds.html).