### PR TITLE
fix buffer-overflow for WKTransferIncludeStatus

### DIFF
--- a/WalletKitJava/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKTransferIncludeStatus.java
+++ b/WalletKitJava/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKTransferIncludeStatus.java
@@ -55,7 +55,7 @@ public class WKTransferIncludeStatus extends Structure {
         public abstract int toCore();
     }
 
-    private static int WK_TRANSFER_STATUS_DETAILS_LENGTH = (63+1);
+    private static final int WK_TRANSFER_STATUS_DETAILS_LENGTH = (127+1);
 
     public int type;
     public byte[] details = new byte[WK_TRANSFER_STATUS_DETAILS_LENGTH];


### PR DESCRIPTION
I was running into a buffer-overflow that crashed my Android-application in random places, either with heap-corruptions or segfaults.
The root-cause seems to be a size-inconsistency between the following two structures:

- a WKTransfer-struct in C: https://github.com/blockset-corp/walletkit/blob/07998077c1725e0c5b23288fe9e6040bf661e824/WalletKitCore/include/event/WKTransfer.h#L23
- a WKTransferIncludeStatus-structure in Java: https://github.com/blockset-corp/walletkit/blob/07998077c1725e0c5b23288fe9e6040bf661e824/WalletKitJava/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKTransferIncludeStatus.java#L58

So the C-struct seems to be twice as large as the corresponding Java-structure, which can trigger a buffer-overflow when copying a C-struct into a Java-structure.

I fear that walletkit has been abandoned by blockset-corp, nevertheless I hope that this might be useful.
