### PR TITLE
CORE-1207: Compute the XTZ 'estimateLimitMaximum' with a Gift

### DIFF
--- a/WalletKitCore/src/tezos/BRTezosFeeBasis.c
+++ b/WalletKitCore/src/tezos/BRTezosFeeBasis.c
@@ -80,7 +80,7 @@ tezosFeeBasisGetFee (BRTezosFeeBasis feeBasis) {
 extern BRTezosFeeBasis
 tezosFeeBasisGiveTezosAGift (BRTezosFeeBasis feeBasis, unsigned int marginPercentage) {
     BRTezosOperationFeeBasis primaryOperationFeeBasis = feeBasis.primaryOperationFeeBasis;
-    primaryOperationFeeBasis.fee *= (marginPercentage + 100) / 100;
+    primaryOperationFeeBasis.fee = (primaryOperationFeeBasis.fee * (marginPercentage + 100)) / 100;
 
     return (BRTezosFeeBasis) {
         feeBasis.mutezPerKByte,

--- a/WalletKitCore/src/tezos/BRTezosFeeBasis.c
+++ b/WalletKitCore/src/tezos/BRTezosFeeBasis.c
@@ -77,6 +77,19 @@ tezosFeeBasisGetFee (BRTezosFeeBasis feeBasis) {
              : 0));
 }
 
+extern BRTezosFeeBasis
+tezosFeeBasisGiveTezosAGift (BRTezosFeeBasis feeBasis, unsigned int marginPercentage) {
+    BRTezosOperationFeeBasis primaryOperationFeeBasis = feeBasis.primaryOperationFeeBasis;
+    primaryOperationFeeBasis.fee *= (marginPercentage + 100) / 100;
+
+    return (BRTezosFeeBasis) {
+        feeBasis.mutezPerKByte,
+        primaryOperationFeeBasis,
+        feeBasis.hasRevealOperationFeeBasis,
+        feeBasis.revealOperationFeeBasis
+    };
+}
+
 extern bool
 tezosFeeBasisIsEqual (BRTezosFeeBasis *fb1, BRTezosFeeBasis *fb2) {
     assert(fb1);

--- a/WalletKitCore/src/tezos/BRTezosFeeBasis.h
+++ b/WalletKitCore/src/tezos/BRTezosFeeBasis.h
@@ -50,6 +50,9 @@ tezosFeeBasisCreateDefault (BRTezosUnitMutez mutexPerKByte, bool isDelegate, boo
 extern BRTezosUnitMutez
 tezosFeeBasisGetFee(BRTezosFeeBasis feeBasis);
 
+extern BRTezosFeeBasis
+tezosFeeBasisGiveTezosAGift (BRTezosFeeBasis feeBasis, unsigned int marginPercentage);
+
 #if 0
 private_extern int64_t
 tezosFeeBasisGetGasLimit(BRTezosFeeBasis feeBasis);

--- a/WalletKitCore/src/tezos/BRTezosOperation.c
+++ b/WalletKitCore/src/tezos/BRTezosOperation.c
@@ -134,7 +134,10 @@ tezosOperationFeeBasisApplyMargin (BRTezosOperationFeeBasis feeBasis,
                                    BRTezosUnitMutez mutezPerKByte,
                                    size_t sizeInByte,
                                    unsigned int marginInPercentage) {
-    // Given a valid, best-estimate `feeBasis`, apply to margin
+    // Given a valid, best-estimate `feeBasis`, apply margin
+
+    // Get a non-zero sizeInByte
+    sizeInByte = (0 == sizeInByte ? TEZOS_TX_SIZE_DEFAULT : sizeInByte);
 
     int64_t mutezPerKByteWithMargin = applyMargin (mutezPerKByte,         MAX (marginInPercentage, TEZOS_TX_SIZE_MARGIN_PERCENTAGE));
     int64_t gasLimitWithMargin      = applyMargin (feeBasis.gasLimit,     MAX (marginInPercentage, TEZOS_GAS_LIMIT_MARGIN_PERCENTAGE));

--- a/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
+++ b/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
@@ -301,7 +301,7 @@ final class Wallet implements com.blockset.walletkit.Wallet {
 
         //
         // We are forced to deal with XTZ.  Not by our choosing.  The value returned by the above
-        // `wkWalletManagerEstimateLimit()` is something well below `self.balance` for XTZ - becuase
+        // `coreManager.estimateLimit` is something well below `self.balance` for XTZ - because
         // we are desperate to get a non-error response from the XTZ node.  And, if we provide the
         // balance for the estimate, we get a `balance_too_low` error.  This then forces us into
         // a binary search until 'not balance_too_low' which for a range of {0, 1 xtz} is ~25

--- a/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
+++ b/WalletKitJava/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
@@ -7,6 +7,7 @@
  */
 package com.blockset.walletkit.brd;
 
+import com.blockset.walletkit.NetworkType;
 import com.blockset.walletkit.nativex.cleaner.ReferenceCleaner;
 import com.blockset.walletkit.nativex.WKAddress;
 import com.blockset.walletkit.nativex.WKAmount;
@@ -295,6 +296,44 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                     handler.handleError(LimitEstimationError.from(error));
                 }
             });
+            return;
+        }
+
+        //
+        // We are forced to deal with XTZ.  Not by our choosing.  The value returned by the above
+        // `wkWalletManagerEstimateLimit()` is something well below `self.balance` for XTZ - becuase
+        // we are desperate to get a non-error response from the XTZ node.  And, if we provide the
+        // balance for the estimate, we get a `balance_too_low` error.  This then forces us into
+        // a binary search until 'not balance_too_low' which for a range of {0, 1 xtz} is ~25
+        // queries of Blockset and the XTZ Node.  Insane.  We will unfortunately sacrifice our
+        // User's funds until XTZ matures.
+        //
+        if (NetworkType.XTZ == walletManager.getNetwork().getType()) {
+            
+            // The absolute minimum value that can be transferred.  If we can't get an estimate for
+            // this we are utterly dead in the water.
+            Amount amountAbsoluteMinimum = Amount.create(1, walletManager.getBaseUnit());
+
+            CompletionHandler<com.blockset.walletkit.TransferFeeBasis, FeeEstimationError> estimationHandlerXTZ =
+                    new CompletionHandler<com.blockset.walletkit.TransferFeeBasis, FeeEstimationError>() {
+                        @Override
+                        public void handleData(com.blockset.walletkit.TransferFeeBasis feeBasis) {
+                            Amount amountEstimated = amount.sub(feeBasis.getFee()).or (Amount.create(0, walletManager.getBaseUnit()));
+                            handler.handleData(amountEstimated.compareTo(amount) == -1
+                                    ? amountEstimated
+                                    : amount);
+                        }
+
+                        @Override
+                        public void handleError(FeeEstimationError error) {
+                            // The request failed.  We will assume that the original amount was correct
+                            // and will use it.  Probably it won't be correct; but this is XTZ
+                            handler.handleData(amount);
+                        }
+                    };
+
+            estimateFee(target, amountAbsoluteMinimum, fee, null, estimationHandlerXTZ);
+
             return;
         }
 


### PR DESCRIPTION
Given the current Tezos Node interface, it is not possible to compute the maximum transfer amount given a balance `B` without doing a binary search (or a truncated binary search) between `{0, B}`.  This might mean ~25 HTTP requests to Blockset which turns around with ~25 HTTP requests to the Tezos Node.

The Tezos devs suggested including OCAML, the implementation language for the Tezos Node, in WalletKit/Blockset, to do the binary search. Obviously a non-starter.

So we determine a default FeeBasis, add margin of %1000 (that is 10x the fee) - this is feeWithGift.  We estimate the fee for a transfer of 1 mutez.    Compute (balance - MAX( feeFor1Mutez, feeWithGift)) as the maximum.  User's pay too much to Tezos; but we get a maximum and can improve it in the future, perhaps as Tezos improves their Node interface.