### PR TITLE
CORE-1304: Canonicalize (sort, remove duplicates) Blockset Transactions

### DIFF
--- a/WalletKitCore/src/walletkit/WKListenerP.h
+++ b/WalletKitCore/src/walletkit/WKListenerP.h
@@ -45,8 +45,8 @@ wkListenerGenerateNetworkEvent (const WKNetworkListener *listener,
 // A Hack: Instead Wallet should listen for WK_TRANSFER_EVENT_CHANGED
 typedef void
 (*WKTransferStateChangedCallback) (WKWallet wallet,
-                                         WKTransfer transfer,
-                                         OwnershipKept WKTransferState newState);
+                                   WKTransfer transfer, // has `newState`
+                                   OwnershipKept WKTransferState oldState);
 
 
 /**

--- a/WalletKitCore/src/walletkit/WKTransfer.c
+++ b/WalletKitCore/src/walletkit/WKTransfer.c
@@ -389,7 +389,7 @@ wkTransferSetStateForced (WKTransfer transfer,
     if (forced || !wkTransferStateIsEqual (oldState, newState)) {
         // A Hack: Instead Wallet shouild listen for WK_TRANSFER_EVENT_CHANGED
         if (NULL != transfer->listener.transferChangedCallback)
-            transfer->listener.transferChangedCallback (transfer->listener.wallet, transfer, newState);
+            transfer->listener.transferChangedCallback (transfer->listener.wallet, transfer, oldState);
 
         wkTransferGenerateEvent (transfer, (WKTransferEvent) {
             WK_TRANSFER_EVENT_CHANGED,

--- a/WalletKitCore/src/walletkit/WKWallet.c
+++ b/WalletKitCore/src/walletkit/WKWallet.c
@@ -22,8 +22,8 @@
 
 static void
 wkWalletUpdTransfer (WKWallet wallet,
-                                  WKTransfer transfer,
-                                  OwnershipKept WKTransferState newState);
+                     WKTransfer transfer,
+                     OwnershipKept WKTransferState oldState);
 
 static void
 wkWalletUpdBalanceOnTransferConfirmation (WKWallet wallet,
@@ -716,19 +716,27 @@ wkWalletReplaceTransfer (WKWallet wallet,
 static void
 wkWalletUpdTransfer (WKWallet wallet,
                          WKTransfer transfer,
-                         WKTransferState newState) {
+                         WKTransferState oldState) {
     // The transfer's state has changed.  This implies a possible amount/fee change as well as
     // perhaps other wallet changes, such a nonce change.
     pthread_mutex_lock (&wallet->lock);
     if (WK_TRUE == wkWalletHasTransferLock (wallet, transfer, false)) {
-        switch (newState->type) {
+        switch (transfer->state->type) {
             case WK_TRANSFER_STATE_CREATED:
             case WK_TRANSFER_STATE_SIGNED:
             case WK_TRANSFER_STATE_SUBMITTED:
             case WK_TRANSFER_STATE_DELETED:
                 break; // nothing
             case WK_TRANSFER_STATE_INCLUDED:
-                wkWalletUpdBalanceOnTransferConfirmation (wallet, transfer);
+                // If the `oldState` is INCLUDED, then this is a re-org and (somehow) the oldState
+                // and the newState can have completely different fees.  Just recompute the wallet
+                // balance with `transfer` (and its `newState`).  This case is highly uncommon.
+                if (WK_TRANSFER_STATE_INCLUDED == oldState->type)
+                    wkWalletUpdBalance (wallet, false);
+                else
+                    // If `oldState` is not INCLUDED, the updae the balance based on a different
+                    // between the estimated and confirmed fees. This case is common.
+                    wkWalletUpdBalanceOnTransferConfirmation (wallet, transfer);
                 break;
             case WK_TRANSFER_STATE_ERRORED:
                 // Recompute the balance

--- a/WalletKitSwift/WalletKit/WKSystem.swift
+++ b/WalletKitSwift/WalletKit/WKSystem.swift
@@ -1486,8 +1486,10 @@ extension System {
 
     internal static func canonicalizeTransactions (_ transactions: [SystemClient.Transaction]) -> [SystemClient.Transaction] {
         var uids = Set<String>()
+
+        // Sort transactions to be ascending {blockHeight, Index}
         return transactions
-            // Sort by {blockHeight, index }
+            // Sort by { blockHeight, index }
             .sorted {
                 let bh0 = $0.blockHeight ?? UInt64.max
                 let bh1 = $1.blockHeight ?? UInt64.max
@@ -1496,8 +1498,12 @@ extension System {
 
                 return bh0 < bh1 || (bh0 == bh1 && bi0 < bi1 )
             }
-            // Remove duplicates
+            // Reverse to be descending
+            .reversed ()
+            // Remove duplicates; keeping newer entries (hence descending order)
             .filter { uids.insert($0.id).inserted }
+            // Back to ascending order
+            .reversed ()
     }
 
     internal static func makeTransactionBundle (_ model: SystemClient.Transaction) -> WKClientTransactionBundle {
@@ -1625,7 +1631,7 @@ extension System {
                     defer { wkWalletManagerGive(cwm) }
                     res.resolve(
                         success: {
-                            var bundles: [WKClientTransferBundle?]  = $0.flatMap { System.makeTransferBundles ($0, addresses: addresses) }
+                            var bundles: [WKClientTransferBundle?]  = System.canonicalizeTransactions($0).flatMap { System.makeTransferBundles ($0, addresses: addresses) }
                             wkClientAnnounceTransfers (cwm, sid, WK_TRUE,  &bundles, bundles.count) },
                         failure: { (e) in
                             print ("SYS: GetTransfers: Error: \(e)")


### PR DESCRIPTION
Handles a case whereby Blockset produced a query result with two transactions (an oddity) having the identical UIDS, but differing in blockHeight.  WalletKit got the balance wrong because of a poor assumption - there CAN BE `INCLUDED -> INCLUDED` transactions - the balance needs to be fully recomputed in that case.

Also, added logic to eliminate the duplicate transfers up-front.  (But the duplicates could still occur 'live')

Confirmed on the ETH wallet w/ the duplicate (`0xba1...`) and other wallets w/o the duplicate.