### PR TITLE
CORE-1219: Avoid a duplicate call to `cryptoClientTransferBundleSetRelease()`

### DIFF
--- a/WalletKitCore/src/crypto/BRCryptoWalletManager.c
+++ b/WalletKitCore/src/crypto/BRCryptoWalletManager.c
@@ -144,7 +144,6 @@ cryptoWalletManagerInitialTransferBundlesLoad (BRCryptoWalletManager manager) {
 
     if (fileServiceHasType (manager->fileService, CRYPTO_FILE_SERVICE_TYPE_TRANSFER) &&
         1 != fileServiceLoad (manager->fileService, bundles, CRYPTO_FILE_SERVICE_TYPE_TRANSFER, 1)) {
-        cryptoClientTransferBundleSetRelease (bundles);
         printf ("CRY: %4s: failed to load transfer bundles",
                 cryptoBlockChainTypeGetCurrencyCode (manager->type));
         cryptoClientTransferBundleSetRelease(bundles);


### PR DESCRIPTION
This code branch was meant as 'belt-and-suspenders'; never expected to be executed.  However, if it is executed then this duplicate 'release' causes a crash.