### PR TITLE
update wallet balance after all getTransactions has been done

### DIFF
--- a/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
+++ b/WalletKitCore/WalletKitCoreTests/test/bitcoin/test.c
@@ -2783,14 +2783,14 @@ int btcWalletTests()
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletTransactions() test 1\n", __func__);
 
     btcTransactionSign(tx, 0, &k, 1);
-    btcWalletRegisterTransaction(w, tx);
+    btcWalletRegisterTransaction(w, tx, true);
     if (btcWalletBalance(w) != SATOSHIS)
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletRegisterTransaction() test 2\n", __func__);
 
     if (btcWalletTransactions(w, NULL, 0) != 1)
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletTransactions() test 2\n", __func__);
 
-    btcWalletRegisterTransaction(w, tx); // test adding same tx twice
+    btcWalletRegisterTransaction(w, tx, true); // test adding same tx twice
     if (btcWalletBalance(w) != SATOSHIS)
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletRegisterTransaction() test 3\n", __func__);
 
@@ -2803,7 +2803,7 @@ int btcWalletTests()
     if (! btcWalletTransactionIsPending(w, tx))
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletTransactionIsPending() test\n", __func__);
 
-    btcWalletRegisterTransaction(w, tx); // test adding tx with future lockTime
+    btcWalletRegisterTransaction(w, tx, true); // test adding tx with future lockTime
     if (btcWalletBalance(w) != SATOSHIS)
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletRegisterTransaction() test 4\n", __func__);
 
@@ -2840,7 +2840,7 @@ int btcWalletTests()
     if (tx && ! btcTransactionIsSigned(tx))
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletSignTransaction() test\n", __func__);
     
-    if (tx) tx->timestamp = 1, btcWalletRegisterTransaction(w, tx);
+    if (tx) tx->timestamp = 1, btcWalletRegisterTransaction(w, tx, true);
     if (tx && btcWalletBalance(w) + btcWalletFeeForTx(w, tx) != SATOSHIS/2)
         r = 0, fprintf(stderr, "***FAILED*** %s: btcWalletRegisterTransaction() test 5\n", __func__);
     

