### PR TITLE
CORE-1158: Avoid `fileServicePurge()` - it causes an Android crash

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -299,7 +299,9 @@ cryptoWalletManagerAllocAndInit (size_t sizeInBytes,
                                                                  networkName,
                                                                  manager,
                                                                  cryptoWalletManagerFileServiceErrorHandler);
-    fileServicePurge (manager->fileService);
+
+    // TODO: This causes an Android (only - Core Demo App) crash.  Understand, then restore
+    // fileServicePurge (manager->fileService);
 
     // Create the alarm clock, but don't start it.
     alarmClockCreateIfNecessary(0);


### PR DESCRIPTION
I've confirmed this fix numerous times.  With 'purge' the Core Demo App Android consistently crashes with a `null` pointer; without 'purge', 100% App success.

Effectively did a `git bisect` (among beta.x tags) to discover 'purge' as the issue.