### PR TITLE
CORE-1314: In Ripple, add AccountDelete support

### DIFF
--- a/WalletKitCore/src/ripple/BRRippleAccount.c
+++ b/WalletKitCore/src/ripple/BRRippleAccount.c
@@ -271,3 +271,25 @@ rippleAccountGetDefaultFeeBasis (BRRippleAccount account) {
         10, 1
     };
 }
+
+extern BRRippleFeeBasis
+rippleAccountGetAccountDeleteFeeBasis (BRRippleAccount account) {
+    return (BRRippleFeeBasis) {
+        5000000, 1
+    };
+}
+
+extern BRRippleTransaction
+rippleAccountCreateCloseTransaction(BRRippleAccount account,
+                                    BRRippleAddress toAddress,
+                                    BRRippleFeeBasis feeBasis)
+{
+    // Get the source address
+    BRRippleAddress sourceAddress = rippleAccountGetAddress(account);
+    BRRippleTransaction tx = rippleTransactionCreateCloseTransaction(sourceAddress,
+                                                                     toAddress,
+                                                                     feeBasis);
+    rippleAddressFree(sourceAddress);
+    return tx;
+}
+

--- a/WalletKitCore/src/ripple/BRRippleAccount.h
+++ b/WalletKitCore/src/ripple/BRRippleAccount.h
@@ -87,6 +87,20 @@ extern void rippleAccountSetLastLedgerSequence(BRRippleAccount account,
                                                BRRippleLastLedgerSequence lastLedgerSequence);
 
 /**
+ * Creates a transaction that will close this account and send all possible XRP to the toAddress (minus the fee)
+ *
+ * @param account   the account to close
+ * @param toAddress the account where any remaining XRP should be sent
+ * @param feeBasis  the fee need to send this transaction
+ *
+ * @return void
+ */
+extern BRRippleTransaction
+rippleAccountCreateCloseTransaction(BRRippleAccount account,
+                                    BRRippleAddress toAddress,
+                                    BRRippleFeeBasis feeBasis);
+
+/**
  * Serialize (and sign) a Ripple Transaction.  Ready for submission to the ledger.
  *
  * @param account         the account sending the payment
@@ -138,7 +152,11 @@ rippleAccountGetBalanceLimit (BRRippleAccount account,
                               int asMaximum,
                               int *hasLimit);
 
+// The default fee for a transfer
 extern BRRippleFeeBasis
 rippleAccountGetDefaultFeeBasis (BRRippleAccount account);
+// THe fee basis to delete an account
+extern BRRippleFeeBasis
+rippleAccountGetAccountDeleteFeeBasis (BRRippleAccount account);
 
 #endif

--- a/WalletKitCore/src/ripple/BRRippleBase.h
+++ b/WalletKitCore/src/ripple/BRRippleBase.h
@@ -40,6 +40,7 @@ typedef enum {
     RIPPLE_TX_TYPE_CHECK_CANCEL      = 18,
     RIPPLE_TX_TYPE_DEPOSIT_PREAUTH   = 19,
     RIPPLE_TX_TYPE_TRUST_SET         = 20,
+    RIPPLE_TX_TYPE_DELETE_ACCOUNT    = 21,
     RIPPLE_TX_TYPE_AMENDMENT         = 100,
     RIPPLE_TX_TYPE_FEE               = 101,
 } BRRippleTransactionType ;

--- a/WalletKitCore/src/ripple/BRRippleTransaction.c
+++ b/WalletKitCore/src/ripple/BRRippleTransaction.c
@@ -129,9 +129,7 @@ struct BRRippleTransactionRecord {
     // The hash; if not provided, derived from signedBytes
     BRRippleTransactionHash hash;
 
-    // The ripple payment information
-    // TODO in the future if more transaction are supported this could
-    // be changed to a union of the various types
+    // The ripple transaction content
     BRRipplePaymentTxRecord payment;
 
     BRRippleSerializedTransaction signedBytes;
@@ -204,6 +202,20 @@ rippleTransactionCreate(BRRippleAddress sourceAddress,
     transaction->fee = calculateFee(transaction);
 
     return transaction;
+}
+
+BRRippleTransaction rippleTransactionCreateCloseTransaction(BRRippleAddress sourceAddress,
+                                                            BRRippleAddress targetAddress,
+                                                            BRRippleFeeBasis feeBasis)
+{
+    // Use the existing tx create code and just modify the type
+    // This assumes that the correct fee basis was passed in since AccountDelete has
+    // a higher fee.
+    BRRippleTransaction transaction = rippleTransactionCreate(sourceAddress, targetAddress,
+                                                              0, feeBasis);
+    transaction->transactionType = RIPPLE_TX_TYPE_DELETE_ACCOUNT;
+    return transaction;
+
 }
 
 extern BRRippleTransaction /* caller must free - rippleTransferFree */
