### PR TITLE
CORE-1298: Handle XTZ 'addresses are garbage collected' re-reveal need.

### DIFF
--- a/WalletKitCore/src/walletkit/WKTransfer.c
+++ b/WalletKitCore/src/walletkit/WKTransfer.c
@@ -289,21 +289,17 @@ wkTransferGetAmountDirectedInternal (WKTransfer transfer,
 
     switch (wkTransferGetDirection(transfer)) {
         case WK_TRANSFER_RECOVERED: {
-            amount = wkAmountCreate (transfer->unit,
-                                         WK_FALSE,
-                                         UINT256_ZERO);
+            amount = wkAmountCreate (transfer->unit, WK_FALSE, UINT256_ZERO);
             break;
         }
 
         case WK_TRANSFER_SENT: {
-            amount = wkTransferGetAmountAsSign (transfer,
-                                                    WK_TRUE);
+            amount = wkTransferGetAmountAsSign (transfer, WK_TRUE);
             break;
         }
 
         case WK_TRANSFER_RECEIVED: {
-            amount = wkTransferGetAmountAsSign (transfer,
-                                                    WK_FALSE);
+            amount = wkTransferGetAmountAsSign (transfer, WK_FALSE);
             break;
         }
         default: assert(0);

--- a/WalletKitCore/src/walletkit/WKTransferP.h
+++ b/WalletKitCore/src/walletkit/WKTransferP.h
@@ -239,6 +239,10 @@ private_extern WKAmount
 wkTransferGetAmountDirectedInternal (WKTransfer transfer,
                                          WKBoolean  respectSuccess);
 
+private_extern OwnershipGiven WKAmount
+wkWalletGetTransferAmountDirectedNet (WKWallet wallet,
+                                      WKTransfer transfer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/WalletKitCore/src/walletkit/WKWallet.c
+++ b/WalletKitCore/src/walletkit/WKWallet.c
@@ -477,24 +477,24 @@ wkWalletDecBalance (WKWallet wallet,
  * Return the amount from `transfer` that applies to the balance of `wallet`.  The result must
  * be in the wallet's unit
  */
-static OwnershipGiven WKAmount // called wtih wallet->lock
+private_extern OwnershipGiven WKAmount // called wtih wallet->lock
 wkWalletGetTransferAmountDirectedNet (WKWallet wallet,
-                                          WKTransfer transfer) {
+                                      WKTransfer transfer) {
     // If the wallet and transfer units are compatible, use the transfer's amount
     WKAmount transferAmount = (WK_TRUE == wkUnitIsCompatible(wallet->unit, transfer->unit)
-                                     ? wkTransferGetAmountDirectedInternal (transfer, WK_TRUE)
-                                     : wkAmountCreateInteger (0, wallet->unit));
+                               ? wkTransferGetAmountDirectedInternal (transfer, WK_TRUE)
+                               : wkAmountCreateInteger (0, wallet->unit));
 
     // If the wallet unit and the transfer unitForFee are compatible and if we did not
     // receive the transfer then use the transfer's fee
     WKAmount transferFee    = (WK_TRUE == wkUnitIsCompatible(wallet->unit, transfer->unitForFee) &&
-                                     WK_TRANSFER_RECEIVED != wkTransferGetDirection(transfer)
-                                     ? wkTransferGetFee (transfer)
-                                     : NULL);
+                               WK_TRANSFER_RECEIVED != wkTransferGetDirection(transfer)
+                               ? wkTransferGetFee (transfer)
+                               : NULL);
 
     WKAmount transferNet = (NULL != transferFee
-                                  ? wkAmountSub  (transferAmount, transferFee)
-                                  : wkAmountTake (transferAmount));
+                            ? wkAmountSub  (transferAmount, transferFee)
+                            : wkAmountTake (transferAmount));
 
     wkAmountGive(transferFee);
     wkAmountGive(transferAmount);


### PR DESCRIPTION
WKWalletXTZ.c contains the meaningful change.

Have tested on multiple 'wedged' test wallets.  Have produced as many as 3 reveals: zero, receive, send+reveal, zero, receive, send+reveal.