--- a/WalletKitCore/WalletKitCoreTests/test/walletkit/testWalletKit.c
+++ b/WalletKitCore/WalletKitCoreTests/test/walletkit/testWalletKit.c
@@ -227,14 +227,14 @@ transferTestsBalance (void) {
     // Initialize wallet w/ each transaction, one by one
     BRBitcoinWallet *wid2 = btcWalletNew (btcTestNetParams->addrParams, NULL, 0, mpk);
     for (size_t index = 0; index < numberOfTransferTests; index++) {
-        btcWalletRegisterTransaction (wid2, btcTransactionCopy (transactions[index]));
+        btcWalletRegisterTransaction (wid2, btcTransactionCopy (transactions[index]), true);
     }
     uint64_t balance2 = btcWalletBalance(wid2);
 
     // Initialize wallet w/ each transaction in reverse order
     BRBitcoinWallet *wid3 = btcWalletNew (btcTestNetParams->addrParams, NULL, 0, mpk);
     for (size_t index = 0; index < numberOfTransferTests; index++) {
-        btcWalletRegisterTransaction (wid3, btcTransactionCopy(transactions[numberOfTransferTests - 1 - index]));
+        btcWalletRegisterTransaction (wid3, btcTransactionCopy(transactions[numberOfTransferTests - 1 - index]), true);
     }
     uint64_t balance3 = btcWalletBalance(wid3);
 
@@ -274,7 +274,7 @@ transferTestsAddress (void) {
         BRBitcoinTransaction *tid = btcTransactionParse (testRawBytes, testRawSize);
         tid->blockHeight = test->blockHeight;
         tid->timestamp   = test->timestamp;
-        btcWalletRegisterTransaction (wid, tid); // ownership given
+        btcWalletRegisterTransaction (wid, tid, true); // ownership given
 
         WKTransferListener listener = { NULL };
         WKTransfer transfer = wkTransferCreateAsBTC (listener,

--- a/WalletKitCore/src/bitcoin/BRBitcoinPeerManager.c
+++ b/WalletKitCore/src/bitcoin/BRBitcoinPeerManager.c
@@ -951,7 +951,7 @@ static void _peerRelayedTx(void *info, BRBitcoinTransaction *tx)
     }
 
     if (manager->syncStartHeight == 0 || btcWalletContainsTransaction(manager->wallet, tx)) {
-        isWalletTx = btcWalletRegisterTransaction(manager->wallet, tx);
+        isWalletTx = btcWalletRegisterTransaction(manager->wallet, tx, true);
         if (isWalletTx) tx = btcWalletTransactionForHash(manager->wallet, tx->txHash);
     }
     else {
@@ -1034,7 +1034,7 @@ static void _peerHasTx(void *info, UInt256 txHash)
     }
 
     if (tx) {
-        isWalletTx = btcWalletRegisterTransaction(manager->wallet, tx);
+        isWalletTx = btcWalletRegisterTransaction(manager->wallet, tx, true);
         if (isWalletTx) tx = btcWalletTransactionForHash(manager->wallet, tx->txHash);
 
         // reschedule sync timeout
@@ -1482,7 +1482,7 @@ static BRBitcoinTransaction *_peerRequestedTx(void *info, UInt256 txHash)
     }
 
     _BRTxPeerListAddPeer(&manager->txRelays, txHash, peer);
-    if (pubTx.tx) btcWalletRegisterTransaction(manager->wallet, pubTx.tx);
+    if (pubTx.tx) btcWalletRegisterTransaction(manager->wallet, pubTx.tx, true);
     if (pubTx.tx && ! btcWalletTransactionIsValid(manager->wallet, pubTx.tx)) error = EINVAL;
     pthread_mutex_unlock(&manager->lock);
     if (pubTx.callback) pubTx.callback(pubTx.info, error);

--- a/WalletKitCore/src/bitcoin/BRBitcoinWallet.h
+++ b/WalletKitCore/src/bitcoin/BRBitcoinWallet.h
@@ -30,6 +30,7 @@
 #include "support/BRBIP32Sequence.h"
 #include "support/BRInt.h"
 #include <string.h>
+#include <stdbool.h>  
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,6 +119,8 @@ size_t btcWalletTxUnconfirmedBefore(BRBitcoinWallet *wallet, BRBitcoinTransactio
 // current wallet balance, not including transactions known to be invalid
 uint64_t btcWalletBalance(BRBitcoinWallet *wallet);
 
+void btcWalletUpdateBalance(BRBitcoinWallet *wallet);
+
 // total amount spent from the wallet (exluding change)
 uint64_t btcWalletTotalSent(BRBitcoinWallet *wallet);
 
@@ -169,7 +172,7 @@ int btcWalletSignTransaction(BRBitcoinWallet *wallet, BRBitcoinTransaction *tx, 
 int btcWalletContainsTransaction(BRBitcoinWallet *wallet, const BRBitcoinTransaction *tx);
 
 // adds a transaction to the wallet, or returns false if it isn't associated with the wallet
-int btcWalletRegisterTransaction(BRBitcoinWallet *wallet, BRBitcoinTransaction *tx);
+int btcWalletRegisterTransaction(BRBitcoinWallet *wallet, BRBitcoinTransaction *tx, bool needUpdateBalance);
 
 // removes a tx from the wallet, along with any tx that depend on its outputs
 void btcWalletRemoveTransaction(BRBitcoinWallet *wallet, UInt256 txHash);

--- a/WalletKitCore/src/walletkit/WKClient.c
+++ b/WalletKitCore/src/walletkit/WKClient.c
@@ -9,6 +9,7 @@
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
 #include "WKClientP.h"
+#include "bitcoin/BRBitcoinWallet.h" 
 
 #include <errno.h>
 #include <math.h>  // round()
@@ -645,6 +646,7 @@ wkClientHandleTransactions (OwnershipKept WKWalletManager manager,
                                                                     callbackState->rid)) {
                     syncCompleted = true;
                     syncSuccess   = true;
+                    wkWalletManagerUpdateWalletBalance(manager);
                 }
 
                 wkWalletGive (wallet);

--- a/WalletKitCore/src/walletkit/WKWalletManager.c
+++ b/WalletKitCore/src/walletkit/WKWalletManager.c
@@ -1192,6 +1192,11 @@ wkWalletManagerRecoverTransfersFromTransactionBundle (WKWalletManager cwm,
 }
 
 private_extern void
+wkWalletManagerUpdateWalletBalance (WKWalletManager cwm) {
+    cwm->handlers->updateWalletBalance (cwm);
+}
+
+private_extern void
 wkWalletManagerRecoverTransferFromTransferBundle (WKWalletManager cwm,
                                                       OwnershipKept WKClientTransferBundle bundle) {
     cwm->handlers->recoverTransferFromTransferBundle (cwm, bundle);

--- a/WalletKitCore/src/walletkit/WKWalletManagerP.h
+++ b/WalletKitCore/src/walletkit/WKWalletManagerP.h
@@ -134,6 +134,9 @@ typedef WKWalletSweeper
                                                     WKWallet wallet,
                                                     WKKey key);
 
+typedef void
+(*WKWalletManagerUpdateWalletBalanceHandler) (WKWalletManager cwm);                                                    
+
 typedef struct {
     WKWalletManagerCreateHandler create;
     WKWalletManagerReleaseHandler release;
@@ -152,6 +155,7 @@ typedef struct {
     WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler        recoverFeeBasisFromFeeEstimate;
     WKWalletManagerWalletSweeperValidateSupportedHandler validateSweeperSupported;
     WKWalletManagerCreateWalletSweeperHandler createSweeper;
+    WKWalletManagerUpdateWalletBalanceHandler updateWalletBalance;
 } WKWalletManagerHandlers;
 
 // MARK: - Wallet Manager State

--- a/WalletKitCore/src/walletkit/handlers/btc/WKWalletManagerBTC.c
+++ b/WalletKitCore/src/walletkit/handlers/btc/WKWalletManagerBTC.c
@@ -306,7 +306,7 @@ wkWalletManagerRecoverTransfersFromTransactionBundleBTC (WKWalletManager manager
     if (needRegistration) {
         if (NULL == btcWalletTransactionForHash (btcWallet, btcTransaction->txHash)) {
             // BRWalletRegisterTransaction doesn't reliably report if the txn was added to the wallet.
-            btcWalletRegisterTransaction (btcWallet, btcTransaction);
+            btcWalletRegisterTransaction (btcWallet, btcTransaction, false);
             if (btcTransaction == btcWalletTransactionForHash (btcWallet, btcTransaction->txHash)) {
                 // If our transaction made it into the wallet, do not deallocate it
                 needFree = false;
@@ -436,6 +436,13 @@ wkWalletManagerCreateWalletSweeperBTC (WKWalletManager cwm,
     wkCurrencyGive (currency);
 
     return sweeper;
+}
+
+static void
+wkWalletManagerUpdateWalletBalanceBTC (WKWalletManager manager)
+{
+    BRBitcoinWallet *btcWallet = wkWalletAsBTC(manager->wallet);
+    btcWalletUpdateBalance(btcWallet);
 }
 
 // MARK: BRBitcoinWallet Callback Balance Changed
@@ -685,7 +692,8 @@ WKWalletManagerHandlers wkWalletManagerHandlersBTC = {
     wkWalletManagerRecoverTransferFromTransferBundleBTC,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedBTC,
-    wkWalletManagerCreateWalletSweeperBTC
+    wkWalletManagerCreateWalletSweeperBTC,
+    wkWalletManagerUpdateWalletBalanceBTC
 };
 
 WKWalletManagerHandlers wkWalletManagerHandlersBCH = {
@@ -705,7 +713,8 @@ WKWalletManagerHandlers wkWalletManagerHandlersBCH = {
     wkWalletManagerRecoverTransferFromTransferBundleBTC,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedBTC,
-    wkWalletManagerCreateWalletSweeperBTC
+    wkWalletManagerCreateWalletSweeperBTC,
+    wkWalletManagerUpdateWalletBalanceBTC
 };
 
 WKWalletManagerHandlers wkWalletManagerHandlersBSV = {
@@ -725,7 +734,8 @@ WKWalletManagerHandlers wkWalletManagerHandlersBSV = {
     wkWalletManagerRecoverTransferFromTransferBundleBTC,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedBTC,
-    wkWalletManagerCreateWalletSweeperBTC
+    wkWalletManagerCreateWalletSweeperBTC,
+    wkWalletManagerUpdateWalletBalanceBTC
 };
 
 WKWalletManagerHandlers wkWalletManagerHandlersLTC = {
@@ -745,7 +755,8 @@ WKWalletManagerHandlers wkWalletManagerHandlersLTC = {
     wkWalletManagerRecoverTransferFromTransferBundleBTC,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedBTC,
-    wkWalletManagerCreateWalletSweeperBTC
+    wkWalletManagerCreateWalletSweeperBTC,
+    wkWalletManagerUpdateWalletBalanceBTC
 };
 
 WKWalletManagerHandlers wkWalletManagerHandlersDOGE = {
@@ -765,5 +776,6 @@ WKWalletManagerHandlers wkWalletManagerHandlersDOGE = {
     wkWalletManagerRecoverTransferFromTransferBundleBTC,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedBTC,
-    wkWalletManagerCreateWalletSweeperBTC
+    wkWalletManagerCreateWalletSweeperBTC,
+    wkWalletManagerUpdateWalletBalanceBTC
 };

--- a/WalletKitCore/src/walletkit/handlers/eth/WKWalletManagerETH.c
+++ b/WalletKitCore/src/walletkit/handlers/eth/WKWalletManagerETH.c
@@ -1025,4 +1025,5 @@ WKWalletManagerHandlers wkWalletManagerHandlersETH = {
     wkWalletManagerRecoverFeeBasisFromFeeEstimateETH,
     NULL,//WKWalletManagerWalletSweeperValidateSupportedHandler not supported
     NULL,//WKWalletManagerCreateWalletSweeperHandler not supported
+    NULL //WKWalletManagerUpdateWalletBalanceHandler not supported
 };

--- a/WalletKitCore/src/walletkit/handlers/hbar/WKWalletManagerHBAR.c
+++ b/WalletKitCore/src/walletkit/handlers/hbar/WKWalletManagerHBAR.c
@@ -314,5 +314,6 @@ WKWalletManagerHandlers wkWalletManagerHandlersHBAR = {
     wkWalletManagerRecoverTransferFromTransferBundleHBAR,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedHBAR,
-    wkWalletManagerCreateWalletSweeperHBAR
+    wkWalletManagerCreateWalletSweeperHBAR,
+    NULL //WKWalletManagerUpdateWalletBalanceHandler not supported
 };

--- a/WalletKitCore/src/walletkit/handlers/xlm/WKWalletManagerXLM.c
+++ b/WalletKitCore/src/walletkit/handlers/xlm/WKWalletManagerXLM.c
@@ -312,5 +312,6 @@ WKWalletManagerHandlers wkWalletManagerHandlersXLM = {
     wkWalletManagerRecoverTransferFromTransferBundleXLM,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedXLM,
-    wkWalletManagerCreateWalletSweeperXLM
+    wkWalletManagerCreateWalletSweeperXLM,
+    NULL //WKWalletManagerUpdateWalletBalanceHandler not supported
 };

--- a/WalletKitCore/src/walletkit/handlers/xrp/WKWalletManagerXRP.c
+++ b/WalletKitCore/src/walletkit/handlers/xrp/WKWalletManagerXRP.c
@@ -315,5 +315,6 @@ WKWalletManagerHandlers wkWalletManagerHandlersXRP = {
     wkWalletManagerRecoverTransferFromTransferBundleXRP,
     NULL,//WKWalletManagerRecoverFeeBasisFromFeeEstimateHandler not supported
     wkWalletManagerWalletSweeperValidateSupportedXRP,
-    wkWalletManagerCreateWalletSweeperXRP
+    wkWalletManagerCreateWalletSweeperXRP,
+    NULL //WKWalletManagerUpdateWalletBalanceHandler not supported
 };

--- a/WalletKitCore/src/walletkit/handlers/xtz/WKWalletManagerXTZ.c
+++ b/WalletKitCore/src/walletkit/handlers/xtz/WKWalletManagerXTZ.c
@@ -381,5 +381,6 @@ WKWalletManagerHandlers wkWalletManagerHandlersXTZ = {
     wkWalletManagerRecoverTransferFromTransferBundleXTZ,
     wkWalletManagerRecoverFeeBasisFromFeeEstimateXTZ,
     wkWalletManagerWalletSweeperValidateSupportedXTZ,
-    wkWalletManagerCreateWalletSweeperXTZ
+    wkWalletManagerCreateWalletSweeperXTZ,
+    NULL //WKWalletManagerUpdateWalletBalanceHandler not supported
 };


### PR DESCRIPTION
Description:
As discussed in https://bwsupport.zendesk.com/hc/en-us/requests/88125, the `_btcWalletUpdateBalance` will not be invoked inside each `btcWalletRegisterTransaction` during a full sync up or a periodic sync up.  After all the historical and latest transactions have been fetched, balance for one wallet would be calculated. To do this, a new `WKWalletManagerHandlers` has been added.

A boolean flag has been added in `int btcWalletRegisterTransaction(BRBitcoinWallet *wallet, BRBitcoinTransaction *tx, bool needUpdateBalance)`. So other methods which invoke `btcWalletRegisterTransaction` could still update wallet's balance when registering a transaction.

Concerns: Only run the basic test. Did not run all the code as a mobile app and Could not run the performance test cases in this branch.