### PR TITLE
CORE-1168: Handle a `null` BRCryptoAddress for Ethereum

### DIFF
--- a/WalletKitCore/src/crypto/handlers/eth/BRCryptoAddressETH.c
+++ b/WalletKitCore/src/crypto/handlers/eth/BRCryptoAddressETH.c
@@ -45,8 +45,9 @@ cryptoAddressCreateAsETH (BREthereumAddress eth) {
 
 private_extern BREthereumAddress
 cryptoAddressAsETH (BRCryptoAddress address) {
-    BRCryptoAddressETH addressETH = cryptoAddressCoerce (address);
-    return addressETH->eth;
+    return (NULL == address
+            ? EMPTY_ADDRESS_INIT
+            : cryptoAddressCoerce (address)->eth);
 }
 
 private_extern BRCryptoAddress


### PR DESCRIPTION
The function `cryptoAddressAsETH()` is a private function in 'handlers/'.  It should return a `BREthereumAddress`; `EMPTY_ADDRESS_INIT` is reasonable on a `null` `address`.  Checked unit tests; checked numerous paperKeys.