### PR TITLE
CORE-1210: Add merge_currencies flag to blockset API calls

### DIFF
--- a/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
+++ b/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
@@ -320,7 +320,10 @@ public class BlocksetSystemClient implements SystemClient {
     public void getTransfer(String transferId,
                             CompletionHandler<Transfer, QueryError> handler) {
 
-        bdbClient.sendGetWithId("transfers", transferId, ImmutableMultimap.of(), BlocksetTransfer.class, handler);
+        Multimap<String, String> params = ImmutableListMultimap.of(
+                "merge_currencies", "true");
+
+        bdbClient.sendGetWithId("transfers", transferId, params, BlocksetTransfer.class, handler);
     }
 
     // Transactions
@@ -434,7 +437,8 @@ public class BlocksetSystemClient implements SystemClient {
                 "include_proof", String.valueOf(includeProof),
                 "include_raw", String.valueOf(includeRaw),
                 "include_transfers", String.valueOf(includeTransfers),
-                "include_calls", "false");
+                "include_calls", "false",
+                "merge_currencies", "true");
 
         bdbClient.sendGetWithId("transactions", transactionId, params, com.blockset.walletkit.brd.systemclient.BlocksetTransaction.class, handler);
     }
@@ -524,6 +528,7 @@ public class BlocksetSystemClient implements SystemClient {
         paramsBuilder.put("end_height", endBlockNumber.toString());
         if (null != maxPageSize)
             paramsBuilder.put("max_page_size", maxPageSize.toString());
+        paramsBuilder.put("merge_currencies", "true");
         ImmutableMultimap<String, String> params = paramsBuilder.build();
 
         CompletionHandler<PagedData<BlocksetBlock>, QueryError> pagedHandler = createPagedBlockResultsHandler(handler);
@@ -541,7 +546,8 @@ public class BlocksetSystemClient implements SystemClient {
                 "include_raw", String.valueOf(includeRaw),
                 "include_tx", String.valueOf(includeTx),
                 "include_tx_raw", String.valueOf(includeTxRaw),
-                "include_tx_proof", String.valueOf(includeTxProof));
+                "include_tx_proof", String.valueOf(includeTxProof),
+                "merge_currencies", "true");
 
         bdbClient.sendGetWithId("blocks", id, params, BlocksetBlock.class, handler);
     }

