### PR TITLE
CORE-1173: Match Wallet and Transfer Attribute Keys

### DIFF
--- a/WalletKitCore/include/BRCryptoWallet.h
+++ b/WalletKitCore/include/BRCryptoWallet.h
@@ -137,6 +137,11 @@ extern "C" {
                                         BRCryptoAddress target,
                                         size_t index);
 
+    extern BRCryptoTransferAttribute
+    cryptoWalletGetTransferAttributeForKey (BRCryptoWallet wallet,
+                                            BRCryptoAddress target,
+                                            const char *key);
+
     extern BRCryptoTransferAttributeValidationError
     cryptoWalletValidateTransferAttribute (BRCryptoWallet wallet,
                                            OwnershipKept BRCryptoTransferAttribute attribute,
@@ -147,12 +152,6 @@ extern "C" {
                                             size_t attributesCount,
                                             OwnershipKept BRCryptoTransferAttribute *attribute,
                                             BRCryptoBoolean *validates);
-
-    extern BRCryptoBoolean
-    cryptoWalletHasTransferAttributeForKey (BRCryptoWallet wallet,
-                                            BRCryptoAddress target,
-                                            const char *key,
-                                            BRCryptoBoolean *isRequired);
 
     /**
      * Create a transfer.

--- a/WalletKitCore/src/crypto/BRCryptoWallet.c
+++ b/WalletKitCore/src/crypto/BRCryptoWallet.c
@@ -825,26 +825,20 @@ cryptoWalletValidateTransferAttributes (BRCryptoWallet wallet,
     return (BRCryptoTransferAttributeValidationError) 0;
 }
 
-extern BRCryptoBoolean
-cryptoWalletHasTransferAttributeForKey (BRCryptoWallet wallet,
+extern BRCryptoTransferAttribute
+cryptoWalletGetTransferAttributeForKey (BRCryptoWallet wallet,
                                         BRCryptoAddress target,
-                                        const char *key,
-                                        BRCryptoBoolean *isRequired) {
-    assert(NULL != isRequired);
-    
+                                        const char *key) {
+
     size_t count = cryptoWalletGetTransferAttributeCount (wallet, target);
     for (size_t index = 0; index < count; index++) {
         BRCryptoTransferAttribute attribute = cryptoWalletGetTransferAttributeAt (wallet, target, index);
-        if (0 == strcasecmp(key, cryptoTransferAttributeGetKey (attribute))) {
-            *isRequired = cryptoTransferAttributeIsRequired (attribute);
-            cryptoTransferAttributeGive (attribute);
-            return CRYPTO_TRUE;
-        }
+        if (0 == strcasecmp (key, cryptoTransferAttributeGetKey (attribute)))
+            return attribute;
         cryptoTransferAttributeGive (attribute);
     }
     
-    *isRequired = CRYPTO_FALSE;
-    return CRYPTO_FALSE;
+    return NULL;
 }
 
 extern BRCryptoTransfer

--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -1232,17 +1232,20 @@ cryptoWalletManagerRecoverTransferAttributesFromTransferBundle (BRCryptoWallet w
         BRArrayOf(BRCryptoTransferAttribute) attributes;
         array_new(attributes, bundle->attributesCount);
         for (size_t index = 0; index < bundle->attributesCount; index++) {
-            const char *key = bundle->attributeKeys[index];
-            BRCryptoBoolean isRequiredAttribute;
-            BRCryptoBoolean isAttribute = cryptoWalletHasTransferAttributeForKey (wallet,
-                                                                                  target,
-                                                                                  key,
-                                                                                  &isRequiredAttribute);
-            if (CRYPTO_TRUE == isAttribute)
+            // Lookup a pre-existing attribute having `key`
+            BRCryptoTransferAttribute attribute =
+            cryptoWalletGetTransferAttributeForKey (wallet,
+                                                    target,
+                                                    bundle->attributeKeys[index]);
+
+            // If an attribute exists, take the bundle's value and extent `attributes`.
+            if (NULL != attribute) {
                 array_add (attributes,
-                           cryptoTransferAttributeCreate(key,
-                                                         bundle->attributeVals[index],
-                                                         isRequiredAttribute));
+                           cryptoTransferAttributeCreate (cryptoTransferAttributeGetKey (attribute),
+                                                          bundle->attributeVals[index],
+                                                          cryptoTransferAttributeIsRequired (attribute)));
+                cryptoTransferAttributeGive(attribute);
+            }
         }
         
         cryptoTransferSetAttributes (transfer, array_count(attributes), attributes);


### PR DESCRIPTION
Ensure that transfer attribute keys match the wallet attribute keys.  Thereby ensures that transfer attributes are a subset of the wallet attributes.  This also eliminates inconsistencies between WalletKit and Blockset attribute keys, notably capitalization.