### PR TITLE
Add all Java modules when not in Android Studio

### DIFF
--- a/WalletKitJava/gradle.properties
+++ b/WalletKitJava/gradle.properties
@@ -5,3 +5,6 @@ maven_url=https://api.bintray.com/maven/brd/walletkit-java
 org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
+
+useAllJvmSources=false
+useAndroidSources=true

--- a/WalletKitJava/settings.gradle
+++ b/WalletKitJava/settings.gradle
@@ -2,14 +2,24 @@ include ':WalletKit'
 include ':WalletKitNative'
 include ':WalletKitBRD'
 
+def useAllJvmSources = ext.get("useAllJvmSources").toString().toBoolean()
+def useAndroidSources = ext.get("useAndroidSources").toString().toBoolean()
+def ideaActive = System.getProperty("idea.active") == "true"
+def enableAndroid = useAllJvmSources || (useAndroidSources && ideaActive) || !ideaActive
+def enableJvmSources = useAllJvmSources || (!useAndroidSources && ideaActive) || !ideaActive
+
 // Android
-include ':WalletKitNative-Android'
-include ':WalletKitBRD-Android'
-include ':WalletKitDemo-Android'
+if (enableAndroid) {
+    include ':WalletKitNative-Android'
+    include ':WalletKitBRD-Android'
+    include ':WalletKitDemo-Android'
+}
 
 // JRE
-//include ':WalletKitNative-JRE'
-//include ':WalletKitBRD-JRE'
+if (enableJvmSources) {
+    include ':WalletKitNative-JRE'
+    include ':WalletKitBRD-JRE'
+}
 
 // Kotlin
 include ':WalletKit-KTX'


### PR DESCRIPTION
By default when the project is opened in Android Studio, only the Android modules will be linked.  If a Gradle task is run from the command line all Java modules will be linked.

- Adds `useAllJvmSources` (default false) to force link all modules when in the IDE
- Adds `useAndroidSources` (default true) to link only the Android modules when true or only JRE when false