@@ -294,9 +306,12 @@ int setFieldInfo(BRRippleField *fields, BRRippleTransaction transaction,
     fields[index].fieldCode = 3;
     fields[index++].data.address = transaction->payment.targetAddress;
 
-    fields[index].typeCode = 6;
-    fields[index].fieldCode = 1;
-    fields[index++].data.i64 = transaction->payment.amount.amount.u64Amount; // XRP only
+    // For Payments we need an amount, not true for DeleteAccount
+    if (transaction->transactionType == RIPPLE_TX_TYPE_PAYMENT) {
+        fields[index].typeCode = 6;
+        fields[index].fieldCode = 1;
+        fields[index++].data.i64 = transaction->payment.amount.amount.u64Amount; // XRP only
+    }
 
     // Public key info
     fields[index].typeCode = 7;
@@ -351,7 +366,8 @@ rippleTransactionSerializeImpl (BRRippleTransaction transaction,
                             uint8_t *signature, size_t sig_length)
 {
     assert(transaction);
-    assert(transaction->transactionType == RIPPLE_TX_TYPE_PAYMENT);
+    assert(transaction->transactionType == RIPPLE_TX_TYPE_PAYMENT ||
+           transaction->transactionType == RIPPLE_TX_TYPE_DELETE_ACCOUNT);
     // NOTE - the address fields will hold a BRRippleAddress pointer BUT
     // they are owned by the the transaction or transfer so we don't need
     // to worry about the memory.
@@ -421,6 +437,7 @@ rippleTransactionSerializeAndSign(BRRippleTransaction transaction, BRKey * priva
     BRRippleSerializedTransaction serializedBytes = rippleTransactionSerializeImpl (transaction, 0, 0);
     BRRippleSignature sig = signBytes(privateKey, serializedBytes->buffer, serializedBytes->size);
 
+    // Serialize again with the signature
     transaction->signedBytes = rippleTransactionSerializeImpl(transaction, sig->signature, sig->sig_length);
     
     rippleSignatureDelete(sig);

--- a/WalletKitCore/src/ripple/BRRippleTransaction.h
+++ b/WalletKitCore/src/ripple/BRRippleTransaction.h
@@ -157,4 +157,10 @@ extern const char *rippleTransactionFieldOptionalNames[];
 extern void rippleTransactionSetDestinationTag (BRRippleTransaction transaction, BRRippleDestinationTag tag);
 extern void rippleTransactionSetInvoiceID (BRRippleTransaction transaction, UInt256 invoiceId);
 
+// NOTE *** this function will create a transaction that will delete the sourceAddress
+// account and send all the remaining XRP to the targetAddress - use with caution as
+// this cannot be undone - however the account can be re-created by sending it at least 10 XRP
+BRRippleTransaction rippleTransactionCreateCloseTransaction(BRRippleAddress sourceAddress,
+                                                            BRRippleAddress targetAddress,
+                                                            BRRippleFeeBasis feeBasis);
 #endif // BRRipple_transaction_h


### PR DESCRIPTION
Added low level code in Ripple to delete your account and send the XRP to some address
+ a unit test