### PR TITLE
CORE-1141: Fix BRCryptoTransferState memory leak.

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoTransfer.c
+++ b/WalletKitCore/src/crypto/BRCryptoTransfer.c
@@ -109,6 +109,7 @@ cryptoTransferStateRelease (BRCryptoTransferState state) {
     }
 
     memset (state, 0, sizeof(struct BRCryptoTransferStateRecord));
+    free (state);
 }
 
 private_extern bool

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoWalletManagerETH.c
@@ -139,10 +139,10 @@ cryptoWalletManagerGetEventTypesETH (BRCryptoWalletManager manager,
 }
 
 static BRCryptoBoolean
-cryptoWalletManagerSignTransaction (BRCryptoWalletManager manager,
-                                    BRCryptoWallet wallet,
-                                    BRCryptoTransfer transfer,
-                                    BRKey *key) {
+cryptoWalletManagerSignTransactionETH (BRCryptoWalletManager manager,
+                                       BRCryptoWallet wallet,
+                                       BRCryptoTransfer transfer,
+                                       BRKey *key) {
     BRCryptoWalletManagerETH managerETH  = cryptoWalletManagerCoerceETH (manager);
     BRCryptoTransferETH      transferETH = cryptoTransferCoerceETH      (transfer);
 
@@ -199,9 +199,9 @@ cryptoWalletManagerSignTransaction (BRCryptoWalletManager manager,
 
 static BRCryptoBoolean
 cryptoWalletManagerSignTransactionWithSeedETH (BRCryptoWalletManager manager,
-                                                      BRCryptoWallet wallet,
-                                                      BRCryptoTransfer transfer,
-                                                      UInt512 seed) {
+                                               BRCryptoWallet wallet,
+                                               BRCryptoTransfer transfer,
+                                               UInt512 seed) {
     BRCryptoWalletManagerETH managerETH  = cryptoWalletManagerCoerceETH (manager);
 
     BREthereumAccount     ethAccount     = managerETH->account;
@@ -209,10 +209,10 @@ cryptoWalletManagerSignTransactionWithSeedETH (BRCryptoWalletManager manager,
 
     BRKey key = derivePrivateKeyFromSeed (seed, ethAccountGetAddressIndex (ethAccount, ethAddress));
     
-    return cryptoWalletManagerSignTransaction (manager,
-                                               wallet,
-                                               transfer,
-                                               &key);
+    return cryptoWalletManagerSignTransactionETH (manager,
+                                                  wallet,
+                                                  transfer,
+                                                  &key);
 }
 
 static BRCryptoBoolean
@@ -220,10 +220,10 @@ cryptoWalletManagerSignTransactionWithKeyETH (BRCryptoWalletManager manager,
                                               BRCryptoWallet wallet,
                                               BRCryptoTransfer transfer,
                                               BRCryptoKey key) {
-    return cryptoWalletManagerSignTransaction (manager,
-                                               wallet,
-                                               transfer,
-                                               cryptoKeyGetCore (key));
+    return cryptoWalletManagerSignTransactionETH (manager,
+                                                  wallet,
+                                                  transfer,
+                                                  cryptoKeyGetCore (key));
 }
 
 static BRCryptoAmount

--- a/WalletKitSwift/WalletKit/BRCryptoSystem.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoSystem.swift
@@ -1361,8 +1361,6 @@ extension System {
                     transferEvent = TransferEvent.created
 
                 case CRYPTO_TRANSFER_EVENT_CHANGED:
-                    defer { cryptoTransferStateGive (event.u.state.old); cryptoTransferStateGive (event.u.state.new) }
-
                     let oldState = TransferState (core: event.u.state.old)
                     let newState = TransferState (core: event.u.state.new)
 

--- a/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
+++ b/WalletKitSwift/WalletKit/BRCryptoTransfer.swift
@@ -433,6 +433,7 @@ public enum TransferState {
     case deleted
 
     internal init (core: BRCryptoTransferState) {
+        defer { cryptoTransferStateGive (core) }
         switch cryptoTransferStateGetType (core) {
         case CRYPTO_TRANSFER_STATE_CREATED:   self = .created
         case CRYPTO_TRANSFER_STATE_SIGNED:    self = .signed
@@ -499,6 +500,7 @@ public enum TransferEvent {
     case changed (old: TransferState, new: TransferState)
     case deleted
 
+    // unused - caution on {old,new}State ownership - will be given
     init (core: BRCryptoTransferEvent) {
         switch core.type {
         case CRYPTO_TRANSFER_EVENT_CREATED:


### PR DESCRIPTION
Recreated this (on the proper branch, with the proper commit JIRA reference).

The Swift `cryptoTransferStateGive()` match the 'take' calls when the event is created:
```
                cryptoTransferGenerateEvent (transfer, (BRCryptoTransferEvent) {
                    CRYPTO_TRANSFER_EVENT_CHANGED,
                    { .state = {
                        cryptoTransferStateTake (state),
                        cryptoTransferStateTake (state) }}
                });
```
