### PR TITLE
CORE-1262: Handle the AVAX "X-" Prefix in Unit Tests

### DIFF
--- a/WalletKitCore/src/avalanche/BRAvalancheAddress.c
+++ b/WalletKitCore/src/avalanche/BRAvalancheAddress.c
@@ -211,14 +211,16 @@ avalancheAddressStringToAddressX (const char *input,
 
     size_t addressBytesCount = AVALANCHE_ADDRESS_BYTES_X;
 
-    bool success = avax_addr_bech32_decode(address.u.x.bytes, &addressBytesCount, prefix, input);
+    bool success = (0 == strncmp (input, prefix, strlen(prefix)) &&
+                    avax_addr_bech32_decode(address.u.x.bytes, &addressBytesCount, prefix, input));
 
-    return (success ? address : avalancheAddressCreateEmptyAddress (AVALANCHE_ADDRESS_BYTES_X));
+    return (success ? address : avalancheAddressCreateEmptyAddress (AVALANCHE_CHAIN_TYPE_X));
 }
 
 extern BRAvalancheAddress
 avalancheAddressStringToAddressC (const char *input) {
-    assert (40 == strlen(input));
+    if (40 != strlen(input) || !hexEncodeValidate(input))
+        return avalancheAddressCreateEmptyAddress (AVALANCHE_CHAIN_TYPE_C);
 
     BRAvalancheAddress address = { AVALANCHE_CHAIN_TYPE_C };
     hexDecode (address.u.c.bytes, AVALANCHE_ADDRESS_BYTES_C, input, strlen(input));

--- a/WalletKitCore/src/walletkit/handlers/avax/WKAVAX.h
+++ b/WalletKitCore/src/walletkit/handlers/avax/WKAVAX.h
@@ -98,7 +98,7 @@ wkAddressAsAVAX (WKAddress address);
 
 typedef struct WKNetworkAVAXRecord {
     struct WKNetworkRecord base;
-    const BRAvalancheNetwork avaxNetwork;
+    BRAvalancheNetwork avax;
 } *WKNetworkAVAX;
 
 static inline WKNetworkAVAX

--- a/WalletKitCore/src/walletkit/handlers/avax/WKNetworkAVAX.c
+++ b/WalletKitCore/src/walletkit/handlers/avax/WKNetworkAVAX.c
@@ -45,7 +45,8 @@ cyptoNetworkCreateAVAX (WKNetworkListener listener,
     bool useMainnet = (0 == strcmp ("mainnet", desc));
     bool useTestnet = (0 == strcmp ("testnet", desc));
 
-    assert (useMainnet || useTestnet);
+    // Ensure consistency with `isMainnet`.
+    assert (isMainnet ? useMainnet : useTestnet);
 
     WKNetworkCreateContextAVAX contextAVAX = {
         (useMainnet ? avaxNetworkMainnet : avaxNetworkTestnet)

--- a/WalletKitCore/src/walletkit/handlers/avax/WKWalletManagerAVAX.c
+++ b/WalletKitCore/src/walletkit/handlers/avax/WKWalletManagerAVAX.c
@@ -217,7 +217,7 @@ wkWalletManagerRecoverTransferFromTransferBundleAVAX (WKWalletManager manager,
     WKWallet wallet = wkWalletManagerGetWallet (manager);
     WKNetworkAVAX networkAVAX = wkNetworkCoerceAVAX(manager->network);
 
-    BRAvalancheNetwork avaxNetwork = networkAVAX->avaxNetwork;
+    BRAvalancheNetwork avaxNetwork = networkAVAX->avax;
     BRAvalancheAccount avaxAccount = wkAccountGetAsAVAX (manager->account);
 
     BRAvalancheAmount avaxAmount;
@@ -230,11 +230,11 @@ wkWalletManagerRecoverTransferFromTransferBundleAVAX (WKWalletManager manager,
     // transfer; we'll use `target` both if a transfer is created and to identify a pre-existing
     // transfer held by wallet.
 
-    BRAvalancheAddress avaxTarget = avalancheNetworkStringToAddress (networkAVAX->avaxNetwork, bundle->to,   false);
-    BRAvalancheAddress avaxSource = avalancheNetworkStringToAddress (networkAVAX->avaxNetwork, bundle->from, false);
+    BRAvalancheAddress avaxTarget = avalancheNetworkStringToAddress (networkAVAX->avax, bundle->to,   false);
+    BRAvalancheAddress avaxSource = avalancheNetworkStringToAddress (networkAVAX->avax, bundle->from, false);
 
-    WKAddress target = wkAddressCreateAsAVAX (avaxTarget, networkAVAX->avaxNetwork);
-    WKAddress source = wkAddressCreateAsAVAX (avaxSource, networkAVAX->avaxNetwork);
+    WKAddress target = wkAddressCreateAsAVAX (avaxTarget, networkAVAX->avax);
+    WKAddress source = wkAddressCreateAsAVAX (avaxSource, networkAVAX->avax);
 
     // A transaction may include a "burn" transfer to target address 'unknown' in addition to the
     // normal transfer, both sharing the same hash. Typically occurs when sending to an un-revealed

--- a/WalletKitSwift/WalletKitTests/Tests/WKAddressTests.swift
+++ b/WalletKitSwift/WalletKitTests/Tests/WKAddressTests.swift
@@ -161,27 +161,34 @@ class WKAddressTests: XCTestCase {
     func testAddressAVAX () {
         if let network = Network.findBuiltin(uids: "avalanche-mainnet") {
 
-            let AddressParsablePairs:[(String, Bool)] = [ // (address, parsable)
-                ("abc", true),
-                ("def", false)
+            let AddressParsablePairs:[(String, Bool, String?)] = [ // (address, parsable)
+                ("X-avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal", true,  nil),
+                ("avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal",   true,  "X-avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal"),
+                ("C-avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal", false, nil),
+                ("avac1escwyq2hsznvwth6au3gpc77f225uacvwldgal",   false, nil),
+                ("avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal3",  false, nil),
+                ("X-fuji1escwyq2hsznvwth6au3gpc77f225uacvzdfh3q", false, nil),
             ]
 
-            for (string, parsable) in AddressParsablePairs {
+            for (string, parsable, match) in AddressParsablePairs {
                 let address = Address.create(string: string, network: network)
-                XCTAssert(parsable ? nil != address : nil == address)
-                XCTAssert(!parsable || string == address!.description)
+                XCTAssert(parsable ? (nil != address) : (nil == address))
+                XCTAssert(!parsable || address!.description == (match ?? string))
             }
         }
 
         if let network = Network.findBuiltin(uids: "avalanche-testnet") {
 
-            let AddressParsablePairs:[(String, Bool)] = [ // (address, parsable)
+            let AddressParsablePairs:[(String, Bool, String?)] = [ // (address, parsable)
+                ("X-fuji1escwyq2hsznvwth6au3gpc77f225uacvzdfh3q",  true,  nil),
+                ("fuji1escwyq2hsznvwth6au3gpc77f225uacvzdfh3q",    true,  "X-fuji1escwyq2hsznvwth6au3gpc77f225uacvzdfh3q"),
+                ("X-avax1escwyq2hsznvwth6au3gpc77f225uacvwldgal",  false, nil),
             ]
 
-            for (string, parsable) in AddressParsablePairs {
+            for (string, parsable, match) in AddressParsablePairs {
                 let address = Address.create(string: string, network: network)
-                XCTAssert(parsable ? nil != address : nil == address)
-                XCTAssert(!parsable || string == address!.description)
+                XCTAssert(parsable ? (nil != address) : (nil == address))
+                XCTAssert(!parsable || address!.description == (match ?? string))
             }
         }
     }


### PR DESCRIPTION
Fixes errors exposed in Swift level testing - (WKNetwork was not initialized correctly for AVAX).