### PR TITLE
CORE-1217: Make core-9.0.0 and core-9.0.2 use consistent persistent storage

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoClient.c
+++ b/WalletKitCore/src/crypto/BRCryptoClient.c
@@ -1417,7 +1417,6 @@ cryptoClientTransferBundleRlpEncode (BRCryptoClientTransferBundle bundle,
                           rlpEncodeString (coder, bundle->amount),
                           rlpEncodeString (coder, bundle->currency),
                           rlpEncodeString (coder, bundle->fee),
-                          rlpEncodeUInt64 (coder, bundle->transferIndex,         0),
                           rlpEncodeUInt64 (coder, bundle->blockTimestamp,        0),
                           rlpEncodeUInt64 (coder, bundle->blockNumber,           0),
                           rlpEncodeUInt64 (coder, bundle->blockConfirmations,    0),
@@ -1426,15 +1425,27 @@ cryptoClientTransferBundleRlpEncode (BRCryptoClientTransferBundle bundle,
                           cryptoClientTransferBundleRlpEncodeAttributes (bundle->attributesCount,
                                                                          (const char **) bundle->attributeKeys,
                                                                          (const char **) bundle->attributeVals,
-                                                                         coder));
+                                                                         coder),
+                          rlpEncodeUInt64 (coder, bundle->transferIndex,         0));
 }
 
 private_extern BRCryptoClientTransferBundle
 cryptoClientTransferBundleRlpDecode (BRRlpItem item,
-                                     BRRlpCoder coder) {
+                                     BRRlpCoder coder,
+                                     BRCryptoFileServiceTransferVersion version) {
     size_t itemsCount;
     const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
-    assert (16 == itemsCount);
+
+    switch (version) {
+        case CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1:
+            assert (15 == itemsCount);
+            break;
+        case CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2:
+            assert (16 == itemsCount);
+            break;
+        default:
+            break;
+    }
 
     char *uids     = rlpDecodeString (coder, items[ 1]);
     char *hash     = rlpDecodeString (coder, items[ 2]);
@@ -1444,10 +1455,41 @@ cryptoClientTransferBundleRlpDecode (BRRlpItem item,
     char *amount   = rlpDecodeString (coder, items[ 6]);
     char *currency = rlpDecodeString (coder, items[ 7]);
     char *fee      = rlpDecodeString (coder, items[ 8]);
-    char *blkHash  = rlpDecodeString (coder, items[14]);
+
+    uint64_t blockTimestamp        = rlpDecodeUInt64 (coder, items[ 9], 0);
+    uint64_t blockNumber           = rlpDecodeUInt64 (coder, items[10], 0);
+    uint64_t blockConfirmations    = rlpDecodeUInt64 (coder, items[11], 0);
+    uint64_t blockTransactionIndex = rlpDecodeUInt64 (coder, items[12], 0);
+
+    char *blockHash  = rlpDecodeString (coder, items[13]);
 
     BRCryptoTransferBundleRlpDecodeAttributesResult attributesResult =
-    cryptoClientTransferBundleRlpDecodeAttributes (items[15], coder);
+    cryptoClientTransferBundleRlpDecodeAttributes (items[14], coder);
+
+    // Set the transferIndex to a default value.
+    uint64_t transferIndex = 0;
+
+    switch (version) {
+        case CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1:
+            // derive the transferIndex from the UIDS
+            if (NULL != uids) {
+                char *sepPtr = strrchr (uids, ':');    // "<network>:<hash>:<index>" for Blockset only!
+
+                if (NULL != sepPtr) {
+                    char *endPtr = NULL;
+                    unsigned long value = strtoul (sepPtr + 1, &endPtr, 10);
+
+                    if ('\0' == endPtr[0])
+                        transferIndex = (uint64_t) value;
+                }
+            }
+            break;
+        case CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2:
+            transferIndex = rlpDecodeUInt64 (coder, items[15], 0);
+            break;
+        default:
+            break;
+    }
 
     BRCryptoClientTransferBundle bundle =
     cryptoClientTransferBundleCreate ((BRCryptoTransferStateType) rlpDecodeUInt64 (coder, items[ 0], 0),
@@ -1459,17 +1501,17 @@ cryptoClientTransferBundleRlpDecode (BRRlpItem item,
                                       amount,
                                       currency,
                                       (0 == strcmp(fee,"") ? NULL : fee),
-                                      rlpDecodeUInt64 (coder, items[ 9], 0),
-                                      rlpDecodeUInt64 (coder, items[10], 0),
-                                      rlpDecodeUInt64 (coder, items[11], 0),
-                                      rlpDecodeUInt64 (coder, items[12], 0),
-                                      rlpDecodeUInt64 (coder, items[13], 0),
-                                      blkHash,
+                                      transferIndex,
+                                      blockTimestamp,
+                                      blockNumber,
+                                      blockConfirmations,
+                                      blockTransactionIndex,
+                                      blockHash,
                                       array_count(attributesResult.keys),
                                       (const char **) attributesResult.keys,
                                       (const char **) attributesResult.vals);
 
-    free (blkHash);
+    free (blockHash);
     free (fee);
     free (currency);
     free (amount);

--- a/WalletKitCore/src/crypto/BRCryptoClientP.h
+++ b/WalletKitCore/src/crypto/BRCryptoClientP.h
@@ -18,6 +18,7 @@
 #include "support/rlp/BRRlp.h"
 #include "support/event/BREvent.h"
 
+#include "BRCryptoFileService.h"
 #include "BRCryptoClient.h"
 #include "BRCryptoSync.h"
 #include "BRCryptoTransfer.h"
@@ -101,7 +102,8 @@ cryptoClientTransferBundleRlpEncode (BRCryptoClientTransferBundle bundle,
 
 private_extern BRCryptoClientTransferBundle
 cryptoClientTransferBundleRlpDecode (BRRlpItem item,
-                                     BRRlpCoder coder);
+                                     BRRlpCoder coder,
+                                     BRCryptoFileServiceTransferVersion version);
 
 // For BRSet
 private_extern size_t

--- a/WalletKitCore/src/crypto/BRCryptoFileService.c
+++ b/WalletKitCore/src/crypto/BRCryptoFileService.c
@@ -47,7 +47,8 @@ cryptoFileServiceTypeTransferV1Reader (BRFileServiceContext context,
     BRRlpData  data  = (BRRlpData) { bytesCount, bytes };
     BRRlpItem  item  = rlpDataGetItem (coder, data);
 
-    BRCryptoClientTransferBundle bundle = cryptoClientTransferBundleRlpDecode(item, coder);
+    BRCryptoClientTransferBundle bundle = cryptoClientTransferBundleRlpDecode (item, coder,
+                                                                               CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1);
 
     rlpItemRelease (coder, item);
     rlpCoderRelease(coder);
@@ -55,6 +56,26 @@ cryptoFileServiceTypeTransferV1Reader (BRFileServiceContext context,
     return bundle;
 }
 
+private_extern void *
+cryptoFileServiceTypeTransferV2Reader (BRFileServiceContext context,
+                                       BRFileService fs,
+                                       uint8_t *bytes,
+                                       uint32_t bytesCount) {
+    BRCryptoWalletManager manager = (BRCryptoWalletManager) context; (void) manager;
+
+    BRRlpCoder coder = rlpCoderCreate();
+    BRRlpData  data  = (BRRlpData) { bytesCount, bytes };
+    BRRlpItem  item  = rlpDataGetItem (coder, data);
+
+    BRCryptoClientTransferBundle bundle = cryptoClientTransferBundleRlpDecode(item, coder,
+                                                                              CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2);
+
+    rlpItemRelease (coder, item);
+    rlpCoderRelease(coder);
+
+    return bundle;
+
+}
 private_extern uint8_t *
 cryptoFileServiceTypeTransferV1Writer (BRFileServiceContext context,
                                  BRFileService fs,
@@ -132,13 +153,19 @@ cryptoFileServiceTypeTransactionV1Writer (BRFileServiceContext context,
 BRFileServiceTypeSpecification cryptoFileServiceSpecifications[] = {
     {
         CRYPTO_FILE_SERVICE_TYPE_TRANSFER,
-        CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1, // current version
-        1,
+        CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2, // current version
+        2,
         {
             {
                 CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1,
                 cryptoFileServiceTypeTransferV1Identifier,
                 cryptoFileServiceTypeTransferV1Reader,
+                cryptoFileServiceTypeTransferV1Writer
+            },
+            {
+                CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2,
+                cryptoFileServiceTypeTransferV1Identifier,
+                cryptoFileServiceTypeTransferV2Reader,
                 cryptoFileServiceTypeTransferV1Writer
             },
         }

--- a/WalletKitCore/src/crypto/BRCryptoFileService.h
+++ b/WalletKitCore/src/crypto/BRCryptoFileService.h
@@ -22,7 +22,8 @@ extern "C" {
 #define CRYPTO_FILE_SERVICE_TYPE_TRANSFER      "crypto_transfers"
 
 typedef enum {
-    CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1
+    CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_1,
+    CRYPTO_FILE_SERVICE_TYPE_TRANSFER_VERSION_2
 } BRCryptoFileServiceTransferVersion;
 
 private_extern UInt256
@@ -32,9 +33,15 @@ cryptoFileServiceTypeTransferV1Identifier (BRFileServiceContext context,
 
 private_extern void *
 cryptoFileServiceTypeTransferV1Reader (BRFileServiceContext context,
-                                 BRFileService fs,
-                                 uint8_t *bytes,
-                                 uint32_t bytesCount);
+                                       BRFileService fs,
+                                       uint8_t *bytes,
+                                       uint32_t bytesCount);
+
+private_extern void *
+cryptoFileServiceTypeTransferV2Reader (BRFileServiceContext context,
+                                       BRFileService fs,
+                                       uint8_t *bytes,
+                                       uint32_t bytesCount);
 
 private_extern uint8_t *
 cryptoFileServiceTypeTransferV1Writer (BRFileServiceContext context,


### PR DESCRIPTION
Adds a 'transfer version' (that is, done the right way) which allows for upgrades.  

Fixes an error in BRFileService where an upgraded entity could be read in the SQLite query; causing a conflict.