--- a/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
+++ b/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
@@ -306,6 +306,7 @@ public class BlocksetSystemClient implements SystemClient {
             paramsBuilder.put("blockchain_id", blockchainId);
             if (beginBlockNumber != null) paramsBuilder.put("start_height", beginBlockNumber.toString());
             if (endBlockNumber   != null) paramsBuilder.put("end_height",   endBlockNumber.toString());
+            paramsBuilder.put("merge_currencies", "true");
             paramsBuilder.put("max_page_size", maxPageSize.toString());
             for (String address : chunkedAddresses) paramsBuilder.put("address", address);
             ImmutableMultimap<String, String> params = paramsBuilder.build();
@@ -411,6 +412,7 @@ public class BlocksetSystemClient implements SystemClient {
             paramsBuilder.put("include_raw", String.valueOf(includeRaw));
             paramsBuilder.put("include_transfers", String.valueOf(includeTransfers));
             paramsBuilder.put("include_calls", "false");
+            paramsBuilder.put("merge_currencies", "true");
             if (beginBlockNumber != null) paramsBuilder.put("start_height", beginBlockNumber.toString());
             if (endBlockNumber != null) paramsBuilder.put("end_height", endBlockNumber.toString());
             paramsBuilder.put("max_page_size", maxPageSize.toString());

--- a/WalletKitSwift/WalletKit/common/WKBlockset.swift
+++ b/WalletKitSwift/WalletKit/common/WKBlockset.swift
@@ -831,11 +831,13 @@ public class BlocksetSystemClient: SystemClient {
             let queryKeys = ["blockchain_id",
                              "start_height",
                              "end_height",
+                             "merge_currencies",
                              "max_page_size"] + Array (repeating: "address", count: addresses.count)
 
             let queryVals = [blockchainId,
                              begBlockNumber.description,
                              endBlockNumber.description,
+                             "true", 
                              maxPageSize.description] + addresses
 
             self.bdbMakeRequest (path: "transfers",
@@ -897,6 +899,7 @@ public class BlocksetSystemClient: SystemClient {
             "blockchain_id",
             begBlockNumber.map { (_) in "start_height" },
             endBlockNumber.map { (_) in "end_height" },
+            "merge_currencies",
             "include_proof",
             "include_raw",
             "include_transfers",
@@ -908,6 +911,7 @@ public class BlocksetSystemClient: SystemClient {
             blockchainId,
             begBlockNumber.map { $0.description },
             endBlockNumber.map { $0.description },
+            "true",  // merge_currencies
             includeProof.description,
             includeRaw.description,
             includeTransfers.description,

--- a/WalletKitSwift/WalletKit/common/WKBlockset.swift
+++ b/WalletKitSwift/WalletKit/common/WKBlockset.swift
@@ -847,7 +847,7 @@ public class BlocksetSystemClient: SystemClient {
     }
 
     public func getTransfer (transferId: String, completion: @escaping (Result<SystemClient.Transfer, SystemClientError>) -> Void) {
-        bdbMakeRequest (path: "transfers/\(transferId)", query: nil, embedded: false) {
+        bdbMakeRequest (path: "transfers/\(transferId)", query: zip(["merge_currencies"], ["true"]), embedded: false) {
             (more: URL?, res: Result<[JSON], SystemClientError>) in
             precondition (nil == more)
             completion (res.flatMap {
@@ -934,8 +934,8 @@ public class BlocksetSystemClient: SystemClient {
                                 includeRaw: Bool = false,
                                 includeProof: Bool = false,
                                 completion: @escaping (Result<SystemClient.Transaction, SystemClientError>) -> Void) {
-        let queryKeys = ["include_proof", "include_raw"]
-        let queryVals = [includeProof.description, includeRaw.description]
+        let queryKeys = ["include_proof", "include_raw", "merge_currencies"]
+        let queryVals = [includeProof.description, includeRaw.description, "true"]
 
         bdbMakeRequest (path: "transactions/\(transactionId)", query: zip (queryKeys, queryVals), embedded: false) {
             (more: URL?, res: Result<[JSON], SystemClientError>) in
@@ -1040,7 +1040,8 @@ public class BlocksetSystemClient: SystemClient {
                          "include_raw",
                          "include_tx",
                          "include_tx_raw",
-                         "include_tx_proof"]
+                         "include_tx_proof",
+                         "merge_currencies"]
 
         var queryVals = [blockchainId,
                          begBlockNumber.description,
@@ -1048,7 +1049,8 @@ public class BlocksetSystemClient: SystemClient {
                          includeRaw.description,
                          includeTx.description,
                          includeTxRaw.description,
-                         includeTxProof.description]
+                         includeTxProof.description,
+                         "true"]
 
         if let maxPageSize = maxPageSize {
             queryKeys += ["max_page_size"]
@@ -1066,9 +1068,17 @@ public class BlocksetSystemClient: SystemClient {
                           includeTxRaw: Bool = false,
                           includeTxProof: Bool = false,
                           completion: @escaping (Result<SystemClient.Block, SystemClientError>) -> Void) {
-        let queryKeys = ["include_raw", "include_tx", "include_tx_raw", "include_tx_proof"]
+        let queryKeys = ["include_raw", 
+                         "include_tx", 
+                         "include_tx_raw", 
+                         "include_tx_proof",
+                         "merge_currencies"]
 
-        let queryVals = [includeRaw.description, includeTx.description, includeTxRaw.description, includeTxProof.description]
+        let queryVals = [includeRaw.description, 
+                         includeTx.description, 
+                         includeTxRaw.description, 
+                         includeTxProof.description,
+                         "true"]
 
         bdbMakeRequest (path: "blocks/\(blockId)", query: zip (queryKeys, queryVals), embedded: false) {
             (more: URL?, res: Result<[JSON], SystemClientError>) in


### PR DESCRIPTION
Added to getTransaction(), getTransfer(), getBlocks(), getBlock(). Confirmed SystemAIT tests OK (excepting subscription)