### PR TITLE
CORE-1226: If appropriate (ETH, XTZ), add margin to the fee estimate.

### DIFF
--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransaction.c
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransaction.c
@@ -21,6 +21,11 @@
 static unsigned int transactionAllocCount = 0;
 #endif
 
+static inline BREthereumGas
+ethGasApplyLimitMargin (BREthereumGas gas) {
+    return ethGasCreate(((100 + ETHEREUM_GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
+}
+
 //
 // Transaction
 //
@@ -230,6 +235,19 @@ extern BREthereumEther
 ethTransactionGetFee (BREthereumTransaction transaction,
                    BREthereumBoolean *overflow) {
     return ethFeeBasisGetFee (ethTransactionGetFeeBasis (transaction), overflow);
+}
+
+extern BREthereumGas
+ethTransactionApplyGasLimitMargin (BREthereumTransaction transaction,
+                                   BREthereumGas gasLimit) {
+    // Apply a margin to `gasLimit` any time the gas value is not DEFAULT_ETHER_GAS_LIMIT.  The
+    // value of DEFAULT_ETHER_GAS_LIMIT identifies a transfer of Ether.
+    //
+    // Eventually, there may be more complicated cases depending in transaction->data, which encodes
+    // a Smart Contract function.
+    return (DEFAULT_ETHER_GAS_LIMIT == gasLimit.amountOfGas
+            ? gasLimit
+            : ethGasApplyLimitMargin (gasLimit));
 }
 
 extern uint64_t

--- a/WalletKitCore/src/ethereum/blockchain/BREthereumTransaction.h
+++ b/WalletKitCore/src/ethereum/blockchain/BREthereumTransaction.h
@@ -22,13 +22,10 @@ extern "C" {
 
 #define ETHEREUM_TRANSACTION_NONCE_IS_NOT_ASSIGNED   UINT64_MAX
 
+#define DEFAULT_ETHER_GAS_LIMIT    21000ull
+
 /// If we get a gasEstimate we'll want the gasLimit to have a margin over the estimate
 #define ETHEREUM_GAS_LIMIT_MARGIN_PERCENT        (20)
-
-static inline BREthereumGas
-gasApplyLimitMargin (BREthereumGas gas) {
-    return ethGasCreate(((100 + ETHEREUM_GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
-}
 
 /**
  * An Ethereum Transaction is a transaction on the Ethereum P2P network
@@ -128,6 +125,10 @@ ethTransactionGetFeeBasis (BREthereumTransaction transaction);
 extern BREthereumEther
 ethTransactionGetFee (BREthereumTransaction transaction,
                    BREthereumBoolean *overflow);
+
+extern BREthereumGas
+ethTransactionApplyGasLimitMargin (BREthereumTransaction transaction,
+                                   BREthereumGas gasLimit);
 
 extern uint64_t
 ethTransactionGetNonce (BREthereumTransaction transaction);

--- a/WalletKitCore/src/walletkit/WKClientP.h
+++ b/WalletKitCore/src/walletkit/WKClientP.h
@@ -199,8 +199,8 @@ struct WKClientCallbackStateRecord {
         struct {
             WKHash hash;
             WKCookie cookie;
+            WKTransfer   transfer;
             WKNetworkFee networkFee;
-            WKFeeBasis initialFeeBasis;
         } estimateTransactionFee;
         // ...
     } u;
@@ -383,8 +383,7 @@ extern void
 wkClientQRYEstimateTransferFee (WKClientQRYManager qry,
                                     WKCookie   cookie,
                                     WKTransfer transfer,
-                                    WKNetworkFee networkFee,
-                                    WKFeeBasis initialFeeBasis);
+                                    WKNetworkFee networkFee);
 
 static inline WKClientSync
 wkClientQRYManagerAsSync (WKClientQRYManager qry) {

--- a/WalletKitCore/src/walletkit/WKWallet.c
+++ b/WalletKitCore/src/walletkit/WKWallet.c
@@ -233,7 +233,7 @@ wkWalletEventExtractFeeBasisUpdate (WKWalletEvent event,
 private_extern WKWalletEvent
 wkWalletEventCreateFeeBasisEstimated (WKStatus status,
                                           WKCookie cookie,
-                                          OwnershipGiven WKFeeBasis basis) {
+                                          OwnershipKept WKFeeBasis basis) {
     WKWalletEvent event = wkWalletEventCreate (WK_WALLET_EVENT_FEE_BASIS_ESTIMATED);
 
     event->u.feeBasisEstimated.status = status;

--- a/WalletKitCore/src/walletkit/WKWalletManager.c
+++ b/WalletKitCore/src/walletkit/WKWalletManager.c
@@ -943,6 +943,8 @@ wkWalletManagerEstimateFeeBasis (WKWalletManager manager,
                                      WKNetworkFee fee,
                                      size_t attributesCount,
                                      OwnershipKept WKTransferAttribute *attributes) {
+
+    // Margin will be added, if appropriate for `manager`
     WKFeeBasis feeBasis = manager->handlers->estimateFeeBasis (manager,
                                                                      wallet,
                                                                      cookie,
@@ -1235,16 +1237,16 @@ wkWalletManagerRecoverTransferAttributesFromTransferBundle (WKWallet wallet,
 
 private_extern WKFeeBasis
 wkWalletManagerRecoverFeeBasisFromFeeEstimate (WKWalletManager cwm,
-                                                   WKNetworkFee networkFee,
-                                                   WKFeeBasis initialFeeBasis,
-                                                   double costUnits,
-                                                   size_t attributesCount,
-                                                   OwnershipKept const char **attributeKeys,
-                                                   OwnershipKept const char **attributeVals) {
+                                               WKTransfer transfer,
+                                               WKNetworkFee networkFee,
+                                               double costUnits,
+                                               size_t attributesCount,
+                                               OwnershipKept const char **attributeKeys,
+                                               OwnershipKept const char **attributeVals) {
     assert (NULL != cwm->handlers->recoverFeeBasisFromFeeEstimate); // not supported by chain
     return cwm->handlers->recoverFeeBasisFromFeeEstimate (cwm,
+                                                          transfer,
                                                           networkFee,
-                                                          initialFeeBasis,
                                                           costUnits,
                                                           attributesCount,
                                                           attributeKeys,

--- a/WalletKitCore/src/walletkit/WKWalletManagerP.h
+++ b/WalletKitCore/src/walletkit/WKWalletManagerP.h
@@ -117,12 +117,12 @@ typedef void
 
 typedef WKFeeBasis
 (*WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler) (WKWalletManager cwm,
-                                                               WKNetworkFee networkFee,
-                                                               WKFeeBasis initialFeeBasis,
-                                                               double costUnits,
-                                                               size_t attributesCount,
-                                                               OwnershipKept const char **attributeKeys,
-                                                               OwnershipKept const char **attributeVals);
+                                                         WKTransfer transfer,
+                                                         WKNetworkFee networkFee,
+                                                         double costUnits,
+                                                         size_t attributesCount,
+                                                         OwnershipKept const char **attributeKeys,
+                                                         OwnershipKept const char **attributeVals);
 
 typedef WKWalletSweeperStatus
 (*WKWalletManagerWalletSweeperValidateSupportedHandler) (WKWalletManager cwm,
@@ -298,12 +298,12 @@ wkWalletManagerRecoverTransferAttributesFromTransferBundle (WKWallet wallet,
 
 private_extern WKFeeBasis
 wkWalletManagerRecoverFeeBasisFromFeeEstimate (WKWalletManager cwm,
-                                                   WKNetworkFee networkFee,
-                                                   WKFeeBasis initialFeeBasis,
-                                                   double costUnits,
-                                                   size_t attributesCount,
-                                                   OwnershipKept const char **attributeKeys,
-                                                   OwnershipKept const char **attributeVals);
+                                               WKTransfer transfer,
+                                               WKNetworkFee networkFee,
+                                               double costUnits,
+                                               size_t attributesCount,
+                                               OwnershipKept const char **attributeKeys,
+                                               OwnershipKept const char **attributeVals);
 
 static inline void
 wkWalletManagerGenerateEvent (WKWalletManager manager,

--- a/WalletKitCore/src/walletkit/handlers/btc/WKWalletManagerBTC.c
+++ b/WalletKitCore/src/walletkit/handlers/btc/WKWalletManagerBTC.c
@@ -171,6 +171,7 @@ wkWalletManagerEstimateFeeBasisBTC (WKWalletManager cwm,
     uint64_t btcAmount   = wkAmountGetIntegerRaw (amount, &overflow);
     assert(WK_FALSE == overflow);
 
+    // No margin needed.
     uint64_t btcFee = (0 == btcAmount ? 0 : btcWalletFeeForTxAmountWithFeePerKb (btcWallet, btcFeePerKB, btcAmount));
 
     return wkFeeBasisCreateAsBTC (wallet->unitForFee, btcFee, btcFeePerKB, WK_FEE_BASIS_BTC_SIZE_UNKNOWN);

--- a/WalletKitCore/src/walletkit/handlers/eth/WKWalletETH.c
+++ b/WalletKitCore/src/walletkit/handlers/eth/WKWalletETH.c
@@ -14,8 +14,6 @@
 #define DEFAULT_ETHER_GAS_PRICE      2ull  // 2 GWEI
 #define DEFAULT_ETHER_GAS_PRICE_UNIT GWEI
 
-#define DEFAULT_ETHER_GAS_LIMIT    21000ull
-
 extern WKWalletETH
 wkWalletCoerce (WKWallet wallet) {
     assert (WK_NETWORK_TYPE_ETH == wallet->type);
@@ -171,7 +169,6 @@ wkWalletCreateTransferETH (WKWallet  wallet,
 
     BREthereumToken    ethToken         = walletETH->ethToken;
     BREthereumFeeBasis ethFeeBasis      = wkFeeBasisAsETH (estimatedFeeBasis);
-    BREthereumGas      ethGasLimit      = ethFeeBasisGetGasLimit(ethFeeBasis);
     BREthereumAddress  ethSourceAddress = ethAccountGetPrimaryAddress (walletETH->ethAccount);
     BREthereumAddress  ethTargetAddress = wkAddressAsETH (target);
 
@@ -192,9 +189,7 @@ wkWalletCreateTransferETH (WKWallet  wallet,
                           wkTransferProvideOriginatingTargetAddress (ethToken, ethTargetAddress),
                           wkTransferProvideOriginatingAmount (ethToken, value),
                           ethFeeBasisGetGasPrice(ethFeeBasis),
-                          (DEFAULT_ETHER_GAS_LIMIT == ethGasLimit.amountOfGas && (NULL == data || '\0' == data[0])
-                           ? ethGasLimit
-                           : gasApplyLimitMargin (ethGasLimit)),
+                          ethFeeBasisGetGasLimit(ethFeeBasis),
                           data,
                           nonce);
 

--- a/WalletKitCore/src/walletkit/handlers/hbar/WKWalletManagerHBAR.c
+++ b/WalletKitCore/src/walletkit/handlers/hbar/WKWalletManagerHBAR.c
@@ -164,6 +164,8 @@ wkWalletManagerEstimateFeeBasisHBAR (WKWalletManager manager,
                                          OwnershipKept WKTransferAttribute *attributes) {
     UInt256 value = wkAmountGetValue (wkNetworkFeeGetPricePerCostFactor (networkFee));
     BRHederaFeeBasis hbarFeeBasis;
+
+    // No margin needed.
     hbarFeeBasis.pricePerCostFactor = (BRHederaUnitTinyBar) value.u64[0];
     hbarFeeBasis.costFactor = 1;  // 'cost factor' is 'transaction'
     

--- a/WalletKitCore/src/walletkit/handlers/xlm/WKWalletManagerXLM.c
+++ b/WalletKitCore/src/walletkit/handlers/xlm/WKWalletManagerXLM.c
@@ -162,6 +162,8 @@ wkWalletManagerEstimateFeeBasisXLM (WKWalletManager manager,
                                          OwnershipKept WKTransferAttribute *attributes) {
     UInt256 value = wkAmountGetValue (wkNetworkFeeGetPricePerCostFactor (networkFee));
     BRStellarFeeBasis xlmFeeBasis;
+
+    // No margin needed.
     xlmFeeBasis.pricePerCostFactor = (BRStellarAmount) value.u64[0];
     xlmFeeBasis.costFactor = 1;  // 'cost factor' is 'transaction'
 

--- a/WalletKitCore/src/walletkit/handlers/xrp/WKWalletManagerXRP.c
+++ b/WalletKitCore/src/walletkit/handlers/xrp/WKWalletManagerXRP.c
@@ -168,7 +168,10 @@ wkWalletManagerEstimateFeeBasisXRP (WKWalletManager manager,
                                         size_t attributesCount,
                                         OwnershipKept WKTransferAttribute *attributes) {
     UInt256 value = wkAmountGetValue (wkNetworkFeeGetPricePerCostFactor (networkFee));
+
+    // No margin needed.
     BRRippleUnitDrops fee = value.u64[0];
+
     return wkFeeBasisCreateAsXRP (wallet->unitForFee, fee);
 }
 

--- a/WalletKitCore/src/walletkit/handlers/xtz/WKWalletManagerXTZ.c
+++ b/WalletKitCore/src/walletkit/handlers/xtz/WKWalletManagerXTZ.c
@@ -22,6 +22,12 @@
 
 #include "tezos/BRTezosAccount.h"
 
+#define TEZOS_FEE_PADDING_PERCENT           (10)
+
+static int64_t
+wkWalletManagerPadValueXTZ (int64_t value) {
+    return ((100 + TEZOS_FEE_PADDING_PERCENT) * value) / 100;
+}
 
 // MARK: - Events
 
@@ -176,8 +182,7 @@ wkWalletManagerEstimateFeeBasisXTZ (WKWalletManager manager,
     wkClientQRYEstimateTransferFee (manager->qryManager,
                                         cookie,
                                         transfer,
-                                        networkFee,
-                                        feeBasis);
+                                        networkFee);
 
     wkTransferGive (transfer);
     wkFeeBasisGive (feeBasis);
@@ -281,27 +286,33 @@ wkWalletManagerRecoverTransferFromTransferBundleXTZ (WKWalletManager manager,
 
 static WKFeeBasis
 wkWalletManagerRecoverFeeBasisFromFeeEstimateXTZ (WKWalletManager cwm,
-                                                      WKNetworkFee networkFee,
-                                                      WKFeeBasis initialFeeBasis,
-                                                      double costUnits,
-                                                      size_t attributesCount,
-                                                      OwnershipKept const char **attributeKeys,
-                                                      OwnershipKept const char **attributeVals) {
+                                                  WKTransfer transfer,
+                                                  WKNetworkFee networkFee,
+                                                  double costUnits,
+                                                  size_t attributesCount,
+                                                  OwnershipKept const char **attributeKeys,
+                                                  OwnershipKept const char **attributeVals) {
     bool parseError;
-    
-    int64_t gasUsed = (int64_t) cwmParseUInt64 (cwmLookupAttributeValueForKey ("consumed_gas", attributesCount, attributeKeys, attributeVals), &parseError);
+
+    // get the serialized txn size from the estimation payload
+    WKFeeBasis initialFeeBasis = wkTransferGetFeeBasis(transfer);
+    double sizeInKBytes = wkFeeBasisCoerceXTZ(initialFeeBasis)->xtzFeeBasis.u.initial.sizeInKBytes;
+    wkFeeBasisGive(initialFeeBasis);
+
+    BRTezosUnitMutez mutezPerKByte = tezosMutezCreate (networkFee->pricePerCostFactor); // given as nanotez/byte
+
+    int64_t gasUsed     = (int64_t) cwmParseUInt64 (cwmLookupAttributeValueForKey ("consumed_gas", attributesCount, attributeKeys, attributeVals), &parseError);
     int64_t storageUsed = (int64_t) cwmParseUInt64 (cwmLookupAttributeValueForKey ("storage_size", attributesCount, attributeKeys, attributeVals), &parseError);
-    int64_t counter = (int64_t) cwmParseUInt64 (cwmLookupAttributeValueForKey ("counter", attributesCount, attributeKeys, attributeVals), &parseError);
+    int64_t counter     = (int64_t) cwmParseUInt64 (cwmLookupAttributeValueForKey ("counter",      attributesCount, attributeKeys, attributeVals), &parseError);
+
     // increment counter
     counter += 1;
-    // add 10% padding to gas/storage limits
-    gasUsed = (int64_t)(gasUsed * 1.1);
-    storageUsed = (int64_t)(storageUsed * 1.1);
-    BRTezosUnitMutez mutezPerKByte = tezosMutezCreate (networkFee->pricePerCostFactor); // given as nanotez/byte
-    
-    // get the serialized txn size from the estimation payload
-    double sizeInKBytes = wkFeeBasisCoerceXTZ(initialFeeBasis)->xtzFeeBasis.u.initial.sizeInKBytes;
 
+    // add 10% padding to gas & storage limits
+    gasUsed     = wkWalletManagerPadValueXTZ (gasUsed);
+    storageUsed = wkWalletManagerPadValueXTZ (storageUsed);
+
+    // Create a feeBasis w/ margin applied
     BRTezosFeeBasis feeBasis = tezosFeeBasisCreateEstimate (mutezPerKByte,
                                                             sizeInKBytes,
                                                             gasUsed,

--- a/WalletKitSwift/WalletKit/WKClient.swift
+++ b/WalletKitSwift/WalletKit/WKClient.swift
@@ -166,10 +166,12 @@ public protocol SystemClient {
     // Transaction Fee
     
     typealias TransactionFee = (
+        // This is the best estimate of the costUnits needed to include the transaction in the
+        // blockchain.  It is does not include margin; it might be an upper limit.
         costUnits: UInt64,
         properties: Dictionary<String,String>?
     )
-    
+
     func estimateTransactionFee (blockchainId: String,
                                  transaction: Data,
                                  completion: @escaping (Result<TransactionFee, SystemClientError>) -> Void)

--- a/WalletKitSwift/WalletKit/WKWallet.swift
+++ b/WalletKitSwift/WalletKit/WKWallet.swift
@@ -516,13 +516,17 @@ public final class Wallet: Equatable {
     public typealias EstimateFeeHandler = (Result<TransferFeeBasis,FeeEstimationError>) -> Void
 
     ///
-    /// Estimate the fee for a transfer with `amount` from `wallet`.  If provided use the `feeBasis`
-    /// otherwise use the wallet's `defaultFeeBasis`
+    /// Estimate the `TransferFeeBasis` for a transfer with `amount` from `wallet`.  The result
+    /// will have margin applied if appropriate for the `target`.  Specifically, some targets for
+    /// some blockchains involve 'Smart Contracts' which may have some uncertainty in their 'cost
+    /// units'.  On a blockchain-specific basis a blockchain-specific amount of margin is added
+    /// to the 'cost units' - thereby ensuring high reliabitly in transfer submission.
     ///
     /// - Parameters:
     ///   - target: the transfer's target address
     ///   - amount: the transfer amount MUST BE GREATER THAN 0
     ///   - fee: the network fee (aka priority)
+    ///   - attributes: arbitrary, generally Network-specific, attributes
     ///   - completion: handler function
     ///
     public func estimateFee (target: Address,


### PR DESCRIPTION
Primarily this fixes an error in ETH code whereby the `WKFeeBasis` for an estimate did not include the margin; but the low level `BREthereumTransaction` did.  The result was that  when trying to send the 'maximum' the submit would fail... because `balance - fee` was too much unless the `fee` included the margin.

The fix is to not add margin at the `BREthereumTransaction` level but instead to add margin as the estimate level.

There are a number of interface changes to accomplish this.  Notably, each blockchain needs to determine its own margin - thus there needs to be `handler`-level support.  We already have `WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler`.  But, that handler needs to change such that the originating `WKTransfer` is passed in.  The margin applied might depend on the structure of the transfer; such as the target address, the currency, and/or the amount.  For example in ETH, based on the currency we might have an Ether, an ERC20, or some other Smart Contract; the margin for Ether could/should be 0 and might differ for the others.

In the end, we create BREthereumTransactions with exactly the fee basis of the Transfer.  We construct a Transfer w/ a fee basis that has margin.  The maximum, which is `balance - fee` will work when submitted (the underlying BREthereumTransaction won't have extra gas leading to insufficient funds.

For XTZ, margin already was added to the fee estimate and the underlying BRTezosTransaction had those fees.  The margin for XTZ does not vary depending on the Transfer (always ~10%)