### PR TITLE
CORE-1165: `cryptoNetworkCreateAddress()` returns NULL on an invalid address

### DIFF
--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoAddressETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoAddressETH.c
@@ -49,12 +49,12 @@ cryptoAddressAsETH (BRCryptoAddress address) {
     return addressETH->eth;
 }
 
-extern BRCryptoAddress
+private_extern BRCryptoAddress
 cryptoAddressCreateFromStringAsETH (const char *ethAddress) {
     assert (ethAddress);
-    return cryptoAddressCreateAsETH (ETHEREUM_BOOLEAN_TRUE == ethAddressValidateString (ethAddress)
-                                     ? ethAddressCreate (ethAddress)
-                                     : EMPTY_ADDRESS_INIT);
+    return (ETHEREUM_BOOLEAN_TRUE == ethAddressValidateString (ethAddress)
+            ? cryptoAddressCreateAsETH (ethAddressCreate (ethAddress))
+            : NULL);
 }
 
 static void

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoETH.h
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoETH.h
@@ -31,6 +31,9 @@ typedef struct BRCryptoAddressETHRecord {
 } *BRCryptoAddressETH;
 
 private_extern BRCryptoAddress
+cryptoAddressCreateFromStringAsETH (const char *address);
+
+private_extern BRCryptoAddress
 cryptoAddressCreateAsETH (BREthereumAddress eth);
 
 private_extern BREthereumAddress

--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoNetworkETH.c
@@ -81,9 +81,6 @@ cryptoNetworkReleaseETH (BRCryptoNetwork network) {
     (void) networkETH;
 }
 
-extern BRCryptoAddress
-cryptoAddressCreateFromStringAsETH (const char *address);
-
 static BRCryptoAddress
 cryptoNetworkCreateAddressETH (BRCryptoNetwork network,
                                const char *addressAsString) {

--- a/WalletKitSwift/WalletKitTests/Tests/BRCryptoAccountTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/BRCryptoAccountTests.swift
@@ -88,6 +88,13 @@ class BRCryptoAccountTests: XCTestCase {
 
         let _ = Address (core: e3!.core, take: true)
         let _ = Address (core: e3!.core)
+
+        XCTAssertNil(Address.create(string: "ethereum:0xb0F225defEc7625C6B5E43126bdDE398bD90eF62", network: network));
+        XCTAssertNil(Address.create(string: "1xb0F225defEc7625C6B5E43126bdDE398bD90eF62", network: network));
+        XCTAssertNil(Address.create(string: "0xWWW225defEc7625C6B5E43126bdDE398bD90eF62", network: network));
+        XCTAssertNil(Address.create(string: "", network: network));
+        XCTAssertNil(Address.create(string: "0xb0F225defEc7625C6B5E43126bdDE398bD90eF6",  network: network));
+        XCTAssertNil(Address.create(string: "0xb0F225defEc7625C6B5E43126bdDE398bD90eF",   network: network));
     }
 
     func testAddressBTC () {
@@ -149,6 +156,8 @@ class BRCryptoAccountTests: XCTestCase {
 
         XCTAssertEqual (Address.create (string: "r41vZ8exoVyUfVzs56yeN8xB5gDhSkho9a", network: network)?.description,
                        "r41vZ8exoVyUfVzs56yeN8xB5gDhSkho9a")
+
+        XCTAssertNil (Address.create (string: "w41vZ8exoVyUfVzs56yeN8xB5gDhSkho9a", network: network))
     }
 
     func testAddressHBAR () {
@@ -157,6 +166,7 @@ class BRCryptoAccountTests: XCTestCase {
         XCTAssertEqual (Address.create (string: "0.0.14222", network: network)?.description,
                        "0.0.14222")
 
+        XCTAssertNil (Address.create (string: "0.0.x14222", network: network))
     }
 /*
         let addr1 = bch.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v") // cashaddr with prefix is valid


### PR DESCRIPTION
An invalid Ethereum address was producing `0x0000....000` instead of `null`.  Other currencies (BTC, XRP, etc) return `null` if the address string is invalid.